### PR TITLE
perf: use fastcache for zktrie node

### DIFF
--- a/trie/zk_trie_database.go
+++ b/trie/zk_trie_database.go
@@ -42,9 +42,23 @@ func (l *ZktrieDatabase) Get(key []byte) ([]byte, error) {
 	if ok {
 		return value, nil
 	}
+
+	if l.db.cleans != nil {
+		if enc := l.db.cleans.Get(nil, concatKey); enc != nil {
+			memcacheCleanHitMeter.Mark(1)
+			memcacheCleanReadMeter.Mark(int64(len(enc)))
+			return enc, nil
+		}
+	}
+
 	v, err := l.db.diskdb.Get(concatKey)
 	if err == leveldb.ErrNotFound {
 		return nil, ErrNotFound
+	}
+	if l.db.cleans != nil {
+		l.db.cleans.Set(concatKey[:], v)
+		memcacheCleanMissMeter.Mark(1)
+		memcacheCleanWriteMeter.Mark(int64(len(v)))
 	}
 	return v, err
 }


### PR DESCRIPTION
## Update
### before
go test -benchtime 20s -benchmem -run=^$ -bench BenchmarkZkTrieUpdate github.com/scroll-tech/go-ethereum/trie
goos: darwin
goarch: amd64
pkg: github.com/scroll-tech/go-ethereum/trie
cpu: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
BenchmarkZkTrieUpdate-8            27381            892882 ns/op          187172 B/op       6861 allocs/op
PASS
ok      github.com/scroll-tech/go-ethereum/trie 66.568s

### after
go test -benchtime 20s -benchmem -run=^$ -bench BenchmarkZkTrieUpdate github.com/scroll-tech/go-ethereum/trie
goos: darwin
goarch: amd64
pkg: github.com/scroll-tech/go-ethereum/trie
cpu: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
BenchmarkZkTrieUpdate-8            27384            884938 ns/op          187228 B/op       6861 allocs/op
PASS
ok      github.com/scroll-tech/go-ethereum/trie 65.222s

## Get
### before
go test -benchtime 20s -benchmem -run=^$ -bench BenchmarkZkTrieGet github.com/scroll-tech/go-ethereum/trie
goos: darwin
goarch: amd64
pkg: github.com/scroll-tech/go-ethereum/trie
cpu: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
BenchmarkZkTrieGet-8      315362             70931 ns/op           15158 B/op        459 allocs/op
PASS
ok      github.com/scroll-tech/go-ethereum/trie 56.366s

### after
go test -benchtime 20s -benchmem -run=^$ -bench BenchmarkZkTrieGet github.com/scroll-tech/go-ethereum/trie
goos: darwin
goarch: amd64
pkg: github.com/scroll-tech/go-ethereum/trie
cpu: Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
BenchmarkZkTrieGet-8      467114             52732 ns/op           13265 B/op        403 allocs/op
PASS
ok      github.com/scroll-tech/go-ethereum/trie 87.763s
