### PR TITLE
feat: make eip2718 & eip1559 configurable in txpool

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1320,8 +1320,8 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// Update all fork indicator by next pending block number.
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
-	pool.eip2718 = pool.chainconfig.IsEIP2718Enabled && pool.chainconfig.IsBerlin(next)
-	pool.eip1559 = pool.chainconfig.IsEIP1559Enabled && pool.chainconfig.IsLondon(next)
+	pool.eip2718 = !pool.chainconfig.DisableEIP2718 && pool.chainconfig.IsBerlin(next)
+	pool.eip1559 = !pool.chainconfig.DisableEIP1559 && pool.chainconfig.IsLondon(next)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1320,7 +1320,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// Update all fork indicator by next pending block number.
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
-	pool.eip2718 = pool.chainconfig.IsBerlin(next)
+	pool.eip2718 = false
 	pool.eip1559 = pool.chainconfig.IsLondon(next)
 }
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1320,8 +1320,8 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// Update all fork indicator by next pending block number.
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
-	pool.eip2718 = false
-	pool.eip1559 = pool.chainconfig.IsLondon(next)
+	pool.eip2718 = pool.chainconfig.IsEIP2718Enabled && pool.chainconfig.IsBerlin(next)
+	pool.eip1559 = pool.chainconfig.IsEIP1559Enabled && pool.chainconfig.IsLondon(next)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1320,8 +1320,8 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// Update all fork indicator by next pending block number.
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
-	pool.eip2718 = !pool.chainconfig.DisableEIP2718 && pool.chainconfig.IsBerlin(next)
-	pool.eip1559 = !pool.chainconfig.DisableEIP1559 && pool.chainconfig.IsLondon(next)
+	pool.eip2718 = pool.chainconfig.EnableEIP2718 && pool.chainconfig.IsBerlin(next)
+	pool.eip1559 = pool.chainconfig.EnableEIP1559 && pool.chainconfig.IsLondon(next)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1121,7 +1121,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args TransactionA
 }
 
 // RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *types.Header) map[string]interface{} {
+func RPCMarshalHeader(head *types.Header, maskBaseFee bool) map[string]interface{} {
 	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
 		"hash":             head.Hash(),
@@ -1142,7 +1142,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 		"receiptsRoot":     head.ReceiptHash,
 	}
 
