### PR TITLE
Fix: error propagation in db layer of zktrie

### DIFF
--- a/trie/zk_trie_database.go
+++ b/trie/zk_trie_database.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/syndtr/goleveldb/leveldb"
 
+	zktrie "github.com/scroll-tech/zktrie/trie"
+
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/ethdb"
-	zktrie "github.com/scroll-tech/zktrie/trie"
 )
 
 // ZktrieDatabase Database adaptor imple zktrie.ZktrieDatbase

--- a/trie/zk_trie_database.go
+++ b/trie/zk_trie_database.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/ethdb"
+	zktrie "github.com/scroll-tech/zktrie/trie"
 )
 
 // ZktrieDatabase Database adaptor imple zktrie.ZktrieDatbase
@@ -53,7 +54,7 @@ func (l *ZktrieDatabase) Get(key []byte) ([]byte, error) {
 
 	v, err := l.db.diskdb.Get(concatKey)
 	if err == leveldb.ErrNotFound {
-		return nil, ErrNotFound
+		return nil, zktrie.ErrKeyNotFound
 	}
 	if l.db.cleans != nil {
 		l.db.cleans.Set(concatKey[:], v)


### PR DESCRIPTION
An error of `ErrNotFound` in trie module has been propagated into zktrie inappropriately. As the result zktrie can not recognize it is a `ErrKeyNotFound` error and throw out the error onto upstream caller. This may cause some unexpected failure and error output in mpt witness generator module.