### PR TITLE
feat(trace): add deletion proof into storage trace

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -351,56 +351,37 @@ func (s *StateDB) GetRootHash() common.Hash {
 }
 
 // StorageTrieProof is not in Db interface and used explictily for reading proof in storage trie (not the dirty value)
-func (s *StateDB) GetStorageTrieProof(a common.Address, key common.Hash) ([][]byte, error) {
+// For zktrie it also provide required data for predict the deletion, else it just fallback to GetStorageProof
+func (s *StateDB) GetStorageTrieProof(a common.Address, key common.Hash) ([][]byte, []byte, error) {
 
 	// try the trie in stateObject first, else we would create one
 	stateObject := s.getStateObject(a)
 	if stateObject == nil {
-		return nil, errors.New("storage trie for requested address does not exist")
+		return nil, nil, errors.New("storage trie for requested address does not exist")
 	}
 
-	trie := stateObject.trie
+	trieS := stateObject.trie
 	var err error
-	if trie == nil {
+	if trieS == nil {
 		// use a new, temporary trie
-		trie, err = s.db.OpenStorageTrie(stateObject.addrHash, stateObject.data.Root)
+		trieS, err = s.db.OpenStorageTrie(stateObject.addrHash, stateObject.data.Root)
 		if err != nil {
-			return nil, fmt.Errorf("can't create storage trie on root %s: %v ", stateObject.data.Root, err)
+			return nil, nil, fmt.Errorf("can't create storage trie on root %s: %v ", stateObject.data.Root, err)
 		}
 	}
 
 	var proof proofList
-	if s.IsZktrie() {
-		key_s, _ := zkt.ToSecureKeyBytes(key.Bytes())
-		err = trie.Prove(key_s.Bytes(), 0, &proof)
-	} else {
-		err = trie.Prove(crypto.Keccak256(key.Bytes()), 0, &proof)
-	}
-	return proof, err
-}
-
-// GetStorageProofFull returns the Merkle proof for given storage slot, in zktrie mode
-// it also provide required data for predict the deletion, else it just fallback to GetStorageProof
-func (s *StateDB) GetStorageProofFull(a common.Address, key common.Hash) ([][]byte, []byte, error) {
-	if !s.IsZktrie() {
-		proof, err := s.GetStorageProof(a, key)
-		return proof, nil, err
-	}
-
-	var proof proofList
-	trieS := s.StorageTrie(a)
-	if trieS == nil {
-		return proof, nil, errors.New("storage trie for requested address does not exist")
-	}
-	zkTrie := trieS.(*trie.ZkTrie)
-	if zkTrie == nil {
-		panic("unexpected trie type for zktrie")
-	}
-	var err error
 	var sibling []byte
-	key_s, _ := zkt.ToSecureKeyBytes(key.Bytes())
-	sibling, err = zkTrie.ProveWithDeletion(key_s.Bytes(), 0, &proof)
-
+	if s.IsZktrie() {
+		zkTrie := trieS.(*trie.ZkTrie)
+		if zkTrie == nil {
+			panic("unexpected trie type for zktrie")
+		}
+		key_s, _ := zkt.ToSecureKeyBytes(key.Bytes())
+		sibling, err = zkTrie.ProveWithDeletion(key_s.Bytes(), 0, &proof)
+	} else {
+		err = trieS.Prove(crypto.Keccak256(key.Bytes()), 0, &proof)
+	}
 	return proof, sibling, err
 }
 

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -48,6 +48,10 @@ type StorageTrace struct {
 
 	// All storage proofs BEFORE execution
 	StorageProofs map[string]map[string][]hexutil.Bytes `json:"storageProofs,omitempty"`
+
+	// Node entries for deletion, no need to distinguish what it is from, just read them
+	// into the partial db
+	DeletionProofs []hexutil.Bytes `json:"deletionProofs,omitempty"`
 }
 
 // ExecutionResult groups all structured logs emitted by the EVM

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -326,7 +326,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 			env.sMu.Lock()
 			m[keyStr] = wrappedProof
 			if sibling != nil {
-				env.DeletionProofs = append(env.DeletionProofs, hexutil.Bytes(sibling))
+				env.DeletionProofs = append(env.DeletionProofs, sibling)
 			}
 			env.sMu.Unlock()
 		}

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -314,7 +314,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 			}
 			env.sMu.Unlock()
 
