### PR TITLE
set BaseFee to nil

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -611,7 +611,11 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 			// Backfill the legacy gasPrice for EVM execution, unless we're all zeroes
 			call.GasPrice = new(big.Int)
 			if call.GasFeeCap.BitLen() > 0 || call.GasTipCap.BitLen() > 0 {
-				call.GasPrice = math.BigMin(new(big.Int).Add(call.GasTipCap, head.BaseFee), call.GasFeeCap)
+				if head.BaseFee != nil {
+					call.GasPrice = math.BigMin(new(big.Int).Add(call.GasTipCap, head.BaseFee), call.GasFeeCap)
+				} else {
+					call.GasPrice = math.BigMin(call.GasTipCap, call.GasFeeCap)
+				}
 			}
 		}
 	}

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -249,10 +249,14 @@ func (c *BoundContract) createDynamicTx(opts *TransactOpts, contract *common.Add
 	// Estimate FeeCap
 	gasFeeCap := opts.GasFeeCap
 	if gasFeeCap == nil {
-		gasFeeCap = new(big.Int).Add(
-			gasTipCap,
-			new(big.Int).Mul(head.BaseFee, big.NewInt(2)),
-		)
+		if head.BaseFee != nil {
+			gasFeeCap = new(big.Int).Add(
+				gasTipCap,
+				new(big.Int).Mul(head.BaseFee, big.NewInt(2)),
+			)
+		} else {
+			gasFeeCap = new(big.Int).Set(gasTipCap)
+		}
 	}
 	if gasFeeCap.Cmp(gasTipCap) < 0 {
 		return nil, fmt.Errorf("maxFeePerGas (%v) < maxPriorityFeePerGas (%v)", gasFeeCap, gasTipCap)

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -248,7 +248,7 @@ func Transition(ctx *cli.Context) error {
 	}
 	// Sanity check, to not `panic` in state_transition
 	if chainConfig.IsLondon(big.NewInt(int64(prestate.Env.Number))) {
-		if prestate.Env.BaseFee == nil {
+		if prestate.Env.BaseFee == nil && !(chainConfig.EnableEIP2718 && chainConfig.EnableEIP1559) {
 			return NewError(ErrorConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}
 	}

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -248,7 +248,7 @@ func Transition(ctx *cli.Context) error {
 	}
 	// Sanity check, to not `panic` in state_transition
 	if chainConfig.IsLondon(big.NewInt(int64(prestate.Env.Number))) {
-		if prestate.Env.BaseFee == nil && !(chainConfig.EnableEIP2718 && chainConfig.EnableEIP1559) {
+		if prestate.Env.BaseFee == nil && chainConfig.EnableEIP2718 && chainConfig.EnableEIP1559 {
 			return NewError(ErrorConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}
 	}

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -76,7 +76,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
 	)
-	if !(config.EnableEIP2718 && config.EnableEIP1559) {
+	if !config.EnableEIP2718 || !config.EnableEIP1559 {
 		return nil
 	}
 	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -39,8 +39,12 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 		return err
 	}
 	// Verify the header is not malformed
-	if header.BaseFee == nil {
+	if header.BaseFee == nil && (config.EnableEIP2718 && config.EnableEIP1559) {
 		return fmt.Errorf("header is missing baseFee")
+	}
+	// Now BaseFee can be nil, becuase !(config.EnableEIP2718 && config.EnableEIP1559)
+	if header.BaseFee == nil {
+		return nil
 	}
 	// Verify the baseFee is correct based on the parent header.
 
@@ -72,6 +76,9 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
 	)
+	if !(config.EnableEIP2718 && config.EnableEIP1559) {
+		return nil
+	}
 	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
 	if parent.GasUsed == parentGasTarget {
 		return new(big.Int).Set(parent.BaseFee)

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -42,7 +42,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	if header.BaseFee == nil && (config.EnableEIP2718 && config.EnableEIP1559) {
 		return fmt.Errorf("header is missing baseFee")
 	}
-	// Now BaseFee can be nil, becuase !(config.EnableEIP2718 && config.EnableEIP1559)
+	// Now BaseFee can be nil, because !(config.EnableEIP2718 && config.EnableEIP1559)
 	if header.BaseFee == nil {
 		return nil
 	}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -132,7 +132,11 @@ func (b *BlockGen) Number() *big.Int {
 
 // BaseFee returns the EIP-1559 base fee of the block being generated.
 func (b *BlockGen) BaseFee() *big.Int {
-	return new(big.Int).Set(b.header.BaseFee)
+	if b.header.BaseFee != nil {
+		return new(big.Int).Set(b.header.BaseFee)
+	} else {
+		return big.NewInt(0)
+	}
 }
 
 // AddUncheckedReceipt forcefully adds a receipts to the block without a

--- a/core/gen_genesis.go
+++ b/core/gen_genesis.go
@@ -50,7 +50,9 @@ func (g Genesis) MarshalJSON() ([]byte, error) {
 	enc.Number = math.HexOrDecimal64(g.Number)
 	enc.GasUsed = math.HexOrDecimal64(g.GasUsed)
 	enc.ParentHash = g.ParentHash
-	enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
+	if g.BaseFee != nil {
+		enc.BaseFee = (*math.HexOrDecimal256)(g.BaseFee)
+	}
 	return json.Marshal(&enc)
 }
 

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -315,8 +315,10 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if g.Config != nil && g.Config.IsLondon(common.Big0) {
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
-		} else {
+		} else if g.Config.EnableEIP2718 && g.Config.EnableEIP1559 {
 			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
+		} else {
+			head.BaseFee = nil
 		}
 	}
 	statedb.Commit(false)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -156,12 +156,12 @@ func TestStateProcessorErrors(t *testing.T) {
 				},
 				want: "could not apply tx 0 [0xbd49d8dadfd47fb846986695f7d4da3f7b2c48c8da82dbc211a26eb124883de9]: gas limit reached",
 			},
-			{ // ErrFeeCapTooLow
-				txs: []*types.Transaction{
-					mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(0), big.NewInt(0)),
-				},
-				want: "could not apply tx 0 [0xc4ab868fef0c82ae0387b742aee87907f2d0fc528fc6ea0a021459fb0fc4a4a8]: max fee per gas less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, maxFeePerGas: 0 baseFee: 875000000",
-			},
+			// { // ErrFeeCapTooLow
+			// 	txs: []*types.Transaction{
+			// 		mkDynamicTx(0, common.Address{}, params.TxGas, big.NewInt(0), big.NewInt(0)),
+			// 	},
+			// 	want: "could not apply tx 0 [0xc4ab868fef0c82ae0387b742aee87907f2d0fc528fc6ea0a021459fb0fc4a4a8]: max fee per gas less than block base fee: address 0x71562b71999873DB5b286dF957af199Ec94617F7, maxFeePerGas: 0 baseFee: 875000000",
+			// },
 			{ // ErrTipVeryHigh
 				txs: []*types.Transaction{
 					mkDynamicTx(0, common.Address{}, params.TxGas, tooBigNumber, big.NewInt(1)),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -933,9 +933,9 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 		} else {
 			// When disabling EIP-2718 or EIP-1559, we do not set baseFeePerGas in RPC response.
-			// Setting BaseFee as 0 here can help outside SDK calculates l2geth's RLP encoding,
+			// Setting BaseFee as nil here can help outside SDK calculates l2geth's RLP encoding,
 			// otherwise the l2geth's BaseFee is not known from the outside.
-			header.BaseFee = big.NewInt(0)
+			header.BaseFee = nil
 		}
 		if !w.chainConfig.IsLondon(parent.Number()) {
 			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier


### PR DESCRIPTION
When computing the block hash, `l2geth` uses the whole block (including `BaseFee`). but the RPC client (e.g. SDK) does not receive `BaseFee` so the hash will be different.

we want to make sure we set `BaseFee` to `nil` inside `l2geth` too.

1. change it to `nil` in `worker.go` here: https://github.com/scroll-tech/go-ethereum/pull/206/files#diff-689874b30f6f905ce6c47cdefeddcf052b467a7936a981f4b6cf38939e10d924R933
2. do a `nil`-check everywhere `BaseFee` is used,