### PR TITLE
fix getProof API when zktrie is enabled

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -657,8 +657,13 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		return nil, err
 	}
 
+	zktrie := s.b.ChainConfig().Zktrie
+
 	storageTrie := state.StorageTrie(address)
-	storageHash := types.EmptyRootHash
+	var storageHash common.Hash
+	if !zktrie {
+		storageHash = types.EmptyRootHash
+	}
 	codeHash := state.GetCodeHash(address)
 	storageProof := make([]StorageResult, len(storageKeys))
 

--- a/les/server.go
+++ b/les/server.go
@@ -18,6 +18,7 @@ package les
 
 import (
 	"crypto/ecdsa"
+	"errors"
 	"time"
 
 	"github.com/scroll-tech/go-ethereum/common/mclock"
@@ -81,6 +82,11 @@ func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*Les
 	if err != nil {
 		return nil, err
 	}
+	// Now disable for zktrie
+	if e.BlockChain().Config().Zktrie {
+		return nil, errors.New("light server not work with zktrie storage")
+	}
+
 	// Calculate the number of threads used to service the light client
 	// requests based on the user-specified value.
 	threads := config.LightServ * 4 / 100


### PR DESCRIPTION
In geth for common mode, we can simply fix the issue in eth_getProof when zktrie is enabled.

The light server mode has used an incompatible implement for stateDb but we can postpone the work and simply disable this unsued mode in geth when zktrie is opened.

