### PR TITLE
feat(trace): add withdraw trie root

### DIFF
--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -31,6 +31,7 @@ type BlockTrace struct {
 	StorageTrace     *StorageTrace      `json:"storageTrace"`
 	ExecutionResults []*ExecutionResult `json:"executionResults"`
 	MPTWitness       *json.RawMessage   `json:"mptwitness,omitempty"`
+	WithdrawTrieRoot common.Hash        `json:"withdraw_trie_root,omitempty"`
 }
 
 // StorageTrace stores proofs of storage needed by storage circuit

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -14,6 +14,8 @@ import (
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/core/vm"
 	"github.com/scroll-tech/go-ethereum/log"
+	"github.com/scroll-tech/go-ethereum/rollup/rcfg"
+	"github.com/scroll-tech/go-ethereum/rollup/withdrawtrie"
 	"github.com/scroll-tech/go-ethereum/rpc"
 	"github.com/scroll-tech/go-ethereum/trie/zkproof"
 )
@@ -382,6 +384,10 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 		if err := zkproof.FillBlockTraceForMPTWitness(zkproof.MPTWitnessType(api.backend.CacheConfig().MPTWitness), blockTrace); err != nil {
 			log.Error("fill mpt witness fail", "error", err)
 		}
+	}
+
+	if rcfg.UsingScroll {
+		blockTrace.WithdrawTrieRoot = withdrawtrie.ReadWTRSlot(rcfg.L2MessageQueueAddress, env.state)
 	}
 
 	return blockTrace, nil

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -386,7 +386,7 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 		}
 	}
 
-	if rcfg.UsingScroll {
+	if api.backend.ChainConfig().UsingScroll {
 		blockTrace.WithdrawTrieRoot = withdrawtrie.ReadWTRSlot(rcfg.L2MessageQueueAddress, env.state)
 	}
 

--- a/params/config.go
+++ b/params/config.go
@@ -258,16 +258,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, true, true, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, nil, true, true, nil, true}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, true, true, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, false, nil, true, true, nil, true}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, true, true, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, false, &common.Address{123}, true, true, nil, true}
 	TestRules       = TestChainConfig.Rules(new(big.Int))
 )
 
