### PR TITLE
[Fix] deletion proof should be collected in log tracing

### DIFF
--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -53,6 +53,7 @@ type StateDB interface {
 	GetProof(addr common.Address) ([][]byte, error)
 	GetProofByHash(addrHash common.Hash) ([][]byte, error)
 	GetStorageProof(a common.Address, key common.Hash) ([][]byte, error)
+	GetDeletetionProof(a common.Address, key common.Hash) ([]byte, error)
 
 	Suicide(common.Address) bool
 	HasSuicided(common.Address) bool

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 0       // Major version component of the current release
 	VersionMinor = 1       // Minor version component of the current release
-	VersionPatch = 10      // Patch version component of the current release
+	VersionPatch = 11      // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Finding that the deletion proof can not be collected from the initialized trie state for each storage slot being touched in the executed txs. Consider following case:

1. We have a leaf node `A` in trie at the beginning
2. The sibling leaf node of `A` is deleted, as the result, `A` is pushed up to a new position in trie and now it has another sibling node (call it `U`)
3. `A` itself is being deleted. For the witness generator side, now it need the information of `U` to deduce the state root after this deletion. However, if we just collect all deletion proofs at the beginning of this tx. We would have no chance to see `U` and record it.

In this PR we add deletion proof collection step into log trace. For every `SSTORE` set a storage slot to 0 (i.e. a deletion occur) we collect the sibling of deleted node right before this step as a deletion proof.
