### PR TITLE
core/vm: Make INVALID a defined opcode

### DIFF
--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -496,7 +496,7 @@ func TestEstimateGas(t *testing.T) {
 			GasPrice: big.NewInt(0),
 			Value:    nil,
 			Data:     common.Hex2Bytes("b9b046f9"),
-		}, 0, errors.New("invalid opcode: opcode 0xfe not defined"), nil},
+		}, 0, errors.New("invalid opcode: INVALID"), nil},
 
 		{"Valid", ethereum.CallMsg{
 			From:     addr,

--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -225,6 +225,7 @@ const (
 
 	STATICCALL   OpCode = 0xfa
 	REVERT       OpCode = 0xfd
+	INVALID      OpCode = 0xfe
 	SELFDESTRUCT OpCode = 0xff
 )
 
@@ -390,6 +391,7 @@ var opCodeToString = map[OpCode]string{
 	CREATE2:      "CREATE2",
 	STATICCALL:   "STATICCALL",
 	REVERT:       "REVERT",
+	INVALID:      "INVALID",
 	SELFDESTRUCT: "SELFDESTRUCT",
 
 	PUSH: "PUSH",
@@ -548,6 +550,7 @@ var stringToOp = map[string]OpCode{
 	"RETURN":         RETURN,
 	"CALLCODE":       CALLCODE,
 	"REVERT":         REVERT,
+	"INVALID":        INVALID,
 	"SELFDESTRUCT":   SELFDESTRUCT,
 }
 

--- a/eth/tracers/internal/tracetest/testdata/call_tracer/inner_throw_outer_revert.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer/inner_throw_outer_revert.json
@@ -59,7 +59,7 @@
   "result": {
     "calls": [
       {
-        "error": "invalid opcode: opcode 0xfe not defined",
+        "error": "invalid opcode: INVALID",
         "from": "0x33056b5dcac09a9b4becad0e1dcf92c19bd0af76",
         "gas": "0x75fe3",
         "gasUsed": "0x75fe3",

--- a/eth/tracers/internal/tracetest/testdata/call_tracer_legacy/inner_throw_outer_revert.json
+++ b/eth/tracers/internal/tracetest/testdata/call_tracer_legacy/inner_throw_outer_revert.json
@@ -59,7 +59,7 @@
   "result": {
     "calls": [
       {
-        "error": "invalid opcode: opcode 0xfe not defined",
+        "error": "invalid opcode: INVALID",
         "from": "0x33056b5dcac09a9b4becad0e1dcf92c19bd0af76",
         "gas": "0x75fe3",
         "gasUsed": "0x75fe3",


### PR DESCRIPTION
cherry-pick https://github.com/ethereum/go-ethereum/commit/3e47e38a4e87b8e46ab6a4cdde52ca65e746e455