@@ -370,6 +370,10 @@ type ChainConfig struct {
 
 	// Scroll genesis extension: Maximum number of transactions per block [optional]
 	MaxTxPerBlock *int `json:"maxTxPerBlock,omitempty"`
+
+	// Scroll genesis extension: enable scroll rollup-related traces & state transition
+	// TODO: merge these config: Zktrie, FeeVaultAddress, EnableEIP2718, EnableEIP1559 & MaxTxPerBlock
+	UsingScroll bool `json:"usingScroll,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/params/config.go
+++ b/params/config.go
@@ -372,7 +372,7 @@ type ChainConfig struct {
 	MaxTxPerBlock *int `json:"maxTxPerBlock,omitempty"`
 
 	// Scroll genesis extension: enable scroll rollup-related traces & state transition
-	// TODO: merge these config: Zktrie, FeeVaultAddress, EnableEIP2718, EnableEIP1559 & MaxTxPerBlock
+	// TODO: merge with these config: Zktrie, FeeVaultAddress, EnableEIP2718, EnableEIP1559 & MaxTxPerBlock
 	UsingScroll bool `json:"usingScroll,omitempty"`
 }
 

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -7,14 +7,12 @@ import (
 )
 
 // TODO:
-// 1. use config
-// 2. allow different networks / hardforks
-// 3. vefify in consensus layer when decentralizing sequencer
+// verify in consensus layer when decentralizing sequencer
 
 var (
 	// L2MessageQueueAddress is the address of the L2MessageQueue
 	// predeploy
-	// see scroll-tech/scroll/contracts/src/L2/predeploys/L2MessageQueue.sol
+	// see contracts/src/L2/predeploys/L2MessageQueue.sol
 	L2MessageQueueAddress = common.HexToAddress("0x5300000000000000000000000000000000000000")
 	WithdrawTrieRootSlot  = common.BigToHash(big.NewInt(0))
 )

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -6,9 +6,6 @@ import (
 	"github.com/scroll-tech/go-ethereum/common"
 )
 
-// UsingScroll is used to enable or disable functionality necessary for scroll rollup.
-var UsingScroll bool
-
 // TODO:
 // 1. use config
 // 2. allow different networks / hardforks

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -18,6 +18,6 @@ var (
 	// L2MessageQueueAddress is the address of the L2MessageQueue
 	// predeploy
 	// see scroll-tech/scroll/contracts/src/L2/predeploys/L2MessageQueue.sol
-	L2MessageQueueAddress = common.HexToAddress("0x5300000000000000000000000000000000000002")
+	L2MessageQueueAddress = common.HexToAddress("0x5300000000000000000000000000000000000000")
 	WithdrawTrieRootSlot  = common.BigToHash(big.NewInt(0))
 )

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -1,0 +1,21 @@
+package rcfg
+
+import (
+	"github.com/scroll-tech/go-ethereum/common"
+)
+
+// UsingScroll is used to enable or disable functionality necessary for scroll rollup.
+var UsingScroll bool
+
+// TODO:
+// 1. use config
+// 2. allow different networks / hardforks
+// 3. vefify in consensus layer when decentralizing sequencer
+
+var (
+	// L2MessageQueueAddress is the address of the L2MessageQueue
+	// predeploy
+	// see scroll-tech/scroll/contracts/src/L2/predeploys/L2MessageQueue.sol
+	L2MessageQueueAddress = common.HexToAddress("0x5300000000000000000000000000000000000002")
+	WithdraTrieRootSlot   = common.BigToHash(big.NewInt(0))
+)

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -17,5 +17,5 @@ var (
 	// predeploy
 	// see scroll-tech/scroll/contracts/src/L2/predeploys/L2MessageQueue.sol
 	L2MessageQueueAddress = common.HexToAddress("0x5300000000000000000000000000000000000002")
-	WithdraTrieRootSlot   = common.BigToHash(big.NewInt(0))
+	WithdrawTrieRootSlot  = common.BigToHash(big.NewInt(0))
 )

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -1,6 +1,8 @@
 package rcfg
 
 import (
+	"math/big"
+
 	"github.com/scroll-tech/go-ethereum/common"
 )
 

--- a/rollup/withdrawtrie/withdraw_trie.go
+++ b/rollup/withdrawtrie/withdraw_trie.go
@@ -11,6 +11,8 @@ type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
 }
 
+// ReadWTRSlot reads WithdrawTrieRoot slot in L2MessageQueue predeploy, i.e., `messageRoot`
+// in scroll-tech/scroll/contracts/src/libraries/common/AppendOnlyMerkleTree.sol
 func ReadWTRSlot(addr common.Address, state StateDB) common.Hash {
 	return state.GetState(addr, rcfg.WithdrawTrieRootSlot)
 }

--- a/rollup/withdrawtrie/withdraw_trie.go
+++ b/rollup/withdrawtrie/withdraw_trie.go
@@ -1,0 +1,15 @@
+package withdrawtrie
+
+import (
+	"github.com/scroll-tech/go-ethereum/common"
+)
+
+// StateDB represents the StateDB interface
+// required to get withdraw trie root
+type StateDB interface {
+	GetState(common.Address, common.Hash) common.Hash
+}
+
+func ReadWTRSlot(addr common.Address, state StateDB) common.Hash {
+	return common.Hash{}
+}

--- a/rollup/withdrawtrie/withdraw_trie.go
+++ b/rollup/withdrawtrie/withdraw_trie.go
@@ -2,6 +2,7 @@ package withdrawtrie
 
 import (
 	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/rollup/rcfg"
 )
 
 // StateDB represents the StateDB interface
@@ -11,5 +12,5 @@ type StateDB interface {
 }
 
 func ReadWTRSlot(addr common.Address, state StateDB) common.Hash {
-	return common.Hash{}
+	return state.GetState(addr, rcfg.WithdrawTrieRootSlot)
 }

--- a/rollup/withdrawtrie/withdraw_trie.go
+++ b/rollup/withdrawtrie/withdraw_trie.go
@@ -12,7 +12,7 @@ type StateDB interface {
 }
 
 // ReadWTRSlot reads WithdrawTrieRoot slot in L2MessageQueue predeploy, i.e., `messageRoot`
-// in scroll-tech/scroll/contracts/src/libraries/common/AppendOnlyMerkleTree.sol
+// in contracts/src/libraries/common/AppendOnlyMerkleTree.sol
 func ReadWTRSlot(addr common.Address, state StateDB) common.Hash {
 	return state.GetState(addr, rcfg.WithdrawTrieRootSlot)
 }


### PR DESCRIPTION
reference:
+ https://github.com/ethereum-optimism/optimism/blob/develop/l2geth/core/state_transition.go#L129-L133
+ https://github.com/ethereum-optimism/optimism/blob/develop/l2geth/rollup/fees/rollup_fee.go#L171
+ https://github.com/scroll-tech/scroll/blob/feat/new_bridge_contracts/contracts/src/L2/predeploys/L2MessageQueue.sol

---
## for `FeeVaultAddress`
@Thegaram do you think we should hardcode `FeeVaultAddress` in rollup/rcfg/config.go (this is also how OP does with their predeploys as in https://github.com/ethereum-optimism/optimism/blob/develop/l2geth/rollup/rcfg/config.go)

Or should we just provide it in `ChainCfg` (current approach)?