### PR TITLE
deprecated.  fix the stupid trie clone

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -275,6 +275,18 @@ func (s *stateObject) SetState(db Database, key, value common.Hash) {
 		prevalue: prev,
 	})
 	s.setState(key, value)
+
+	// always update trie
+	tr := s.getTrie(db)
+	if (value == common.Hash{}) {
+		s.setError(tr.TryDelete(key[:]))
+		//s.db.StorageDeleted += 1
+	} else {
+		// Encoding []byte cannot fail, ok to ignore the error.
+		v, _ := rlp.EncodeToBytes(common.TrimLeftZeroes(value[:]))
+		s.setError(tr.TryUpdate(key[:], v))
+		//s.db.StorageUpdated += 1
+	}
 }
 
 // SetStorage replaces the entire state storage with the given one.

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -328,7 +328,11 @@ func (s *StateDB) GetProofByHash(addrHash common.Hash) ([][]byte, error) {
 // GetStorageProof returns the Merkle proof for given storage slot.
 func (s *StateDB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, error) {
 	var proof proofList
-	trie := s.StorageTrie(a)
+	stateObject := s.getStateObject(a)
+	if stateObject == nil {
+		return proof, errors.New("storage trie for requested address does not exist")
+	}
+	trie := stateObject.trie
 	if trie == nil {
 		return proof, errors.New("storage trie for requested address does not exist")
 	}


### PR DESCRIPTION
update 2022.05.19: https://github.com/scroll-tech/go-ethereum/pull/102 gives a better solution


`make test` can pass

TODO: use a global constant boolean flag to enable/disable this write through behavior