### PR TITLE
feat: return 0 for op `DIFFICULTY` 

### DIFF
--- a/accounts/abi/bind/backends/simulated_test.go
+++ b/accounts/abi/bind/backends/simulated_test.go
@@ -423,9 +423,10 @@ func TestEstimateGas(t *testing.T) {
 		    function Assert() public { assert(false);}
 		    function SelfDestruct() public { selfdestruct(msg.sender); }
 		    function Valid() public {}
+		    function Difficulty() public { assert(block.difficulty == 0); }
 		}*/
-	const contractAbi = "[{\"inputs\":[],\"name\":\"Assert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"OOG\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PureRevert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Revert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SelfDestruct\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Valid\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
-	const contractBin = "0x608060405234801561001057600080fd5b50610181806100206000396000f3fe608060405234801561001057600080fd5b50600436106100625760003560e01c806350f6fe3414610067578063aa8b1d3014610071578063b9b046f91461007b578063d8b9839114610085578063dba5e9171461008f578063e09fface14610099575b600080fd5b61006f6100a3565b005b6100796100b3565b005b6100836100b8565b005b61008d6100c2565b005b610097610130565b005b6100a1610149565b005b60005b80806001019150506100a6565b600080fd5b60006100c057fe5b565b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600d8152602001807f72657665727420726561736f6e0000000000000000000000000000000000000081525060200191505060405180910390fd5b3373ffffffffffffffffffffffffffffffffffffffff16ff5b56fea2646970667358221220381c1672ed4be389ed2337c96f8e2fccf83479ec05cb9dd10362e8819e7ca38f64736f6c634300060c0033"
+	const contractAbi = "[{\"inputs\":[],\"name\":\"Assert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Difficulty\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"OOG\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"PureRevert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Revert\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SelfDestruct\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"Valid\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+	const contractBin = "0x608060405234801561001057600080fd5b506101b2806100206000396000f3fe608060405234801561001057600080fd5b506004361061007d5760003560e01c8063b9b046f91161005b578063b9b046f9146100a0578063d8b98391146100aa578063dba5e917146100b4578063e09fface146100be5761007d565b806350f6fe341461008257806391b4a0e71461008c578063aa8b1d3014610096575b600080fd5b61008a6100c8565b005b6100946100d8565b005b61009e6100e4565b005b6100a86100e9565b005b6100b26100f3565b005b6100bc610161565b005b6100c661017a565b005b60005b80806001019150506100cb565b600044146100e257fe5b565b600080fd5b60006100f157fe5b565b6040517f08c379a000000000000000000000000000000000000000000000000000000000815260040180806020018281038252600d8152602001807f72657665727420726561736f6e0000000000000000000000000000000000000081525060200191505060405180910390fd5b3373ffffffffffffffffffffffffffffffffffffffff16ff5b56fea26469706673582212201b608395248efd3133d81869fff20e9b287dc3fd8c43c02baf86a41efe9bfae164736f6c634300060c0033"
 
 	key, _ := crypto.GenerateKey()
 	addr := crypto.PubkeyToAddress(key.PublicKey)
@@ -515,7 +516,16 @@ func TestEstimateGas(t *testing.T) {
 			GasPrice: big.NewInt(0),
 			Value:    nil,
 			Data:     common.Hex2Bytes("e09fface"),
-		}, 21296, nil, nil},
+		}, 21274, nil, nil},
+
+		{"Difficulty", ethereum.CallMsg{
+			From:     addr,
+			To:       &contractAddr,
+			Gas:      100000,
+			GasPrice: big.NewInt(0),
+			Value:    nil,
+			Data:     common.Hex2Bytes("91b4a0e7"),
+		}, 21253, nil, nil},
 	}
 	for _, c := range cases {
 		got, err := sim.EstimateGas(context.Background(), c.message)

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -471,7 +471,7 @@ func opNumber(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]b
 }
 
 func opDifficulty(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	v, _ := uint256.FromBig(interpreter.evm.Context.Difficulty)
+	v := uint256.NewInt(0)
 	scope.Stack.push(v)
 	return nil, nil
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -86,6 +86,26 @@ func TestEVM(t *testing.T) {
 	}, nil, nil)
 }
 
+func TestDifficulty(t *testing.T) {
+	ret, _, err := Execute([]byte{
+		byte(vm.DIFFICULTY),
+		byte(vm.PUSH1), 0,
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 32,
+		byte(vm.PUSH1), 0,
+		byte(vm.RETURN),
+	}, nil, &Config{Difficulty: big.NewInt(1)})
+
+	if err != nil {
+		t.Fatal("didn't expect error", err)
+	}
+
+	num := new(big.Int).SetBytes(ret)
+	if num.Cmp(big.NewInt(0)) != 0 {
+		t.Error("Expected 0, got", num)
+	}
+}
+
 func TestExecute(t *testing.T) {
 	ret, _, err := Execute([]byte{
 		byte(vm.PUSH1), 10,


### PR DESCRIPTION
This PR changes the behaviour of `DIFFICULTY` so that it always returns 0.

Note that `header.difficulty` will still be `> 0` since it is used by [Clique PoA](https://eips.ethereum.org/EIPS/eip-225):

```
difficulty: Contains the standalone score of the block to derive the quality of a chain.
- Must be DIFF_NOTURN if BLOCK_NUMBER % SIGNER_COUNT != SIGNER_INDEX
- Must be DIFF_INTURN if BLOCK_NUMBER % SIGNER_COUNT == SIGNER_INDEX
```