-	if head.BaseFee != nil {
+	if !maskBaseFee && head.BaseFee != nil {
 		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
 	}
 
@@ -1153,7 +1153,7 @@ func RPCMarshalHeader(head *types.Header) map[string]interface{} {
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
-	fields := RPCMarshalHeader(block.Header())
+	fields := RPCMarshalHeader(block.Header(), config.DisableEIP2718 || config.DisableEIP1559)
 	fields["size"] = hexutil.Uint64(block.Size())
 
 	if inclTx {
@@ -1188,7 +1188,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
 // a `PublicBlockchainAPI`.
 func (s *PublicBlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) map[string]interface{} {
-	fields := RPCMarshalHeader(header)
+	fields := RPCMarshalHeader(header, s.b.ChainConfig().DisableEIP2718 || s.b.ChainConfig().DisableEIP1559)
 	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
 	return fields
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1121,7 +1121,7 @@ func (s *PublicBlockChainAPI) EstimateGas(ctx context.Context, args TransactionA
 }
 
 // RPCMarshalHeader converts the given header to the RPC output .
-func RPCMarshalHeader(head *types.Header, maskBaseFee bool) map[string]interface{} {
+func RPCMarshalHeader(head *types.Header, enableBaseFee bool) map[string]interface{} {
 	result := map[string]interface{}{
 		"number":           (*hexutil.Big)(head.Number),
 		"hash":             head.Hash(),
@@ -1142,7 +1142,7 @@ func RPCMarshalHeader(head *types.Header, maskBaseFee bool) map[string]interface
 		"receiptsRoot":     head.ReceiptHash,
 	}
 
-	if !maskBaseFee && head.BaseFee != nil {
+	if enableBaseFee && head.BaseFee != nil {
 		result["baseFeePerGas"] = (*hexutil.Big)(head.BaseFee)
 	}
 
@@ -1153,7 +1153,7 @@ func RPCMarshalHeader(head *types.Header, maskBaseFee bool) map[string]interface
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
-	fields := RPCMarshalHeader(block.Header(), config.DisableEIP2718 || config.DisableEIP1559)
+	fields := RPCMarshalHeader(block.Header(), config.EnableEIP2718 && config.EnableEIP1559)
 	fields["size"] = hexutil.Uint64(block.Size())
 
 	if inclTx {
@@ -1188,7 +1188,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
 // a `PublicBlockchainAPI`.
 func (s *PublicBlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) map[string]interface{} {
-	fields := RPCMarshalHeader(header, s.b.ChainConfig().DisableEIP2718 || s.b.ChainConfig().DisableEIP1559)
+	fields := RPCMarshalHeader(header, s.b.ChainConfig().EnableEIP2718 && s.b.ChainConfig().EnableEIP1559)
 	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
 	return fields
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -928,7 +928,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 		} else {
 			// When disabling EIP-2718 or EIP-1559, we do not set baseFeePerGas in RPC response.
-			// Setting BaseFee as 0 here can help outside SDK calculates l2geth's RLP encoding.
+			// Setting BaseFee as 0 here can help outside SDK calculates l2geth's RLP encoding,
 			// otherwise the l2geth's BaseFee is not known from the outside.
 			header.BaseFee = big.NewInt(0)
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -924,7 +924,14 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
-		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
+		if w.chainConfig.EnableEIP2718 && w.chainConfig.EnableEIP1559 {
+			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
+		} else {
+			// When disabling EIP-2718 or EIP-1559, we do not set baseFeePerGas in RPC response.
+			// Setting BaseFee as 0 here can help outside SDK calculates l2geth's RLP encoding.
+			// otherwise the l2geth's BaseFee is not known from the outside.
+			header.BaseFee = big.NewInt(0)
+		}
 		if !w.chainConfig.IsLondon(parent.Number()) {
 			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
 			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)

--- a/params/config.go
+++ b/params/config.go
@@ -363,10 +363,10 @@ type ChainConfig struct {
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
 
 	// Scroll genesis extension: enable EIP-2718 in tx pool.
-	IsEIP2718Enabled bool `json:"isEIP2718Enabled"`
+	IsEIP2718Enabled bool `json:"isEIP2718Enabled,omitempty"`
 
-	// Scroll genesis extension: enable EIP-1559 in tx pool.
-	IsEIP1559Enabled bool `json:"isEIP1559Enabled"`
+	// Scroll genesis extension: enable EIP-1559 in tx pool, IsEIP2718Enabled should also set to true.
+	IsEIP1559Enabled bool `json:"isEIP1559Enabled,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/params/config.go
+++ b/params/config.go
@@ -258,16 +258,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, true, true}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, true, true}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, true, true}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -362,11 +362,11 @@ type ChainConfig struct {
 	// Scroll genesis extension: Transaction fee vault address [optional]
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
 
-	// Scroll genesis extension: disable EIP-2718 in tx pool.
-	DisableEIP2718 bool `json:"disableEIP2718,omitempty"`
+	// Scroll genesis extension: enable EIP-2718 in tx pool.
+	EnableEIP2718 bool `json:"enableEIP2718,omitempty"`
 
-	// Scroll genesis extension: disable EIP-1559 in tx pool.
-	DisableEIP1559 bool `json:"disableEIP1559,omitempty"`
+	// Scroll genesis extension: enable EIP-1559 in tx pool, EnableEIP2718 should be true too.
+	EnableEIP1559 bool `json:"enableEIP1559,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/params/config.go
+++ b/params/config.go
@@ -361,6 +361,12 @@ type ChainConfig struct {
 
 	// Scroll genesis extension: Transaction fee vault address [optional]
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
+
+	// Scroll genesis extension: enable EIP-2718 in tx pool.
+	IsEIP2718Enabled bool `json:"isEIP2718Enabled"`
+
+	// Scroll genesis extension: enable EIP-1559 in tx pool.
+	IsEIP1559Enabled bool `json:"isEIP1559Enabled"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/params/config.go
+++ b/params/config.go
@@ -258,16 +258,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, false, false}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, true, true}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, false, false}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, true, true}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, false, false}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, true, true}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 

--- a/params/config.go
+++ b/params/config.go
@@ -258,16 +258,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, true, true}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, false, false}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, true, true}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, false, false}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, true, true}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, false, false}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 
@@ -362,11 +362,11 @@ type ChainConfig struct {
 	// Scroll genesis extension: Transaction fee vault address [optional]
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
 
-	// Scroll genesis extension: enable EIP-2718 in tx pool.
-	IsEIP2718Enabled bool `json:"isEIP2718Enabled,omitempty"`
+	// Scroll genesis extension: disable EIP-2718 in tx pool.
+	DisableEIP2718 bool `json:"disableEIP2718,omitempty"`
 
-	// Scroll genesis extension: enable EIP-1559 in tx pool, IsEIP2718Enabled should also set to true.
-	IsEIP1559Enabled bool `json:"isEIP1559Enabled,omitempty"`
+	// Scroll genesis extension: disable EIP-1559 in tx pool.
+	DisableEIP1559 bool `json:"disableEIP1559,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
background:

circuit only support legacy tx but cannot support Typed Transaction Envelope tx. We plan to support non legacy tx within months.   So here i disable non-legacy tx at **txpool** level but not consensus level.  all the sequencers within months will be "non-evil", they will not deliberately produce blocks with Typed Transaction Envelope. So as long as we support non-legacy tx before scroll network becomes decentralied (i believe this), this PR is a good solution.

alternative solutions:
(1) disable London/Berlin. We will miss a lot of new features
(2) disable some related EIPs. I find it is not easy.. Forks and eips are coupled tightly in codes, and i think using this solution we need to modify much more codes and much more error-prone.