### PR TITLE
Trace the account accessed by `EXTCODE` op

### DIFF
--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -50,6 +50,7 @@ func traceLastNAddressCode(n int) traceFunc {
 		address := common.Address(stack.data[stack.len()-1-n].Bytes20())
 		code := l.env.StateDB.GetCode(address)
 		extraData.CodeList = append(extraData.CodeList, hexutil.Encode(code))
+		l.statesAffected[address] = struct{}{}
 		return nil
 	}
 }


### PR DESCRIPTION
This PR make `storeTrace`, which save the accounts' proof and initial status which are accessed in the block execution, also save the account being access by `EXTCODESIZE` and `EXTCODECOPY` op