### PR TITLE
Fix: in zktrie, elimating persistent malleability 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
-	github.com/scroll-tech/zktrie v0.3.0
+	github.com/scroll-tech/zktrie v0.3.1
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -380,8 +380,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scroll-tech/zktrie v0.3.0 h1:c0GRNELUyAtyuiwllQKT1XjNbs7NRGfguKouiyLfFNY=
-github.com/scroll-tech/zktrie v0.3.0/go.mod h1:CuJFlG1/soTJJBAySxCZgTF7oPvd5qF6utHOEciC43Q=
+github.com/scroll-tech/zktrie v0.3.1 h1:HlR+fMBdjXX1/7cUMqpUgGEhGy/3vN1JpwQ0ovg/Ys8=
+github.com/scroll-tech/zktrie v0.3.1/go.mod h1:CuJFlG1/soTJJBAySxCZgTF7oPvd5qF6utHOEciC43Q=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=


### PR DESCRIPTION
In zktrie, we have [a sanity check in `addNode`](https://github.com/scroll-tech/zktrie/blob/669bf283b327842c9d12eb6e70c7da96075c3523/trie/zk_trie_impl.go#L309):

``` go

	oldV, err := mt.db.Get(k[:])
	if err == nil {
		if !bytes.Equal(oldV, v) {
			fmt.Printf("fail on conflicted key: %v, old value %x and new %x\n", k, oldV, v)
			return nil, ErrNodeKeyAlreadyExists
		} else {
			// duplicated
			return k, nil
		}
	}

```

It read the key of node which would be added from db and check if any conflicting occurs. However, zktrie persist bytes obtain from `node.Value` method, which has encoded every field inside a Node structure. And this behavior has induced malleability on the persisted bytes so the sanity check would fail in some cases.

For the leaf node, `PreImage` field is designed to be encoded in the proof for conveying more information under some scheme. The persisted preimage should be avaliable only if the 'Preimage' flag is enabled. However, zktrie module also persist it into db under the witness generator scheme, which lead to confiction in the db's key (when adding a leaf node, whose preimage field is never set, it may be encoutered an existed one with preimage being encoded)

To elimate such malleability we incuded CanonicalValue method in zktrie 0.3.1. It only encoded essential fields of node and should be used for persistent.

This upgrading is not critical and is expected to break nothing for current data generated by geth. The issue only raised when witness generator is tested by some trace generated before zktrie module is induced on the current code.