### PR TITLE
Disable EIP-3198

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -68,7 +68,7 @@ type JumpTable [256]*operation
 func newLondonInstructionSet() JumpTable {
 	instructionSet := newBerlinInstructionSet()
 	enable3529(&instructionSet) // EIP-3529: Reduction in refunds https://eips.ethereum.org/EIPS/eip-3529
-	enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
+	// enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
 	return instructionSet
 }
 

--- a/params/version.go
+++ b/params/version.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	VersionMajor = 0       // Major version component of the current release
+	VersionMajor = 3       // Major version component of the current release
 	VersionMinor = 1       // Minor version component of the current release
-	VersionPatch = 10      // Patch version component of the current release
+	VersionPatch = 0       // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## Problem

Producing a block that contains `BASEFEE` will fail.

## Solution

Disable EIP-3198. This is backward-compatible with the existing ledger since we could not produce such blocks previously.

## Deployment

1. Merge and build image
2. Test syncing the ledger
3. Ask partners to upgrade to latest version
4. Upgrade signers