### PR TITLE
Improve logger for CREATE/CALL op

### DIFF
--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -68,14 +68,19 @@ type StructLogRes struct {
 }
 
 type ExtraData struct {
+	// Indicate the call success or not for CALL/CREATE op
+	CallFailed bool
 	// CALL | CALLCODE | DELEGATECALL | STATICCALL: [tx.to address’s code, stack.nth_last(1) address’s code]
 	CodeList [][]byte `json:"codeList,omitempty"`
 	// SSTORE | SLOAD: [storageProof]
 	// SELFDESTRUCT: [contract address’s accountProof, stack.nth_last(0) address’s accountProof]
 	// SELFBALANCE: [contract address’s accountProof]
 	// BALANCE | EXTCODEHASH: [stack.nth_last(0) address’s accountProof]
-	// CREATE | CREATE2: [sender's accountProof, created contract address’s accountProof]
-	// CALL | CALLCODE: [caller contract address’s accountProof, stack.nth_last(1) address’s accountProof]
+	// CREATE | CREATE2: [sender's accountProof, created contract address’s accountProof,
+	//					  created contract address's data (before constructing),
+	// 					  created contract address's data (after constructing)]
+	// CALL | CALLCODE: [caller contract address’s accountProof, stack.nth_last(1) address’s accountProof
+	//					  created contract address's data (before constructing)]
 	ProofList []*AccountProofWrapper `json:"proofList,omitempty"`
 }
 

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -69,18 +69,17 @@ type StructLogRes struct {
 
 type ExtraData struct {
 	// Indicate the call success or not for CALL/CREATE op
-	CallFailed bool
+	CallFailed bool `json:"callFailed,omitempty"`
 	// CALL | CALLCODE | DELEGATECALL | STATICCALL: [tx.to address’s code, stack.nth_last(1) address’s code]
 	CodeList [][]byte `json:"codeList,omitempty"`
 	// SSTORE | SLOAD: [storageProof]
 	// SELFDESTRUCT: [contract address’s accountProof, stack.nth_last(0) address’s accountProof]
 	// SELFBALANCE: [contract address’s accountProof]
 	// BALANCE | EXTCODEHASH: [stack.nth_last(0) address’s accountProof]
-	// CREATE | CREATE2: [sender's accountProof, created contract address’s accountProof,
-	//					  created contract address's data (before constructing),
-	// 					  created contract address's data (after constructing)]
+	// CREATE | CREATE2: [sender's accountProof, created contract address’s accountProof (before constructed),
+	// 					  created contract address's data (after constructed)]
 	// CALL | CALLCODE: [caller contract address’s accountProof, stack.nth_last(1) address’s accountProof
-	//					  created contract address's data (before constructing)]
+	//					  created contract address's data (before construced, value updated)]
 	ProofList []*AccountProofWrapper `json:"proofList,omitempty"`
 }
 

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -290,14 +290,6 @@ func (l *StructLogger) CaptureStateAfter(pc uint64, op OpCode, gas, cost uint64,
 // CaptureFault implements the EVMLogger interface to trace an execution fault
 // while running an opcode.
 func (l *StructLogger) CaptureFault(pc uint64, op OpCode, gas, cost uint64, scope *ScopeContext, depth int, err error) {
-	//when captureFault is triggerred, the op has been logged as the last log and we should update it
-	failedLog := l.logs[len(l.logs)-1]
-	if failedLog.Op != op || failedLog.Pc != pc {
-		log.Error("unexpected capture fault behavior", "capture pc", pc, "last pc", failedLog.Pc)
-		return
-	}
-
-	failedLog.Err = err
 }
 
 // CaptureEnd is called after the call finishes to finalize the tracing.

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -17,10 +17,10 @@ var (
 		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceCallerProof, traceLastNAddressProof(1)},
 		DELEGATECALL: {traceToAddressCode, traceLastNAddressCode(1)},
 		STATICCALL:   {traceToAddressCode, traceLastNAddressCode(1)},
-		CREATE:       {traceCreatedContractProof}, // sender's wrapped_proof is already recorded in BlockChain.writeBlockResult
-		CREATE2:      {traceCreatedContractProof}, // sender's wrapped_proof is already recorded in BlockChain.writeBlockResult
-		SLOAD:        {},                          // record storage_proof in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
-		SSTORE:       {},                          // record storage_proof in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
+		CREATE:       {}, // sender's wrapped_proof is already recorded in BlockChain.writeBlockResult
+		CREATE2:      {}, // sender's wrapped_proof is already recorded in BlockChain.writeBlockResult
+		SLOAD:        {}, // record storage_proof in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
+		SSTORE:       {}, // record storage_proof in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
 		SELFDESTRUCT: {traceContractProof, traceLastNAddressProof(0)},
 		SELFBALANCE:  {traceContractProof},
 		BALANCE:      {traceLastNAddressProof(0)},


### PR DESCRIPTION
This PR improve the proofList data inside the log of CALL/CREATE by:

1. Appended account data being updated AFTER the CALL/CREATE op has been executed as the last element of proofList
2. Fix the issue of calling traceCreatedContractProof in CaptureState phase (in which the address of created account is still unknown, this func only work while being called in CaptureStateAfter)
3. Add some "forecasting" for the execution result of op

The inside story:

CaptureState is called BEFORE an op is being executed and the return data it has captured is in fact the result of execution by LAST op. So consider a CALL/CREATE op the log sequence would be like:

> + the log data of CALL ( evm depth: n)
> + .... ops inside the method being called (evm depth: n+1)
> + the op just following CALL ( evm depth: n), and it own the returning of CALL (success or not)

But it would be more convenient for the witness generator in circuit part to know if it has succeed or not while hanlding the log data of op CALL (fior example, storage circuit do nothing for the following SSTOREs if CALL has failed). In this PR, CallFailed field is added in ExtraData to indicate the failure of CALL/CREATE.
