### PR TITLE
Ignoring non-protected transactions

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -96,4 +96,6 @@ var (
 
 	// ErrSenderNoEOA is returned if the sender of a transaction is a contract.
 	ErrSenderNoEOA = errors.New("sender not an eoa")
+
+	ErrNonProtectedTx = errors.New("only replay-protected (EIP-155) transactions are allowed to be added to the Transaction Pool")
 )

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -600,6 +600,13 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
+
+	// Reject non-protected transaction for resisting Replay Attack.
+	// Todo: It looks like too many test cases rely on Non-EIP155 transactions (Temporary Idle).
+	// if !tx.Protected() {
+	//	 return ErrNonProtectedTx
+	// }
+
 	// Accept only legacy transactions until EIP-2718/2930 activates.
 	if !pool.eip2718 && tx.Type() != types.LegacyTxType {
 		return ErrTxTypeNotSupported

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -600,13 +600,11 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 // validateTx checks whether a transaction is valid according to the consensus
 // rules and adheres to some heuristic limits of the local node (price and size).
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
-
 	// Reject non-protected transaction for resisting Replay Attack.
 	// Todo: It looks like too many test cases rely on Non-EIP155 transactions (Temporary Idle).
-	// if !tx.Protected() {
-	//	 return ErrNonProtectedTx
-	// }
-
+	if !tx.Protected() {
+		return ErrNonProtectedTx
+	}
 	// Accept only legacy transactions until EIP-2718/2930 activates.
 	if !pool.eip2718 && tx.Type() != types.LegacyTxType {
 		return ErrTxTypeNotSupported

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -341,6 +341,21 @@ func TestTransactionQueue(t *testing.T) {
 	}
 }
 
+// Test TxPool validate Non-protected transaction
+// Expected failed when meet Non-protected transaction
+//func TestValidateNonProtectedTransaction(t *testing.T) {
+//	pool, key := setupTxPool()
+//	defer pool.Stop()
+//
+//	tx1 := transaction(0, 100000, key)
+//	from, _ := deriveSender(tx1)
+//	testAddBalance(pool, from, big.NewInt(10000000))
+//
+//	if err := pool.validateTx(tx1, true); err != nil {
+//		t.Error("expected the transaction pool reject such non-protected transaction", err)
+//	}
+//}
+
 func TestTransactionQueue2(t *testing.T) {
 	t.Parallel()
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -952,12 +952,21 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		from, _ := types.Sender(w.current.signer, tx)
 		// Check whether the tx is replay protected. If we're not in the EIP155 hf
 		// phase, start ignoring the sender until we do.
+		// Todo: This if statement will always be false while EIP155 is enabled on block 0
 		if tx.Protected() && !w.chainConfig.IsEIP155(w.current.header.Number) {
 			log.Trace("Ignoring reply protected transaction", "hash", tx.Hash(), "eip155", w.chainConfig.EIP155Block)
 
 			txs.Pop()
 			continue
 		}
+		// Ignoring the unprotected transactions after enable EIP155
+		if !tx.Protected() && w.chainConfig.IsEIP155(w.current.header.Number) {
+			log.Trace("Ignoring non-protected transaction", "hash", tx.Hash())
+
+			txs.Pop()
+			continue
+		}
+
 		// Start executing the transaction
 		w.current.state.Prepare(tx.Hash(), w.current.tcount)
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -950,15 +950,7 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		//
 		// We use the eip155 signer regardless of the current hf.
 		from, _ := types.Sender(w.current.signer, tx)
-		// Check whether the tx is replay protected. If we're not in the EIP155 hf
-		// phase, start ignoring the sender until we do.
-		// Todo: This if statement will always be false while EIP155 is enabled on block 0
-		if tx.Protected() && !w.chainConfig.IsEIP155(w.current.header.Number) {
-			log.Trace("Ignoring reply protected transaction", "hash", tx.Hash(), "eip155", w.chainConfig.EIP155Block)
 
-			txs.Pop()
-			continue
-		}
 		// Ignoring the unprotected transactions after enable EIP155
 		if !tx.Protected() && w.chainConfig.IsEIP155(w.current.header.Number) {
 			log.Trace("Ignoring non-protected transaction", "hash", tx.Hash())


### PR DESCRIPTION
1. dissmiss non-protected transactions by the transaction pool.
2. Ignore non-protected transactions when worker(miner) commit transactions to the new blocks.

Problem：
It looks like too many test cases rely on Non-EIP155 transactions.