-			proof, sibling, err := state.GetStorageProofFull(addr, key)
+			proof, sibling, err := state.GetStorageTrieProof(addr, key)
 			if err != nil {
 				log.Error("Storage proof not available", "error", err, "address", addrStr, "key", keyStr)
 				// but we still mark the proofs map with nil array

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -314,7 +314,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 			}
 			env.sMu.Unlock()
 
-			proof, err := state.GetStorageTrieProof(addr, key)
+			proof, sibling, err := state.GetStorageProofFull(addr, key)
 			if err != nil {
 				log.Error("Storage proof not available", "error", err, "address", addrStr, "key", keyStr)
 				// but we still mark the proofs map with nil array
@@ -325,6 +325,9 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 			}
 			env.sMu.Lock()
 			m[keyStr] = wrappedProof
+			if sibling != nil {
+				env.DeletionProofs = append(env.DeletionProofs, hexutil.Bytes(sibling))
+			}
 			env.sMu.Unlock()
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
-	github.com/scroll-tech/zktrie v0.5.0
+	github.com/scroll-tech/zktrie v0.5.1
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
-	github.com/scroll-tech/zktrie v0.5.1
+	github.com/scroll-tech/zktrie v0.5.2
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scroll-tech/zktrie v0.5.0 h1:dABDR6lMZq6Hs+fWQSiHbX8s3AOX6hY+5nkhSYm5rmU=
-github.com/scroll-tech/zktrie v0.5.0/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
+github.com/scroll-tech/zktrie v0.5.1 h1:g2kIoC6cbBiYqn2iCE+/7NA+AUVAbPRhZgmvfkJURQQ=
+github.com/scroll-tech/zktrie v0.5.1/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scroll-tech/zktrie v0.5.1 h1:g2kIoC6cbBiYqn2iCE+/7NA+AUVAbPRhZgmvfkJURQQ=
-github.com/scroll-tech/zktrie v0.5.1/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
+github.com/scroll-tech/zktrie v0.5.2 h1:U34jPXMLGOlRHfdvYp5VVgOcC0RuPeJmcS3bWotCWiY=
+github.com/scroll-tech/zktrie v0.5.2/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -174,11 +174,12 @@ func (t *ZkTrie) NodeIterator(start []byte) NodeIterator {
 // nodes of the longest existing prefix of the key (at least the root node), ending
 // with the node that proves the absence of the key.
 func (t *ZkTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
+	// omit sibling, which is not required for proving only
 	_, err := t.ProveWithDeletion(key, fromLevel, proofDb)
 	return err
 }
 
-// ProveForDeletion is the implement of Prove, it also return possible sibling node
+// ProveWithDeletion is the implement of Prove, it also return possible sibling node
 // (if there is, i.e. the node of key exist and is not the only node in trie)
 // so witness generator can predict the final state root after deletion of this key
 // the returned sibling node has no key along with it for witness generator must decode

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -174,7 +174,7 @@ func (t *ZkTrie) NodeIterator(start []byte) NodeIterator {
 // nodes of the longest existing prefix of the key (at least the root node), ending
 // with the node that proves the absence of the key.
 func (t *ZkTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
-	_, err := t.ProveForDeletion(key, fromLevel, proofDb)
+	_, err := t.ProveWithDeletion(key, fromLevel, proofDb)
 	return err
 }
 
@@ -183,7 +183,7 @@ func (t *ZkTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter)
 // so witness generator can predict the final state root after deletion of this key
 // the returned sibling node has no key along with it for witness generator must decode
 // the node for its purpose
-func (t *ZkTrie) ProveForDeletion(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) (sibling []byte, err error) {
+func (t *ZkTrie) ProveWithDeletion(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) (sibling []byte, err error) {
 	err = t.ZkTrie.ProveWithDeletion(key, fromLevel,
 		func(n *zktrie.Node) error {
 			nodeHash, err := n.NodeHash()

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -174,29 +174,47 @@ func (t *ZkTrie) NodeIterator(start []byte) NodeIterator {
 // nodes of the longest existing prefix of the key (at least the root node), ending
 // with the node that proves the absence of the key.
 func (t *ZkTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error {
-	err := t.ZkTrie.Prove(key, fromLevel, func(n *zktrie.Node) error {
-		nodeHash, err := n.NodeHash()
-		if err != nil {
-			return err
-		}
+	_, err := t.ProveForDeletion(key, fromLevel, proofDb)
+	return err
+}
 
-		if n.Type == zktrie.NodeTypeLeaf {
-			preImage := t.GetKey(n.NodeKey.Bytes())
-			if len(preImage) > 0 {
-				n.KeyPreimage = &zkt.Byte32{}
-				copy(n.KeyPreimage[:], preImage)
-				//return fmt.Errorf("key preimage not found for [%x] ref %x", n.NodeKey.Bytes(), k.Bytes())
+// ProveForDeletion is the implement of Prove, it also return possible sibling node
+// (if there is, i.e. the node of key exist and is not the only node in trie)
+// so witness generator can predict the final state root after deletion of this key
+// the returned sibling node has no key along with it for witness generator must decode
+// the node for its purpose
+func (t *ZkTrie) ProveForDeletion(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) (sibling []byte, err error) {
+	err = t.ZkTrie.ProveWithDeletion(key, fromLevel,
+		func(n *zktrie.Node) error {
+			nodeHash, err := n.NodeHash()
+			if err != nil {
+				return err
 			}
-		}
-		return proofDb.Put(nodeHash[:], n.Value())
-	})
+
+			if n.Type == zktrie.NodeTypeLeaf {
+				preImage := t.GetKey(n.NodeKey.Bytes())
+				if len(preImage) > 0 {
+					n.KeyPreimage = &zkt.Byte32{}
+					copy(n.KeyPreimage[:], preImage)
+					//return fmt.Errorf("key preimage not found for [%x] ref %x", n.NodeKey.Bytes(), k.Bytes())
+				}
+			}
+			return proofDb.Put(nodeHash[:], n.Value())
+		},
+		func(_ *zktrie.Node, n *zktrie.Node) {
+			if n != nil {
+				sibling = n.Value()
+			}
+		},
+	)
 	if err != nil {
-		return err
+		return
 	}
 
 	// we put this special kv pair in db so we can distinguish the type and
 	// make suitable Proof
-	return proofDb.Put(magicHash, zktrie.ProofMagicBytes())
+	err = proofDb.Put(magicHash, zktrie.ProofMagicBytes())
+	return
 }
 
 // VerifyProof checks merkle proofs. The given proof must contain the value for

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -203,7 +203,8 @@ func (t *ZkTrie) ProveWithDeletion(key []byte, fromLevel uint, proofDb ethdb.Key
 			return proofDb.Put(nodeHash[:], n.Value())
 		},
 		func(_ *zktrie.Node, n *zktrie.Node) {
-			if n != nil {
+			// the sibling for each leaf should be unique except for EmptyNode
+			if n != nil && n.Type != zktrie.NodeTypeEmpty {
 				sibling = n.Value()
 			}
 		},

--- a/trie/zk_trie_proof_test.go
+++ b/trie/zk_trie_proof_test.go
@@ -222,6 +222,8 @@ func TestProofWithDeletion(t *testing.T) {
 	nd, err := tr.TryGet(key2)
 	assert.NoError(t, err)
 	l := len(sibling1)
+	// a hacking to grep the value part directly from the encoded leaf node,
+	// notice the sibling of key `k*32`` is just the leaf of key `m*32`
 	assert.Equal(t, sibling1[l-33:l-1], nd)
 
 	s_key2, err := zkt.ToSecureKeyBytes(bytes.Repeat([]byte("x"), 32))

--- a/trie/zk_trie_proof_test.go
+++ b/trie/zk_trie_proof_test.go
@@ -213,9 +213,7 @@ func TestProofWithDeletion(t *testing.T) {
 	)
 	assert.NoError(t, err)
 
-	var proof *memorydb.Database
-
-	proof = memorydb.New()
+	proof := memorydb.New()
 	s_key1, err := zkt.ToSecureKeyBytes(key1)
 	assert.NoError(t, err)
 

--- a/trie/zk_trie_proof_test.go
+++ b/trie/zk_trie_proof_test.go
@@ -219,7 +219,7 @@ func TestProofWithDeletion(t *testing.T) {
 	s_key1, err := zkt.ToSecureKeyBytes(key1)
 	assert.NoError(t, err)
 
-	sibling1, err := tr.ProveForDeletion(s_key1.Bytes(), 0, proof)
+	sibling1, err := tr.ProveWithDeletion(s_key1.Bytes(), 0, proof)
 	assert.NoError(t, err)
 	nd, err := tr.TryGet(key2)
 	assert.NoError(t, err)
@@ -229,7 +229,7 @@ func TestProofWithDeletion(t *testing.T) {
 	s_key2, err := zkt.ToSecureKeyBytes(bytes.Repeat([]byte("x"), 32))
 	assert.NoError(t, err)
 
-	sibling2, err := tr.ProveForDeletion(s_key2.Bytes(), 0, proof)
+	sibling2, err := tr.ProveWithDeletion(s_key2.Bytes(), 0, proof)
 	assert.NoError(t, err)
 	assert.Nil(t, sibling2)
 

--- a/trie/zk_trie_proof_test.go
+++ b/trie/zk_trie_proof_test.go
@@ -143,8 +143,8 @@ func TestSMTMissingKeyProof(t *testing.T) {
 	tr, _ := NewZkTrie(common.Hash{}, NewZktrieDatabase((memorydb.New())))
 	mt := &zkTrieImplTestWrapper{tr.Tree()}
 	err := mt.UpdateWord(
-		zkt.NewByte32FromBytesPaddingZero(bytes.Repeat([]byte("k"), 20)),
-		zkt.NewByte32FromBytesPaddingZero(bytes.Repeat([]byte("v"), 20)),
+		zkt.NewByte32FromBytesPaddingZero(bytes.Repeat([]byte("k"), 32)),
+		zkt.NewByte32FromBytesPaddingZero(bytes.Repeat([]byte("v"), 32)),
 	)
 	assert.Nil(t, err)
 
@@ -194,4 +194,43 @@ func randomZktrie(t *testing.T, n int) (*ZkTrie, map[string]*kv) {
 	}
 
 	return tr, vals
+}
+
+// Tests that new "proof with deletion" feature
+func TestProofWithDeletion(t *testing.T) {
+	tr, _ := NewZkTrie(common.Hash{}, NewZktrieDatabase((memorydb.New())))
+	mt := &zkTrieImplTestWrapper{tr.Tree()}
+	key1 := bytes.Repeat([]byte("k"), 32)
+	key2 := bytes.Repeat([]byte("m"), 32)
+	err := mt.UpdateWord(
+		zkt.NewByte32FromBytesPaddingZero(key1),
+		zkt.NewByte32FromBytesPaddingZero(bytes.Repeat([]byte("v"), 32)),
+	)
+	assert.NoError(t, err)
+	err = mt.UpdateWord(
+		zkt.NewByte32FromBytesPaddingZero(key2),
+		zkt.NewByte32FromBytesPaddingZero(bytes.Repeat([]byte("n"), 32)),
+	)
+	assert.NoError(t, err)
+
+	var proof *memorydb.Database
+
+	proof = memorydb.New()
+	s_key1, err := zkt.ToSecureKeyBytes(key1)
+	assert.NoError(t, err)
+
+	sibling1, err := tr.ProveForDeletion(s_key1.Bytes(), 0, proof)
+	assert.NoError(t, err)
+	nd, err := tr.TryGet(key2)
+	assert.NoError(t, err)
+	l := len(sibling1)
+	assert.Equal(t, sibling1[l-33:l-1], nd)
+
+	s_key2, err := zkt.ToSecureKeyBytes(bytes.Repeat([]byte("x"), 32))
+	assert.NoError(t, err)
+
+	sibling2, err := tr.ProveForDeletion(s_key2.Bytes(), 0, proof)
+	assert.NoError(t, err)
+	assert.Nil(t, sibling2)
+
 }


### PR DESCRIPTION
The witness generator, which work inside zkevm-circuit and calculate the state root for mpt update, work under a 'partial' database provided by the `storageTrace` field in `blockTrace`, that is, only the entries of db involved in zktrie updating is provided.

When handling a deletion of leaf in zktrie, the detail of its sibling (if it is a leaf or not) must be known by witness generator but currently the storage trace do not provide this entry. As the result, we have to add an additonal field `deletionProof` into storage trace so witness generator can read this field and obtain information it needed.

This work require updating zktrie module to `v0.5.1`, which has a new method for `prove` which also provide the data of sibling node when obtain the proof (in the form Merkle path) of a key. And we just add it for each storage slot referred by storage trace. The cost is small: only one extra query on db (not on trie) for each slot.

This patch do not break chaindata we have generated. We can just apply the new node on current data, continue running and pull the block trace one more time

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204190807715958