### PR TITLE
fix: Update baseFee verification logic

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -47,7 +47,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	var expectedBaseFee *big.Int
 
 	// compatible check with the logic in commitNewWork
-	if config.EnableEIP2718 && config.EnableEIP1559 {
+	if config.Clique == nil || (config.EnableEIP2718 && config.EnableEIP1559) {
 		expectedBaseFee = CalcBaseFee(config, parent)
 	} else {
 		expectedBaseFee = big.NewInt(0)

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -43,7 +43,16 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 		return fmt.Errorf("header is missing baseFee")
 	}
 	// Verify the baseFee is correct based on the parent header.
-	expectedBaseFee := CalcBaseFee(config, parent)
+
+	var expectedBaseFee *big.Int
+
+	// compatible check with the logic in commitNewWork
+	if config.EnableEIP2718 && config.EnableEIP1559 {
+		expectedBaseFee = CalcBaseFee(config, parent)
+	} else {
+		expectedBaseFee = big.NewInt(0)
+	}
+
 	if header.BaseFee.Cmp(expectedBaseFee) != 0 {
 		return fmt.Errorf("invalid baseFee: have %s, want %s, parentBaseFee %s, parentGasUsed %d",
 			expectedBaseFee, header.BaseFee, parent.BaseFee, parent.GasUsed)


### PR DESCRIPTION
#206 changed the way we calculate `header.BaseFee` in `commitNewWork`. This change was not deployed on the signer so it did not take effect. At the same time, we did not change the corresponding verification logic in `VerifyEip1559Header`. When we later deployed the changes on the signer, the verifiers (follower nodes) failed to verify the signer's new blocks:

```
########## BAD BLOCK #########
Chain config: {ChainID: 5343541 Homestead: 0 DAO: <nil> DAOSupport: false EIP150: 0 EIP155: 0 EIP158: 0 Byzantium: 0 Constantinople: 0 Petersburg: 0 Istanbul: 0, Muir Glacier: <nil>, Berlin: 0, London: 0, Arrow Glacier: <nil>, Engine: clique}

Number: 1064858
Hash: 0xfc92629d61aeb44b043d6049c69ceecc83090ae68804765b9853e787162df726


Error: invalid baseFee: have 7, want 0, parentBaseFee 7, parentGasUsed 0
##############################
 
WARN [02-09|14:25:46.241] Synchronisation failed, dropping peer    peer=c1760d85345a9466b87fa4f762a659ad8f0df29a9550a0ea9f5bb6750c91dd63 err="retrieved hash chain is invalid: invalid baseFee: have 7, want 0, parentBaseFee 7, parentGasUsed 0"
INFO [02-09|14:26:01.147] Deep froze chain segment                 blocks=4  elapsed=8.149ms     number=974,857   hash=78981f..f9a86c
INFO [02-09|14:26:21.233] Looking for peers                        peercount=0 tried=1 static=1
INFO [02-09|14:26:21.244] Skip duplicated bad block                number=1,064,858 hash=fc9262..2df726
ERROR[02-09|14:26:21.244] 
########## BAD BLOCK #########
Chain config: {ChainID: 5343541 Homestead: 0 DAO: <nil> DAOSupport: false EIP150: 0 EIP155: 0 EIP158: 0 Byzantium: 0 Constantinople: 0 Petersburg: 0 Istanbul: 0, Muir Glacier: <nil>, Berlin: 0, London: 0, Arrow Glacier: <nil>, Engine: clique}

Number: 1064858
Hash: 0xfc92629d61aeb44b043d6049c69ceecc83090ae68804765b9853e787162df726
```