### PR TITLE
feat: make `BLOCKHASH` return only last blockhash

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -440,7 +440,7 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 	}
 	var upper, lower uint64
 	upper = interpreter.evm.Context.BlockNumber.Uint64()
-	if upper < 1 {
+	if upper < 2 {
 		lower = 0
 	} else {
 		lower = upper - 1

--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -440,10 +440,10 @@ func opBlockhash(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) (
 	}
 	var upper, lower uint64
 	upper = interpreter.evm.Context.BlockNumber.Uint64()
-	if upper < 257 {
+	if upper < 1 {
 		lower = 0
 	} else {
-		lower = upper - 256
+		lower = upper - 1
 	}
 	if num64 >= lower && num64 < upper {
 		num.SetBytes(interpreter.evm.Context.GetHash(num64).Bytes())

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -274,7 +274,7 @@ func (d *dummyChain) GetHeader(h common.Hash, n uint64) *types.Header {
 // requires access to a chain reader.
 func TestBlockhash(t *testing.T) {
 	// Current head
-	n := uint64(1000)
+	n := uint64(20)
 	parentHash := common.Hash{}
 	s := common.LeftPadBytes(big.NewInt(int64(n-1)).Bytes(), 32)
 	copy(parentHash[:], s)
@@ -301,7 +301,7 @@ func TestBlockhash(t *testing.T) {
 				bytes32 zero;
 				zero = blockhash(x); // Should be zeroes
 				first = blockhash(x-1);
-				for(uint256 i = 2 ; i < 260; i++){
+				for(uint256 i = 2 ; i < 16; i++){
 					bytes32 hash = blockhash(x - i);
 					if (uint256(hash) != 0){
 						last = hash;
@@ -334,13 +334,13 @@ func TestBlockhash(t *testing.T) {
 	if zero.BitLen() != 0 {
 		t.Fatalf("expected zeroes, got %x", ret[0:32])
 	}
-	if first.Uint64() != 999 {
-		t.Fatalf("second block should be 999, got %d (%x)", first, ret[32:64])
+	if first.Uint64() != 19 {
+		t.Fatalf("second block should be 19, got %d (%x)", first, ret[32:64])
 	}
-	if last.Uint64() != 744 {
-		t.Fatalf("last block should be 744, got %d (%x)", last, ret[64:96])
+	if last.Uint64() != 0 {
+		t.Fatalf("last block should be 0, got %d (%x)", last, ret[64:96])
 	}
-	if exp, got := 255, chain.counter; exp != got {
+	if exp, got := 0, chain.counter; exp != got {
 		t.Errorf("suboptimal; too much chain iteration, expected %d, got %d", exp, got)
 	}
 }

--- a/core/vm/runtime/runtime_test.go
+++ b/core/vm/runtime/runtime_test.go
@@ -274,7 +274,7 @@ func (d *dummyChain) GetHeader(h common.Hash, n uint64) *types.Header {
 // requires access to a chain reader.
 func TestBlockhash(t *testing.T) {
 	// Current head
-	n := uint64(20)
+	n := uint64(1000)
 	parentHash := common.Hash{}
 	s := common.LeftPadBytes(big.NewInt(int64(n-1)).Bytes(), 32)
 	copy(parentHash[:], s)
@@ -301,7 +301,7 @@ func TestBlockhash(t *testing.T) {
 				bytes32 zero;
 				zero = blockhash(x); // Should be zeroes
 				first = blockhash(x-1);
-				for(uint256 i = 2 ; i < 16; i++){
+				for(uint256 i = 2 ; i < 260; i++){
 					bytes32 hash = blockhash(x - i);
 					if (uint256(hash) != 0){
 						last = hash;
@@ -334,8 +334,8 @@ func TestBlockhash(t *testing.T) {
 	if zero.BitLen() != 0 {
 		t.Fatalf("expected zeroes, got %x", ret[0:32])
 	}
-	if first.Uint64() != 19 {
-		t.Fatalf("second block should be 19, got %d (%x)", first, ret[32:64])
+	if first.Uint64() != 999 {
+		t.Fatalf("second block should be 999, got %d (%x)", first, ret[32:64])
 	}
 	if last.Uint64() != 0 {
 		t.Fatalf("last block should be 0, got %d (%x)", last, ret[64:96])


### PR DESCRIPTION
Change behavior of `BLOCKHASH` accordingly to https://www.notion.so/scrollzkp/Differences-between-Scroll-and-Ethereum-aaab25ed6b734e50a61c4cce27e33096#ab6e0d856f1a45ea85997c668bd1e244