### PR TITLE
refactor(config): consolidate scroll flags

### DIFF
--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -248,7 +248,7 @@ func Transition(ctx *cli.Context) error {
 	}
 	// Sanity check, to not `panic` in state_transition
 	if chainConfig.IsLondon(big.NewInt(int64(prestate.Env.Number))) {
-		if prestate.Env.BaseFee == nil && chainConfig.EnableEIP2718 && chainConfig.EnableEIP1559 {
+		if prestate.Env.BaseFee == nil && chainConfig.Scroll.BaseFeeEnabled() {
 			return NewError(ErrorConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}
 	}

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -39,10 +39,10 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 		return err
 	}
 	// Verify the header is not malformed
-	if header.BaseFee == nil && (config.EnableEIP2718 && config.EnableEIP1559) {
+	if header.BaseFee == nil && (config.Scroll != nil && config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559) {
 		return fmt.Errorf("header is missing baseFee")
 	}
-	// Now BaseFee can be nil, because !(config.EnableEIP2718 && config.EnableEIP1559)
+	// Now BaseFee can be nil, because !(config.Scroll!=nil &&config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559)
 	if header.BaseFee == nil {
 		return nil
 	}
@@ -51,7 +51,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	var expectedBaseFee *big.Int
 
 	// compatible check with the logic in commitNewWork
-	if config.Clique == nil || (config.EnableEIP2718 && config.EnableEIP1559) {
+	if config.Clique == nil || (config.Scroll != nil && config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559) {
 		expectedBaseFee = CalcBaseFee(config, parent)
 	} else {
 		expectedBaseFee = big.NewInt(0)
@@ -76,7 +76,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
 	)
-	if !config.EnableEIP2718 || !config.EnableEIP1559 {
+	if config.Scroll == nil || !config.Scroll.EnableEIP2718 || !config.Scroll.EnableEIP1559 {
 		return nil
 	}
 	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -39,10 +39,10 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 		return err
 	}
 	// Verify the header is not malformed
-	if header.BaseFee == nil && (config.Scroll != nil && config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559) {
+	if header.BaseFee == nil && config.Scroll.BaseFeeEnabled() {
 		return fmt.Errorf("header is missing baseFee")
 	}
-	// Now BaseFee can be nil, because !(config.Scroll!=nil &&config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559)
+	// Now BaseFee can be nil, because !config.Scroll.BaseFeeEnabled()
 	if header.BaseFee == nil {
 		return nil
 	}
@@ -51,7 +51,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 	var expectedBaseFee *big.Int
 
 	// compatible check with the logic in commitNewWork
-	if config.Clique == nil || (config.Scroll != nil && config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559) {
+	if config.Clique == nil || config.Scroll.BaseFeeEnabled() {
 		expectedBaseFee = CalcBaseFee(config, parent)
 	} else {
 		expectedBaseFee = big.NewInt(0)
@@ -76,7 +76,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
 	)
-	if config.Scroll == nil || !config.Scroll.EnableEIP2718 || !config.Scroll.EnableEIP1559 {
+	if !config.Scroll.BaseFeeEnabled() {
 		return nil
 	}
 	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -54,7 +54,7 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if v.bc.HasBlockAndState(block.Hash(), block.NumberU64()) {
 		return ErrKnownBlock
 	}
-	if !v.config.IsValidTxCount(len(block.Transactions())) {
+	if !v.config.Scroll.IsValidTxCount(len(block.Transactions())) {
 		return consensus.ErrInvalidTxCount
 	}
 	// Header validity is known at this point, check the uncles and transactions

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -231,7 +231,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	txLookupCache, _ := lru.New(txLookupCacheLimit)
 	futureBlocks, _ := lru.New(maxFutureBlocks)
 	// override snapshot setting
-	if chainConfig.Scroll != nil && chainConfig.Scroll.UseZktrie && cacheConfig.SnapshotLimit > 0 {
+	if chainConfig.Scroll.ZktrieEnabled() && cacheConfig.SnapshotLimit > 0 {
 		log.Warn("Snapshot has been disabled by zktrie")
 		cacheConfig.SnapshotLimit = 0
 	}
@@ -249,8 +249,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			Cache:     cacheConfig.TrieCleanLimit,
 			Journal:   cacheConfig.TrieCleanJournal,
 			Preimages: cacheConfig.Preimages,
-			// TODO:
-			// Zktrie:    chainConfig.Zktrie,
+			Zktrie:    chainConfig.Scroll.ZktrieEnabled(),
 		}),
 		quit:           make(chan struct{}),
 		chainmu:        syncx.NewClosableMutex(),

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -236,7 +236,7 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 		cacheConfig.SnapshotLimit = 0
 	}
 
-	if chainConfig.Scroll != nil && chainConfig.Scroll.FeeVaultAddress != nil {
+	if chainConfig.Scroll.L1FeeEnabled() {
 		log.Warn("Using fee vault address", "FeeVaultAddress", *chainConfig.Scroll.FeeVaultAddress)
 	}
 

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -231,13 +231,13 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	txLookupCache, _ := lru.New(txLookupCacheLimit)
 	futureBlocks, _ := lru.New(maxFutureBlocks)
 	// override snapshot setting
-	if chainConfig.Zktrie && cacheConfig.SnapshotLimit > 0 {
+	if chainConfig.Scroll != nil && chainConfig.Scroll.UseZktrie && cacheConfig.SnapshotLimit > 0 {
 		log.Warn("Snapshot has been disabled by zktrie")
 		cacheConfig.SnapshotLimit = 0
 	}
 
-	if chainConfig.FeeVaultAddress != nil {
-		log.Warn("Using fee vault address", "FeeVaultAddress", *chainConfig.FeeVaultAddress)
+	if chainConfig.Scroll != nil && chainConfig.Scroll.FeeVaultAddress != nil {
+		log.Warn("Using fee vault address", "FeeVaultAddress", *chainConfig.Scroll.FeeVaultAddress)
 	}
 
 	bc := &BlockChain{
@@ -249,7 +249,8 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 			Cache:     cacheConfig.TrieCleanLimit,
 			Journal:   cacheConfig.TrieCleanJournal,
 			Preimages: cacheConfig.Preimages,
-			Zktrie:    chainConfig.Zktrie,
+			// TODO:
+			// Zktrie:    chainConfig.Zktrie,
 		}),
 		quit:           make(chan struct{}),
 		chainmu:        syncx.NewClosableMutex(),

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3170,7 +3170,7 @@ func TestFeeVault(t *testing.T) {
 	}
 
 	// Ensure that the fee vault received all tx fees
-	actual = state.GetBalance(*params.TestChainConfig.FeeVaultAddress)
+	actual = state.GetBalance(*params.TestChainConfig.Scroll.FeeVaultAddress)
 	expected = new(big.Int).SetUint64(block.GasUsed() * block.Transactions()[0].GasTipCap().Uint64())
 
 	if actual.Cmp(expected) != 0 {
@@ -3182,8 +3182,8 @@ func TestFeeVault(t *testing.T) {
 func TestTransactionCountLimit(t *testing.T) {
 	// Create config that allows at most 1 transaction per block
 	config := params.TestChainConfig
-	config.MaxTxPerBlock = new(int)
-	*config.MaxTxPerBlock = 1
+	config.Scroll.MaxTxPerBlock = new(int)
+	*config.Scroll.MaxTxPerBlock = 1
 
 	var (
 		engine  = ethash.NewFaker()

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -187,11 +187,11 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, override
 		storedcfg := rawdb.ReadChainConfig(db, stored)
 		if storedcfg == nil {
 			log.Warn("Found genesis block without chain config")
-		} else if storedcfg.Scroll != nil {
-			trieCfg = &trie.Config{Zktrie: storedcfg.Scroll.UseZktrie}
+		} else {
+			trieCfg = &trie.Config{Zktrie: storedcfg.Scroll.ZktrieEnabled()}
 		}
-	} else if genesis.Config.Scroll != nil {
-		trieCfg = &trie.Config{Zktrie: genesis.Config.Scroll.UseZktrie}
+	} else {
+		trieCfg = &trie.Config{Zktrie: genesis.Config.Scroll.ZktrieEnabled()}
 	}
 
 	if _, err := state.New(header.Root, state.NewDatabaseWithConfig(db, trieCfg), nil); err != nil {
@@ -276,8 +276,8 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		db = rawdb.NewMemoryDatabase()
 	}
 	var trieCfg *trie.Config
-	if g.Config != nil && g.Config.Scroll != nil {
-		trieCfg = &trie.Config{Zktrie: g.Config.Scroll.UseZktrie}
+	if g.Config != nil {
+		trieCfg = &trie.Config{Zktrie: g.Config.Scroll.ZktrieEnabled()}
 	}
 	statedb, err := state.New(common.Hash{}, state.NewDatabaseWithConfig(db, trieCfg), nil)
 	if err != nil {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -315,7 +315,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if g.Config != nil && g.Config.IsLondon(common.Big0) {
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
-		} else if g.Config.Scroll != nil && g.Config.Scroll.EnableEIP2718 && g.Config.Scroll.EnableEIP1559 {
+		} else if g.Config.Scroll.BaseFeeEnabled() {
 			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		} else {
 			head.BaseFee = nil

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -166,7 +166,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 // NewStateTransition initialises and returns a new state transition object.
 func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition {
 	l1Fee := new(big.Int)
-	if evm.ChainConfig().UsingScroll {
+	if evm.ChainConfig().Scroll != nil && evm.ChainConfig().Scroll.FeeVaultAddress != nil {
 		l1Fee, _ = fees.CalculateL1MsgFee(msg, evm.StateDB)
 	}
 
@@ -207,7 +207,7 @@ func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).SetUint64(st.msg.Gas())
 	mgval = mgval.Mul(mgval, st.gasPrice)
 
-	if st.evm.ChainConfig().UsingScroll {
+	if st.evm.ChainConfig().Scroll != nil && st.evm.ChainConfig().Scroll.FeeVaultAddress != nil {
 		// always add l1fee, because all tx are L2-to-L1 ATM
 		log.Debug("Adding L1 fee", "l1_fee", st.l1Fee)
 		mgval = mgval.Add(mgval, st.l1Fee)
@@ -218,7 +218,7 @@ func (st *StateTransition) buyGas() error {
 		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
 		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
 		balanceCheck.Add(balanceCheck, st.value)
-		if st.evm.ChainConfig().UsingScroll {
+		if st.evm.ChainConfig().Scroll != nil && st.evm.ChainConfig().Scroll.FeeVaultAddress != nil {
 			// always add l1fee, because all tx are L2-to-L1 ATM
 			balanceCheck.Add(balanceCheck, st.l1Fee)
 		}
@@ -370,7 +370,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		}
 	}
 
-	if st.evm.ChainConfig().UsingScroll {
+	if st.evm.ChainConfig().Scroll != nil && st.evm.ChainConfig().Scroll.FeeVaultAddress != nil {
 		// The L2 Fee is the same as the fee that is charged in the normal geth
 		// codepath. Add the L1 fee to the L2 fee for the total fee that is sent
 		// to the sequencer.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -166,7 +166,7 @@ func IntrinsicGas(data []byte, accessList types.AccessList, isContractCreation b
 // NewStateTransition initialises and returns a new state transition object.
 func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition {
 	l1Fee := new(big.Int)
-	if evm.ChainConfig().Scroll != nil && evm.ChainConfig().Scroll.FeeVaultAddress != nil {
+	if evm.ChainConfig().Scroll.L1FeeEnabled() {
 		l1Fee, _ = fees.CalculateL1MsgFee(msg, evm.StateDB)
 	}
 
@@ -207,7 +207,7 @@ func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).SetUint64(st.msg.Gas())
 	mgval = mgval.Mul(mgval, st.gasPrice)
 
-	if st.evm.ChainConfig().Scroll != nil && st.evm.ChainConfig().Scroll.FeeVaultAddress != nil {
+	if st.evm.ChainConfig().Scroll.L1FeeEnabled() {
 		// always add l1fee, because all tx are L2-to-L1 ATM
 		log.Debug("Adding L1 fee", "l1_fee", st.l1Fee)
 		mgval = mgval.Add(mgval, st.l1Fee)
@@ -218,7 +218,7 @@ func (st *StateTransition) buyGas() error {
 		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
 		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
 		balanceCheck.Add(balanceCheck, st.value)
-		if st.evm.ChainConfig().Scroll != nil && st.evm.ChainConfig().Scroll.FeeVaultAddress != nil {
+		if st.evm.ChainConfig().Scroll.L1FeeEnabled() {
 			// always add l1fee, because all tx are L2-to-L1 ATM
 			balanceCheck.Add(balanceCheck, st.l1Fee)
 		}
@@ -370,7 +370,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		}
 	}
 
-	if st.evm.ChainConfig().Scroll != nil && st.evm.ChainConfig().Scroll.FeeVaultAddress != nil {
+	if st.evm.ChainConfig().Scroll.L1FeeEnabled() {
 		// The L2 Fee is the same as the fee that is charged in the normal geth
 		// codepath. Add the L1 fee to the L2 fee for the total fee that is sent
 		// to the sequencer.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -682,7 +682,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 	// the sender is marked as local previously, treat it as the local transaction.
 	isLocal := local || pool.locals.containsTx(tx)
 
-	if pool.chainconfig.UsingScroll {
+	if pool.chainconfig.Scroll != nil && pool.chainconfig.Scroll.FeeVaultAddress != nil {
 		if err := fees.VerifyFee(pool.signer, tx, pool.currentState); err != nil {
 			log.Trace("Discarding insufficient l1fee transaction", "hash", hash, "err", err)
 			invalidTxMeter.Mark(1)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -682,7 +682,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 	// the sender is marked as local previously, treat it as the local transaction.
 	isLocal := local || pool.locals.containsTx(tx)
 
-	if pool.chainconfig.Scroll != nil && pool.chainconfig.Scroll.FeeVaultAddress != nil {
+	if pool.chainconfig.Scroll.L1FeeEnabled() {
 		if err := fees.VerifyFee(pool.signer, tx, pool.currentState); err != nil {
 			log.Trace("Discarding insufficient l1fee transaction", "hash", hash, "err", err)
 			invalidTxMeter.Mark(1)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1330,13 +1330,8 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 
-	if pool.chainconfig.Scroll != nil {
-		pool.eip2718 = pool.chainconfig.Scroll.EnableEIP2718 && pool.chainconfig.IsBerlin(next)
-		pool.eip1559 = pool.chainconfig.Scroll.EnableEIP1559 && pool.chainconfig.IsLondon(next)
-	} else {
-		pool.eip2718 = pool.chainconfig.IsBerlin(next)
-		pool.eip1559 = pool.chainconfig.IsLondon(next)
-	}
+	pool.eip2718 = pool.chainconfig.Scroll.EnableEIP2718 && pool.chainconfig.IsBerlin(next)
+	pool.eip1559 = pool.chainconfig.Scroll.EnableEIP1559 && pool.chainconfig.IsLondon(next)
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1329,8 +1329,14 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	// Update all fork indicator by next pending block number.
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
-	pool.eip2718 = pool.chainconfig.EnableEIP2718 && pool.chainconfig.IsBerlin(next)
-	pool.eip1559 = pool.chainconfig.EnableEIP1559 && pool.chainconfig.IsLondon(next)
+
+	if pool.chainconfig.Scroll != nil {
+		pool.eip2718 = pool.chainconfig.Scroll.EnableEIP2718 && pool.chainconfig.IsBerlin(next)
+		pool.eip1559 = pool.chainconfig.Scroll.EnableEIP1559 && pool.chainconfig.IsLondon(next)
+	} else {
+		pool.eip2718 = pool.chainconfig.IsBerlin(next)
+		pool.eip1559 = pool.chainconfig.IsLondon(next)
+	}
 }
 
 // promoteExecutables moves transactions that have become processable from the

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -535,8 +535,8 @@ func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
 
 // FeeRecipient returns the environment's transaction fee recipient address.
 func (evm *EVM) FeeRecipient() common.Address {
-	if evm.ChainConfig().FeeVaultAddress != nil {
-		return *evm.chainConfig.FeeVaultAddress
+	if evm.ChainConfig().Scroll != nil && evm.ChainConfig().Scroll.FeeVaultAddress != nil {
+		return *evm.chainConfig.Scroll.FeeVaultAddress
 	} else {
 		return evm.Context.Coinbase
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -535,7 +535,7 @@ func (evm *EVM) ChainConfig() *params.ChainConfig { return evm.chainConfig }
 
 // FeeRecipient returns the environment's transaction fee recipient address.
 func (evm *EVM) FeeRecipient() common.Address {
-	if evm.ChainConfig().Scroll != nil && evm.ChainConfig().Scroll.FeeVaultAddress != nil {
+	if evm.ChainConfig().Scroll.L1FeeEnabled() {
 		return *evm.chainConfig.Scroll.FeeVaultAddress
 	} else {
 		return evm.Context.Coinbase

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -516,7 +516,7 @@ func (s *Ethereum) BloomIndexer() *core.ChainIndexer   { return s.bloomIndexer }
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.ethDialCandidates)
-	if !(s.blockchain.Config().Scroll != nil && s.blockchain.Config().Scroll.UseZktrie) && s.config.SnapshotCache > 0 {
+	if !s.blockchain.Config().Scroll.ZktrieEnabled() && s.config.SnapshotCache > 0 {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler), s.snapDialCandidates)...)
 	}
 	return protos

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -516,7 +516,7 @@ func (s *Ethereum) BloomIndexer() *core.ChainIndexer   { return s.bloomIndexer }
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.ethDialCandidates)
-	if !s.blockchain.Config().Zktrie && s.config.SnapshotCache > 0 {
+	if !(s.blockchain.Config().Scroll != nil && s.blockchain.Config().Scroll.UseZktrie) && s.config.SnapshotCache > 0 {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler), s.snapDialCandidates)...)
 	}
 	return protos

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -900,7 +900,8 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 
 	// If gasPrice is 0, make sure that the account has sufficient balance to cover `l1Fee`.
-	if api.backend.ChainConfig().UsingScroll && message.GasPrice().Cmp(big.NewInt(0)) == 0 {
+	if api.backend.ChainConfig().Scroll != nil && api.backend.ChainConfig().Scroll.FeeVaultAddress != nil &&
+		message.GasPrice().Cmp(big.NewInt(0)) == 0 {
 		l1Fee, err := fees.CalculateL1MsgFee(message, vmenv.StateDB)
 		if err != nil {
 			return nil, err

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -900,8 +900,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 
 	// If gasPrice is 0, make sure that the account has sufficient balance to cover `l1Fee`.
-	if api.backend.ChainConfig().Scroll != nil && api.backend.ChainConfig().Scroll.FeeVaultAddress != nil &&
-		message.GasPrice().Cmp(big.NewInt(0)) == 0 {
+	if api.backend.ChainConfig().Scroll.L1FeeEnabled() && message.GasPrice().Cmp(big.NewInt(0)) == 0 {
 		l1Fee, err := fees.CalculateL1MsgFee(message, vmenv.StateDB)
 		if err != nil {
 			return nil, err

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -397,7 +397,7 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 		}
 	}
 
-	if api.backend.ChainConfig().UsingScroll {
+	if api.backend.ChainConfig().Scroll != nil {
 		blockTrace.WithdrawTrieRoot = withdrawtrie.ReadWTRSlot(rcfg.L2MessageQueueAddress, env.state)
 	}
 

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -98,8 +98,8 @@ func (api *API) createTraceEnv(ctx context.Context, config *TraceConfig, block *
 
 	// get coinbase
 	var coinbase common.Address
-	if api.backend.ChainConfig().FeeVaultAddress != nil {
-		coinbase = *api.backend.ChainConfig().FeeVaultAddress
+	if api.backend.ChainConfig().Scroll != nil && api.backend.ChainConfig().Scroll.FeeVaultAddress != nil {
+		coinbase = *api.backend.ChainConfig().Scroll.FeeVaultAddress
 	} else {
 		coinbase, err = api.backend.Engine().Author(block.Header())
 		if err != nil {
@@ -391,7 +391,7 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 	}
 
 	// only zktrie model has the ability to get `mptwitness`.
-	if api.backend.ChainConfig().Zktrie {
+	if api.backend.ChainConfig().Scroll != nil && api.backend.ChainConfig().Scroll.UseZktrie {
 		if err := zkproof.FillBlockTraceForMPTWitness(zkproof.MPTWitnessType(api.backend.CacheConfig().MPTWitness), blockTrace); err != nil {
 			log.Error("fill mpt witness fail", "error", err)
 		}

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -98,7 +98,7 @@ func (api *API) createTraceEnv(ctx context.Context, config *TraceConfig, block *
 
 	// get coinbase
 	var coinbase common.Address
-	if api.backend.ChainConfig().Scroll != nil && api.backend.ChainConfig().Scroll.FeeVaultAddress != nil {
+	if api.backend.ChainConfig().Scroll.L1FeeEnabled() {
 		coinbase = *api.backend.ChainConfig().Scroll.FeeVaultAddress
 	} else {
 		coinbase, err = api.backend.Engine().Author(block.Header())

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -397,9 +397,7 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 		}
 	}
 
-	if api.backend.ChainConfig().Scroll != nil {
-		blockTrace.WithdrawTrieRoot = withdrawtrie.ReadWTRSlot(rcfg.L2MessageQueueAddress, env.state)
-	}
+	blockTrace.WithdrawTrieRoot = withdrawtrie.ReadWTRSlot(rcfg.L2MessageQueueAddress, env.state)
 
 	return blockTrace, nil
 }

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -391,7 +391,7 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 	}
 
 	// only zktrie model has the ability to get `mptwitness`.
-	if api.backend.ChainConfig().Scroll != nil && api.backend.ChainConfig().Scroll.UseZktrie {
+	if api.backend.ChainConfig().Scroll.ZktrieEnabled() {
 		if err := zkproof.FillBlockTraceForMPTWitness(zkproof.MPTWitnessType(api.backend.CacheConfig().MPTWitness), blockTrace); err != nil {
 			log.Error("fill mpt witness fail", "error", err)
 		}

--- a/eth/tracers/api_blocktrace_test.go
+++ b/eth/tracers/api_blocktrace_test.go
@@ -182,7 +182,7 @@ func checkStructLogs(t *testing.T, expect []*txTraceResult, actual []*types.Exec
 func checkCoinbase(t *testing.T, b *testBackend, wrapper *types.AccountWrapper) {
 	var coinbase common.Address
 	if b.chainConfig.Scroll.L1FeeEnabled() {
-		coinbase = *b.chainConfig.FeeVaultAddress
+		coinbase = *b.chainConfig.Scroll.FeeVaultAddress
 	} else {
 		header, err := b.HeaderByNumber(context.Background(), 1)
 		assert.NoError(t, err)

--- a/eth/tracers/api_blocktrace_test.go
+++ b/eth/tracers/api_blocktrace_test.go
@@ -181,7 +181,7 @@ func checkStructLogs(t *testing.T, expect []*txTraceResult, actual []*types.Exec
 
 func checkCoinbase(t *testing.T, b *testBackend, wrapper *types.AccountWrapper) {
 	var coinbase common.Address
-	if b.chainConfig.FeeVaultAddress != nil {
+	if b.chainConfig.Scroll.L1FeeEnabled() {
 		coinbase = *b.chainConfig.FeeVaultAddress
 	} else {
 		header, err := b.HeaderByNumber(context.Background(), 1)

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -908,7 +908,7 @@ func newRPCBalance(balance *big.Int) **hexutil.Big {
 }
 
 func CalculateL1MsgFee(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, timeout time.Duration, globalGasCap uint64, config *params.ChainConfig) (*big.Int, error) {
-	if !config.UsingScroll {
+	if config.Scroll == nil || config.Scroll.FeeVaultAddress == nil {
 		return big.NewInt(0), nil
 	}
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -908,7 +908,7 @@ func newRPCBalance(balance *big.Int) **hexutil.Big {
 }
 
 func CalculateL1MsgFee(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, timeout time.Duration, globalGasCap uint64, config *params.ChainConfig) (*big.Int, error) {
-	if config.Scroll == nil || config.Scroll.FeeVaultAddress == nil {
+	if !config.Scroll.L1FeeEnabled() {
 		return big.NewInt(0), nil
 	}
 
@@ -1249,7 +1249,7 @@ func RPCMarshalHeader(head *types.Header, enableBaseFee bool) map[string]interfa
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
-	fields := RPCMarshalHeader(block.Header(), config.Scroll != nil && config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559)
+	fields := RPCMarshalHeader(block.Header(), config.Scroll.BaseFeeEnabled())
 	fields["size"] = hexutil.Uint64(block.Size())
 
 	if inclTx {
@@ -1284,7 +1284,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
 // a `PublicBlockchainAPI`.
 func (s *PublicBlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) map[string]interface{} {
-	fields := RPCMarshalHeader(header, s.b.ChainConfig().Scroll != nil && s.b.ChainConfig().Scroll.EnableEIP2718 && s.b.ChainConfig().Scroll.EnableEIP1559)
+	fields := RPCMarshalHeader(header, s.b.ChainConfig().Scroll.BaseFeeEnabled())
 	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
 	return fields
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -661,7 +661,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		return nil, err
 	}
 
-	zktrie := s.b.ChainConfig().Zktrie
+	zktrie := s.b.ChainConfig().Scroll != nil && s.b.ChainConfig().Scroll.UseZktrie
 
 	storageTrie := state.StorageTrie(address)
 	var storageHash common.Hash
@@ -1249,7 +1249,7 @@ func RPCMarshalHeader(head *types.Header, enableBaseFee bool) map[string]interfa
 // returned. When fullTx is true the returned block contains full transaction details, otherwise it will only contain
 // transaction hashes.
 func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *params.ChainConfig) (map[string]interface{}, error) {
-	fields := RPCMarshalHeader(block.Header(), config.EnableEIP2718 && config.EnableEIP1559)
+	fields := RPCMarshalHeader(block.Header(), config.Scroll != nil && config.Scroll.EnableEIP2718 && config.Scroll.EnableEIP1559)
 	fields["size"] = hexutil.Uint64(block.Size())
 
 	if inclTx {
@@ -1284,7 +1284,7 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool, config *param
 // rpcMarshalHeader uses the generalized output filler, then adds the total difficulty field, which requires
 // a `PublicBlockchainAPI`.
 func (s *PublicBlockChainAPI) rpcMarshalHeader(ctx context.Context, header *types.Header) map[string]interface{} {
-	fields := RPCMarshalHeader(header, s.b.ChainConfig().EnableEIP2718 && s.b.ChainConfig().EnableEIP1559)
+	fields := RPCMarshalHeader(header, s.b.ChainConfig().Scroll != nil && s.b.ChainConfig().Scroll.EnableEIP2718 && s.b.ChainConfig().Scroll.EnableEIP1559)
 	fields["totalDifficulty"] = (*hexutil.Big)(s.b.GetTd(ctx, header.Hash()))
 	return fields
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -661,7 +661,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		return nil, err
 	}
 
-	zktrie := s.b.ChainConfig().Scroll != nil && s.b.ChainConfig().Scroll.UseZktrie
+	zktrie := s.b.ChainConfig().Scroll.ZktrieEnabled()
 
 	storageTrie := state.StorageTrie(address)
 	var storageHash common.Hash

--- a/les/server.go
+++ b/les/server.go
@@ -83,7 +83,7 @@ func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*Les
 		return nil, err
 	}
 	// Now disable for zktrie
-	if e.BlockChain().Config().Scroll != nil && e.BlockChain().Config().Scroll.UseZktrie {
+	if e.BlockChain().Config().Scroll.ZktrieEnabled() {
 		return nil, errors.New("light server not work with zktrie storage")
 	}
 

--- a/les/server.go
+++ b/les/server.go
@@ -83,7 +83,7 @@ func NewLesServer(node *node.Node, e ethBackend, config *ethconfig.Config) (*Les
 		return nil, err
 	}
 	// Now disable for zktrie
-	if e.BlockChain().Config().Zktrie {
+	if e.BlockChain().Config().Scroll != nil && e.BlockChain().Config().Scroll.UseZktrie {
 		return nil, errors.New("light server not work with zktrie storage")
 	}
 

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -405,7 +405,7 @@ func (pool *TxPool) add(ctx context.Context, tx *types.Transaction) error {
 		return fmt.Errorf("Known transaction (%x)", hash[:4])
 	}
 
-	if pool.config.UsingScroll {
+	if pool.config.Scroll != nil && pool.config.Scroll.FeeVaultAddress != nil {
 		if err := fees.VerifyFee(pool.signer, tx, pool.currentState(ctx)); err != nil {
 			return err
 		}

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -405,7 +405,7 @@ func (pool *TxPool) add(ctx context.Context, tx *types.Transaction) error {
 		return fmt.Errorf("Known transaction (%x)", hash[:4])
 	}
 
-	if pool.config.Scroll != nil && pool.config.Scroll.FeeVaultAddress != nil {
+	if pool.config.Scroll.L1FeeEnabled() {
 		if err := fees.VerifyFee(pool.signer, tx, pool.currentState(ctx)); err != nil {
 			return err
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -819,10 +819,8 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 			return atomic.LoadInt32(interrupt) == commitInterruptNewHead
 		}
 		// If we have collected enough transactions then we're done
-		if !w.chainConfig.IsValidTxCount(w.current.tcount + 1) {
-			if w.chainConfig.Scroll != nil && w.chainConfig.Scroll.MaxTxPerBlock != nil {
-				log.Trace("Transaction count limit reached", "have", w.current.tcount, "want", w.chainConfig.Scroll.MaxTxPerBlock)
-			}
+		if !w.chainConfig.Scroll.IsValidTxCount(w.current.tcount + 1) {
+			log.Trace("Transaction count limit reached", "have", w.current.tcount, "want", w.chainConfig.Scroll.MaxTxPerBlock)
 			break
 		}
 		// If we don't have enough gas for any further transactions then we're done

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -931,7 +931,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
-		if w.chainConfig.Scroll != nil && w.chainConfig.Scroll.EnableEIP2718 && w.chainConfig.Scroll.EnableEIP1559 {
+		if w.chainConfig.Scroll.BaseFeeEnabled() {
 			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 		} else {
 			// When disabling EIP-2718 or EIP-1559, we do not set baseFeePerGas in RPC response.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -820,7 +820,9 @@ func (w *worker) commitTransactions(txs *types.TransactionsByPriceAndNonce, coin
 		}
 		// If we have collected enough transactions then we're done
 		if !w.chainConfig.IsValidTxCount(w.current.tcount + 1) {
-			log.Trace("Transaction count limit reached", "have", w.current.tcount, "want", w.chainConfig.MaxTxPerBlock)
+			if w.chainConfig.Scroll != nil && w.chainConfig.Scroll.MaxTxPerBlock != nil {
+				log.Trace("Transaction count limit reached", "have", w.current.tcount, "want", w.chainConfig.Scroll.MaxTxPerBlock)
+			}
 			break
 		}
 		// If we don't have enough gas for any further transactions then we're done
@@ -929,7 +931,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
 	if w.chainConfig.IsLondon(header.Number) {
-		if w.chainConfig.EnableEIP2718 && w.chainConfig.EnableEIP1559 {
+		if w.chainConfig.Scroll != nil && w.chainConfig.Scroll.EnableEIP2718 && w.chainConfig.Scroll.EnableEIP1559 {
 			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
 		} else {
 			// When disabling EIP-2718 or EIP-1559, we do not set baseFeePerGas in RPC response.

--- a/params/config.go
+++ b/params/config.go
@@ -395,6 +395,14 @@ func (s *ScrollConfig) L1FeeEnabled() bool {
 	return s.FeeVaultAddress != nil
 }
 
+func (s *ScrollConfig) ZktrieEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return s.UseZktrie
+}
+
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
 type EthashConfig struct{}
 

--- a/params/config.go
+++ b/params/config.go
@@ -379,6 +379,22 @@ type ScrollConfig struct {
 	EnableEIP1559 bool `json:"enableEIP1559,omitempty"`
 }
 
+func (s *ScrollConfig) BaseFeeEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return s.EnableEIP2718 && s.EnableEIP1559
+}
+
+func (s *ScrollConfig) L1FeeEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return s.FeeVaultAddress != nil
+}
+
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
 type EthashConfig struct{}
 

--- a/params/config.go
+++ b/params/config.go
@@ -431,6 +431,15 @@ func (s *ScrollConfig) ZktrieEnabled() bool {
 	return s.UseZktrie
 }
 
+// IsValidTxCount returns whether the given block's transaction count is below the limit.
+func (s *ScrollConfig) IsValidTxCount(count int) bool {
+	if s == nil || s.MaxTxPerBlock == nil {
+		return true
+	}
+
+	return count <= *s.MaxTxPerBlock
+}
+
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
 type EthashConfig struct{}
 
@@ -554,11 +563,6 @@ func (c *ChainConfig) IsTerminalPoWBlock(parentTotalDiff *big.Int, totalDiff *bi
 		return false
 	}
 	return parentTotalDiff.Cmp(c.TerminalTotalDifficulty) < 0 && totalDiff.Cmp(c.TerminalTotalDifficulty) >= 0
-}
-
-// IsValidTxCount returns whether the given block's transaction count is below the limit.
-func (c *ChainConfig) IsValidTxCount(count int) bool {
-	return c.Scroll == nil || c.Scroll.MaxTxPerBlock == nil || count <= *c.Scroll.MaxTxPerBlock
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported

--- a/params/config.go
+++ b/params/config.go
@@ -400,10 +400,10 @@ type ScrollConfig struct {
 	// Transaction fee vault address [optional]
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
 
-	// enable EIP-2718 in tx pool.
+	// Enable EIP-2718 in tx pool.
 	EnableEIP2718 bool `json:"enableEIP2718,omitempty"`
 
-	// enable EIP-1559 in tx pool, EnableEIP2718 should be true too.
+	// Enable EIP-1559 in tx pool, EnableEIP2718 should be true too.
 	EnableEIP1559 bool `json:"enableEIP1559,omitempty"`
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -258,19 +258,47 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, &ScrollConfig{}}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
+		&ScrollConfig{
+			UseZktrie:       false,
+			FeeVaultAddress: nil,
+			EnableEIP2718:   true,
+			EnableEIP1559:   true,
+			MaxTxPerBlock:   nil,
+		}}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, &ScrollConfig{}}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000},
+		&ScrollConfig{
+			UseZktrie:       false,
+			FeeVaultAddress: nil,
+			EnableEIP2718:   true,
+			EnableEIP1559:   true,
+			MaxTxPerBlock:   nil,
+		}}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, &ScrollConfig{}}
-	TestRules       = TestChainConfig.Rules(new(big.Int))
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
+		&ScrollConfig{
+			UseZktrie:       false,
+			FeeVaultAddress: &common.Address{123},
+			EnableEIP2718:   true,
+			EnableEIP1559:   true,
+			MaxTxPerBlock:   nil,
+		}}
+	TestRules = TestChainConfig.Rules(new(big.Int))
 
-	TestNoL1feeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
+	TestNoL1feeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
+		&ScrollConfig{
+			UseZktrie:       false,
+			FeeVaultAddress: nil,
+			EnableEIP2718:   true,
+			EnableEIP1559:   true,
+			MaxTxPerBlock:   nil,
+		}}
 )
 
 // TrustedCheckpoint represents a set of post-processed trie roots (CHT and

--- a/params/config.go
+++ b/params/config.go
@@ -259,7 +259,7 @@ var (
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
 	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
-		&ScrollConfig{
+		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: nil,
 			EnableEIP2718:   true,
@@ -273,7 +273,7 @@ var (
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
 	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000},
-		&ScrollConfig{
+		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: nil,
 			EnableEIP2718:   true,
@@ -282,7 +282,7 @@ var (
 		}}
 
 	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
-		&ScrollConfig{
+		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: &common.Address{123},
 			EnableEIP2718:   true,
@@ -292,7 +292,7 @@ var (
 	TestRules = TestChainConfig.Rules(new(big.Int))
 
 	TestNoL1feeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
-		&ScrollConfig{
+		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: nil,
 			EnableEIP2718:   true,
@@ -387,11 +387,11 @@ type ChainConfig struct {
 	Clique *CliqueConfig `json:"clique,omitempty"`
 
 	// Scroll genesis extension: enable scroll rollup-related traces & state transition
-	Scroll *ScrollConfig `json:"scroll,omitempty"`
+	Scroll ScrollConfig `json:"scroll,omitempty"`
 }
 
 type ScrollConfig struct {
-	// Use zktrie
+	// Use zktrie [optional]
 	UseZktrie bool `json:"useZktrie,omitempty"`
 
 	// Maximum number of transactions per block [optional]
@@ -400,44 +400,28 @@ type ScrollConfig struct {
 	// Transaction fee vault address [optional]
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
 
-	// Enable EIP-2718 in tx pool.
+	// Enable EIP-2718 in tx pool [optional]
 	EnableEIP2718 bool `json:"enableEIP2718,omitempty"`
 
-	// Enable EIP-1559 in tx pool, EnableEIP2718 should be true too.
+	// Enable EIP-1559 in tx pool, EnableEIP2718 should be true too [optional]
 	EnableEIP1559 bool `json:"enableEIP1559,omitempty"`
 }
 
-func (s *ScrollConfig) BaseFeeEnabled() bool {
-	if s == nil {
-		return false
-	}
-
+func (s ScrollConfig) BaseFeeEnabled() bool {
 	return s.EnableEIP2718 && s.EnableEIP1559
 }
 
-func (s *ScrollConfig) L1FeeEnabled() bool {
-	if s == nil {
-		return false
-	}
-
+func (s ScrollConfig) L1FeeEnabled() bool {
 	return s.FeeVaultAddress != nil
 }
 
-func (s *ScrollConfig) ZktrieEnabled() bool {
-	if s == nil {
-		return false
-	}
-
+func (s ScrollConfig) ZktrieEnabled() bool {
 	return s.UseZktrie
 }
 
 // IsValidTxCount returns whether the given block's transaction count is below the limit.
-func (s *ScrollConfig) IsValidTxCount(count int) bool {
-	if s == nil || s.MaxTxPerBlock == nil {
-		return true
-	}
-
-	return count <= *s.MaxTxPerBlock
+func (s ScrollConfig) IsValidTxCount(count int) bool {
+	return s.MaxTxPerBlock == nil || count <= *s.MaxTxPerBlock
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 3       // Major version component of the current release
 	VersionMinor = 1       // Minor version component of the current release
-	VersionPatch = 2       // Patch version component of the current release
+	VersionPatch = 3       // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
baseFee & EIP-2718 & EIP-1559 related PRs:

+ https://github.com/scroll-tech/go-ethereum/pull/206
+ https://github.com/scroll-tech/go-ethereum/pull/211
+ https://github.com/scroll-tech/go-ethereum/pull/222

---

we can also move `FeeVaultAddress` into `rollup/rcfg/config.go`, but that's a bigger refactor so can be left for future
