### PR TITLE
feat: add `to` AccountProof to trace

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1384,14 +1384,16 @@ func (bc *BlockChain) writeBlockResult(state *state.StateDB, block *types.Block,
 		}
 
 		to := evmTrace.To.Address
-		// Get proof
-		proof, err = state.GetProof(to)
-		if err != nil {
-			log.Error("Failed to get proof", "blockNumber", block.NumberU64(), "address", to.String(), "err", err)
-		} else {
-			evmTrace.To.Proof = make([]string, len(proof))
-			for i := range proof {
-				evmTrace.To.Proof[i] = hexutil.Encode(proof[i])
+		if to != nil {
+			// Get proof
+			proof, err = state.GetProof(to)
+			if err != nil {
+				log.Error("Failed to get proof", "blockNumber", block.NumberU64(), "address", to.String(), "err", err)
+			} else {
+				evmTrace.To.Proof = make([]string, len(proof))
+				for i := range proof {
+					evmTrace.To.Proof[i] = hexutil.Encode(proof[i])
+				}
 			}
 		}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1370,16 +1370,28 @@ func (bc *BlockChain) writeBlockResult(state *state.StateDB, block *types.Block,
 	blockResult.BlockTrace = types.NewTraceBlock(bc.chainConfig, block, &coinbase)
 	for i, tx := range block.Transactions() {
 		evmTrace := blockResult.ExecutionResults[i]
-		from := evmTrace.Sender.Address
 
+		from := evmTrace.From.Address
 		// Get proof
 		proof, err := state.GetProof(from)
 		if err != nil {
 			log.Error("Failed to get proof", "blockNumber", block.NumberU64(), "address", from.String(), "err", err)
 		} else {
-			evmTrace.Sender.Proof = make([]string, len(proof))
+			evmTrace.From.Proof = make([]string, len(proof))
 			for i := range proof {
-				evmTrace.Sender.Proof[i] = hexutil.Encode(proof[i])
+				evmTrace.From.Proof[i] = hexutil.Encode(proof[i])
+			}
+		}
+
+		to := evmTrace.To.Address
+		// Get proof
+		proof, err = state.GetProof(to)
+		if err != nil {
+			log.Error("Failed to get proof", "blockNumber", block.NumberU64(), "address", to.String(), "err", err)
+		} else {
+			evmTrace.To.Proof = make([]string, len(proof))
+			for i := range proof {
+				evmTrace.To.Proof[i] = hexutil.Encode(proof[i])
 			}
 		}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1388,8 +1388,8 @@ func (bc *BlockChain) writeBlockResult(state *state.StateDB, block *types.Block,
 			}
 		}
 
-		to := evmTrace.To.Address
-		if to != nil {
+		if evmTrace.To != nil {
+			to := evmTrace.To.Address
 			// Get proof
 			proof, err = state.GetProof(to)
 			if err != nil {

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -19,7 +19,9 @@ type ExecutionResult struct {
 	Failed      bool   `json:"failed"`
 	ReturnValue string `json:"returnValue,omitempty"`
 	// Sender's account proof.
-	Sender *AccountProofWrapper `json:"sender,omitempty"`
+	From *AccountProofWrapper `json:"from,omitempty"`
+	// Receiver's account proof.
+	To *AccountProofWrapper `json:"to,omitempty"`
 	// It's exist only when tx is a contract call.
 	CodeHash *common.Hash `json:"codeHash,omitempty"`
 	// If it is a contract call, the contract code is returned.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -795,7 +795,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		CodeHash: w.current.state.GetCodeHash(from),
 	}
 	// Get receiver's address.
-	receiver := nil
+	receiver := (*types.AccountProofWrapper)(nil)
 	if tx.To() != nil {
 		to := *tx.To()
 		receiver = &types.AccountProofWrapper{

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -795,7 +795,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		CodeHash: w.current.state.GetCodeHash(from),
 	}
 	// Get receiver's address.
-	receiver := (*types.AccountProofWrapper)(nil)
+	var receiver *types.AccountProofWrapper
 	if tx.To() != nil {
 		to := *tx.To()
 		receiver = &types.AccountProofWrapper{

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -794,6 +794,14 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		Balance:  (*hexutil.Big)(w.current.state.GetBalance(from)),
 		CodeHash: w.current.state.GetCodeHash(from),
 	}
+	// Get receiver's address.
+	to, _ := types.Sender(w.current.signer, tx) // TODO: fix
+	receiver := &types.AccountProofWrapper{
+		Address:  to,
+		Nonce:    w.current.state.GetNonce(to),
+		Balance:  (*hexutil.Big)(w.current.state.GetBalance(to)),
+		CodeHash: w.current.state.GetCodeHash(to),
+	}
 
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {
@@ -805,7 +813,8 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	w.current.receipts = append(w.current.receipts, receipt)
 	w.current.executionResults = append(w.current.executionResults, &types.ExecutionResult{
 		Gas:         receipt.GasUsed,
-		Sender:      sender,
+		From:        sender,
+		To:          receiver,
 		Failed:      receipt.Status != types.ReceiptStatusSuccessful,
 		ReturnValue: fmt.Sprintf("%x", receipt.ReturnValue),
 		StructLogs:  vm.FormatLogs(tracer.StructLogs()),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -795,7 +795,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		CodeHash: w.current.state.GetCodeHash(from),
 	}
 	// Get receiver's address.
-	to, _ := types.Sender(w.current.signer, tx) // TODO: fix
+	to := *tx.To()
 	receiver := &types.AccountProofWrapper{
 		Address:  to,
 		Nonce:    w.current.state.GetNonce(to),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -795,12 +795,15 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		CodeHash: w.current.state.GetCodeHash(from),
 	}
 	// Get receiver's address.
-	to := *tx.To()
-	receiver := &types.AccountProofWrapper{
-		Address:  to,
-		Nonce:    w.current.state.GetNonce(to),
-		Balance:  (*hexutil.Big)(w.current.state.GetBalance(to)),
-		CodeHash: w.current.state.GetCodeHash(to),
+	receiver := nil
+	if tx.To() != nil {
+		to := *tx.To()
+		receiver = &types.AccountProofWrapper{
+			Address:  to,
+			Nonce:    w.current.state.GetNonce(to),
+			Balance:  (*hexutil.Big)(w.current.state.GetBalance(to)),
+			CodeHash: w.current.state.GetCodeHash(to),
+		}
 	}
 
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())


### PR DESCRIPTION
Turns out that we forget to add  `to` AccountProof in the trace.
https://github.com/appliedzkp/zkevm-circuits/blob/287a3f4dfe38d13a7ab920c2d781fb26fd519179/bus-mapping/src/circuit_input_builder/access.rs#L124-L127



This wasn't detected because previously we use created smart contract address as the receiver:
https://github.com/scroll-tech/integration-test/pull/25
