### PR TITLE
fix(trace): add more opcode handlings

### DIFF
--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -103,7 +103,7 @@ func NewStructLogResBasic(pc uint64, op string, gas, gasCost uint64, depth int, 
 	return logRes
 }
 
-// init
+// TODO: need to update comments
 type ExtraData struct {
 	// Indicate the call succeeds or not for CALL/CREATE op
 	CallFailed bool `json:"callFailed,omitempty"`

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -103,11 +103,13 @@ func NewStructLogResBasic(pc uint64, op string, gas, gasCost uint64, depth int, 
 	return logRes
 }
 
-// TODO: need to update comments
 type ExtraData struct {
 	// Indicate the call succeeds or not for CALL/CREATE op
 	CallFailed bool `json:"callFailed,omitempty"`
 	// CALL | CALLCODE | DELEGATECALL | STATICCALL: [tx.to address’s code, stack.nth_last(1) address’s code]
+	// CREATE | CREATE2: [created contract’s code]
+	// CODESIZE | CODECOPY: [contract’s code]
+	// EXTCODESIZE | EXTCODECOPY: [stack.nth_last(1) address’s code]
 	CodeList []string `json:"codeList,omitempty"`
 	// SSTORE | SLOAD: [storageProof]
 	// SELFDESTRUCT: [contract address’s account, stack.nth_last(0) address’s account]

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -103,6 +103,7 @@ func NewStructLogResBasic(pc uint64, op string, gas, gasCost uint64, depth int, 
 	return logRes
 }
 
+// init
 type ExtraData struct {
 	// Indicate the call succeeds or not for CALL/CREATE op
 	CallFailed bool `json:"callFailed,omitempty"`

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -109,7 +109,7 @@ type ExtraData struct {
 	// CALL | CALLCODE | DELEGATECALL | STATICCALL: [tx.to address’s code, stack.nth_last(1) address’s code]
 	// CREATE | CREATE2: [created contract’s code]
 	// CODESIZE | CODECOPY: [contract’s code]
-	// EXTCODESIZE | EXTCODECOPY: [stack.nth_last(1) address’s code]
+	// EXTCODESIZE | EXTCODECOPY: [stack.nth_last(0) address’s code]
 	CodeList []string `json:"codeList,omitempty"`
 	// SSTORE | SLOAD: [storageProof]
 	// SELFDESTRUCT: [contract address’s account, stack.nth_last(0) address’s account]

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -349,6 +349,8 @@ func (l *StructLogger) CaptureExit(output []byte, gasUsed uint64, err error) {
 		lastAccData := theLog.ExtraData.StateList[dataLen-1]
 		wrappedStatus := getWrappedAccountForAddr(l, lastAccData.Address)
 		theLog.ExtraData.StateList = append(theLog.ExtraData.StateList, wrappedStatus)
+		code := getCodeForAddr(l, lastAccData.Address)
+		theLog.ExtraData.CodeList = append(theLog.ExtraData.CodeList, hexutil.Encode(code))
 	default:
 		//do nothing for other op code
 		return

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -11,8 +11,8 @@ type traceFunc func(l *StructLogger, scope *ScopeContext, extraData *types.Extra
 var (
 	// OpcodeExecs the map to load opcodes' trace funcs.
 	OpcodeExecs = map[OpCode][]traceFunc{
-		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceContractAccount, traceLastNAddressAccount(1)}, // contract account is the caller, last 1th is the callee
-		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceContractAccount, traceLastNAddressAccount(1)}, // contract account is the caller, last 1th is the callee
+		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceContractAccount, traceLastNAddressAccount(1)}, // contract account is the caller, stack.nth_last(1) is the callee's address
+		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceContractAccount, traceLastNAddressAccount(1)}, // contract account is the caller, stack.nth_last(1) is the callee's address
 		DELEGATECALL: {traceToAddressCode, traceLastNAddressCode(1)},
 		STATICCALL:   {traceToAddressCode, traceLastNAddressCode(1), traceLastNAddressAccount(1)},
 		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -100,17 +100,6 @@ func traceLastNAddressAccount(n int) traceFunc {
 	}
 }
 
-// traceCaller gets caller address's account.
-func traceCaller(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error {
-	address := scope.Contract.CallerAddress
-	state := getWrappedAccountForAddr(l, address)
-
-	extraData.StateList = append(extraData.StateList, state)
-	l.statesAffected[scope.Contract.Address()] = struct{}{}
-
-	return nil
-}
-
 // StorageWrapper will be empty
 func getWrappedAccountForAddr(l *StructLogger, address common.Address) *types.AccountWrapper {
 	return &types.AccountWrapper{

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -54,6 +54,16 @@ func traceLastNAddressCode(n int) traceFunc {
 	}
 }
 
+// traceContractCode
+func traceContractCode() traceFunc {
+	return func(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error {
+		address := scope.Contract.Address()
+		code := l.env.StateDB.GetCode(address)
+		extraData.CodeList = append(extraData.CodeList, hexutil.Encode(code))
+		return nil
+	}
+}
+
 // traceStorage get contract's storage at storage_address
 func traceStorage(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error {
 	if scope.Stack.len() == 0 {

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -9,8 +9,6 @@ import (
 type traceFunc func(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error
 
 var (
-	//init
-
 	// OpcodeExecs the map to load opcodes' trace funcs.
 	OpcodeExecs = map[OpCode][]traceFunc{
 		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceLastNAddressAccount(1)},
@@ -25,6 +23,10 @@ var (
 		SELFBALANCE:  {traceContractAccount},
 		BALANCE:      {traceLastNAddressAccount(0)},
 		EXTCODEHASH:  {traceLastNAddressAccount(0)},
+		CODESIZE:     {traceContractCode},
+		CODECOPY:     {traceContractCode},
+		EXTCODESIZE:  {traceLastNAddressCode(0)},
+		EXTCODECOPY:  {traceLastNAddressCode(0)},
 	}
 )
 

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -54,7 +54,7 @@ func traceLastNAddressCode(n int) traceFunc {
 	}
 }
 
-// traceContractCode
+// traceContractCode gets the contract's code
 func traceContractCode(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error {
 	code := l.env.StateDB.GetCode(scope.Contract.Address())
 	extraData.CodeList = append(extraData.CodeList, hexutil.Encode(code))

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -15,8 +15,8 @@ var (
 		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceContractAccount, traceLastNAddressAccount(1)}, // TODO: is scope.Contract.Address() ==scope.Contract.CallerAddress?
 		DELEGATECALL: {traceToAddressCode, traceLastNAddressCode(1)},
 		STATICCALL:   {traceToAddressCode, traceLastNAddressCode(1), traceLastNAddressAccount(1)},
-		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit TODO????
-		CREATE2:      {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit TODO????
+		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit
+		CREATE2:      {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit
 		SLOAD:        {}, // trace storage in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
 		SSTORE:       {}, // trace storage in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
 		SELFDESTRUCT: {traceContractAccount, traceLastNAddressAccount(0)},
@@ -132,4 +132,8 @@ func getWrappedAccountForStorage(l *StructLogger, address common.Address, key co
 			Value: l.env.StateDB.GetState(address, key).String(),
 		},
 	}
+}
+
+func getCodeForAddr(l *StructLogger, address common.Address) []byte {
+	return l.env.StateDB.GetCode(address)
 }

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -11,8 +11,8 @@ type traceFunc func(l *StructLogger, scope *ScopeContext, extraData *types.Extra
 var (
 	// OpcodeExecs the map to load opcodes' trace funcs.
 	OpcodeExecs = map[OpCode][]traceFunc{
-		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceLastNAddressAccount(1)},
-		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceLastNAddressAccount(1)},
+		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceContractAccount, traceLastNAddressAccount(1)}, // TODO: is scope.Contract.Address() ==scope.Contract.CallerAddress?
+		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceContractAccount, traceLastNAddressAccount(1)}, // TODO: is scope.Contract.Address() ==scope.Contract.CallerAddress?
 		DELEGATECALL: {traceToAddressCode, traceLastNAddressCode(1)},
 		STATICCALL:   {traceToAddressCode, traceLastNAddressCode(1), traceLastNAddressAccount(1)},
 		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -11,8 +11,8 @@ type traceFunc func(l *StructLogger, scope *ScopeContext, extraData *types.Extra
 var (
 	// OpcodeExecs the map to load opcodes' trace funcs.
 	OpcodeExecs = map[OpCode][]traceFunc{
-		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceContractAccount, traceLastNAddressAccount(1)}, // TODO: is scope.Contract.Address() ==scope.Contract.CallerAddress?
-		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceContractAccount, traceLastNAddressAccount(1)}, // TODO: is scope.Contract.Address() ==scope.Contract.CallerAddress?
+		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceContractAccount, traceLastNAddressAccount(1)}, // contract account is the caller, last 1th is the callee
+		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceContractAccount, traceLastNAddressAccount(1)}, // contract account is the caller, last 1th is the callee
 		DELEGATECALL: {traceToAddressCode, traceLastNAddressCode(1)},
 		STATICCALL:   {traceToAddressCode, traceLastNAddressCode(1), traceLastNAddressAccount(1)},
 		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -15,8 +15,8 @@ var (
 		CALLCODE:     {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceContractAccount, traceLastNAddressAccount(1)}, // TODO: is scope.Contract.Address() ==scope.Contract.CallerAddress?
 		DELEGATECALL: {traceToAddressCode, traceLastNAddressCode(1)},
 		STATICCALL:   {traceToAddressCode, traceLastNAddressCode(1), traceLastNAddressAccount(1)},
-		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit
-		CREATE2:      {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit
+		CREATE:       {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit TODO????
+		CREATE2:      {}, // sender is already recorded in ExecutionResult, callee is recorded in CaptureEnter&CaptureExit TODO????
 		SLOAD:        {}, // trace storage in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
 		SSTORE:       {}, // trace storage in `captureState` instead of here, to handle `l.cfg.DisableStorage` flag
 		SELFDESTRUCT: {traceContractAccount, traceLastNAddressAccount(0)},

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -9,6 +9,8 @@ import (
 type traceFunc func(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error
 
 var (
+	//init
+
 	// OpcodeExecs the map to load opcodes' trace funcs.
 	OpcodeExecs = map[OpCode][]traceFunc{
 		CALL:         {traceToAddressCode, traceLastNAddressCode(1), traceCaller, traceLastNAddressAccount(1)},

--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -55,13 +55,10 @@ func traceLastNAddressCode(n int) traceFunc {
 }
 
 // traceContractCode
-func traceContractCode() traceFunc {
-	return func(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error {
-		address := scope.Contract.Address()
-		code := l.env.StateDB.GetCode(address)
-		extraData.CodeList = append(extraData.CodeList, hexutil.Encode(code))
-		return nil
-	}
+func traceContractCode(l *StructLogger, scope *ScopeContext, extraData *types.ExtraData) error {
+	code := l.env.StateDB.GetCode(scope.Contract.Address())
+	extraData.CodeList = append(extraData.CodeList, hexutil.Encode(code))
+	return nil
 }
 
 // traceStorage get contract's storage at storage_address


### PR DESCRIPTION
according to https://github.com/scroll-tech/zkevm-circuits/blob/scroll-dev-0714/bus-mapping/src/circuit_input_builder/access.rs#L114

related PR: https://github.com/scroll-tech/common-rs/pull/29

---

# question

In fact I don't know why I have `traceCaller` for `CALL` & `CALLCODE`, but looks like we should use `traceContractAccount`?