### PR TITLE
fix: revert block-on-demand (and use constant block time for clique)

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -397,7 +397,7 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 		case head := <-w.chainHeadCh:
 			clearPending(head.Block.NumberU64())
 			timestamp = time.Now().Unix()
-			commit(true, commitInterruptNewHead)
+			commit(false, commitInterruptNewHead)
 
 		case <-timer.C:
 			// If mining is running resubmit a new work cycle periodically to pull in


### PR DESCRIPTION
this revert the changes to miner.go in #8 & #19 & #29

you can also compare with  https://github.com/scroll-tech/go-ethereum/commit/ee15a2652fca6271e09c0f971a293bc1dcb51bde (our genesis commit)
<img width="1396" alt="image" src="https://user-images.githubusercontent.com/37070449/208799044-7200c16b-6f0c-4bfd-b1a7-8edb4d305f11.png">

