### PR TITLE
feat: re-enable p2p layer

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -539,7 +539,7 @@ func (s *Ethereum) Start() error {
 	s.startBloomHandlers(params.BloomBitsBlocks)
 
 	// Figure out a max peers count based on the server limits
-	//maxPeers := s.p2pServer.MaxPeers
+	maxPeers := s.p2pServer.MaxPeers
 	//if s.config.LightServ > 0 {
 	//	if s.config.LightPeers >= s.p2pServer.MaxPeers {
 	//		return fmt.Errorf("invalid peer config: light peer count (%d) >= total peer count (%d)", s.config.LightPeers, s.p2pServer.MaxPeers)
@@ -547,7 +547,7 @@ func (s *Ethereum) Start() error {
 	//	maxPeers -= s.config.LightPeers
 	//}
 	// Start the networking layer and the light server if requested
-	//s.handler.Start(maxPeers)
+	s.handler.Start(maxPeers)
 	return nil
 }
 
@@ -557,7 +557,7 @@ func (s *Ethereum) Stop() error {
 	// Stop all the peer-related stuff first.
 	s.ethDialCandidates.Close()
 	s.snapDialCandidates.Close()
-	//s.handler.Stop()
+	s.handler.Stop()
 
 	// Then stop everything else.
 	s.bloomIndexer.Close()

--- a/node/node.go
+++ b/node/node.go
@@ -262,15 +262,15 @@ func (n *Node) doClose(errs []error) error {
 // openEndpoints starts all network and RPC endpoints.
 func (n *Node) openEndpoints() error {
 	// start networking endpoints
-	/*n.log.Info("Starting peer-to-peer node", "instance", n.server.Name)
+	n.log.Info("Starting peer-to-peer node", "instance", n.server.Name)
 	if err := n.server.Start(); err != nil {
 		return convertFileLockError(err)
-	}*/
+	}
 	// start RPC endpoints
 	err := n.startRPC()
 	if err != nil {
 		n.stopRPC()
-		//n.server.Stop()
+		n.server.Stop()
 	}
 	return err
 }
@@ -299,7 +299,7 @@ func (n *Node) stopServices(running []Lifecycle) error {
 	}
 
 	// Stop p2p networking.
-	//n.server.Stop()
+	n.server.Stop()
 
 	if len(failure.Services) > 0 {
 		return failure


### PR DESCRIPTION
Enable p2p so that we can switch to a multi-node setup with multiple block producer (primary) and RPC (secondary) nodes.

This PR partially reverts #8.