### PR TITLE
feat(snapshot): Close snapshot p2p protocol when using zktrie.

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -516,7 +516,7 @@ func (s *Ethereum) BloomIndexer() *core.ChainIndexer   { return s.bloomIndexer }
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.ethDialCandidates)
-	if s.config.SnapshotCache > 0 {
+	if !s.blockchain.Config().Zktrie && s.config.SnapshotCache > 0 {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler), s.snapDialCandidates)...)
 	}
 	return protos


### PR DESCRIPTION
When we use zktrie the snapshot is closed, so snapshot(p2p protocol) don't need to use.