### PR TITLE
Make COINBASE return null

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -454,7 +454,7 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 }
 
 func opCoinbase(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
-	scope.Stack.push(new(uint256.Int).SetBytes(interpreter.evm.Context.Coinbase.Bytes()))
+	scope.Stack.push(new(uint256.Int))
 	return nil, nil
 }
 

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -106,6 +106,26 @@ func TestDifficulty(t *testing.T) {
 	}
 }
 
+func TestCoinbase(t *testing.T) {
+	ret, _, err := Execute([]byte{
+		byte(vm.COINBASE),
+		byte(vm.PUSH1), 0,
+		byte(vm.MSTORE),
+		byte(vm.PUSH1), 32,
+		byte(vm.PUSH1), 0,
+		byte(vm.RETURN),
+	}, nil, &Config{Coinbase: common.HexToAddress("0x0000000000000000000000000000000000000001")})
+
+	if err != nil {
+		t.Fatal("didn't expect error", err)
+	}
+
+	addr := common.BytesToAddress(ret)
+	if addr != (common.Address{}) {
+		t.Error("Expected null address, got", addr)
+	}
+}
+
 func TestExecute(t *testing.T) {
 	ret, _, err := Execute([]byte{
 		byte(vm.PUSH1), 10,


### PR DESCRIPTION
Note: While under Clique `header.coinbase` is often `0x0000000000000000000000000000000000000000` (unless there is a new signer proposal), `COINBASE` (in Solidity: `block.coinbase`) still returns the actual signer, encoded into `header.extra`.

Asana: https://app.asana.com/0/1202293017617135/1203232823713752/f