### PR TITLE
Rename nonce to queueindex, increment sender nonce on L1 message execution

### DIFF
--- a/core/rawdb/accessors_l1_message.go
+++ b/core/rawdb/accessors_l1_message.go
@@ -46,7 +46,7 @@ func WriteL1Message(db ethdb.KeyValueWriter, l1Msg types.L1MessageTx) {
 	if err != nil {
 		log.Crit("Failed to RLP encode L1 message", "err", err)
 	}
-	enqueueIndex := l1Msg.Nonce
+	enqueueIndex := l1Msg.QueueIndex
 	if err := db.Put(L1MessageKey(enqueueIndex), bytes); err != nil {
 		log.Crit("Failed to store L1 message", "err", err)
 	}

--- a/core/rawdb/accessors_l1_message_test.go
+++ b/core/rawdb/accessors_l1_message_test.go
@@ -30,12 +30,12 @@ func TestReadWriteSyncedL1BlockNumber(t *testing.T) {
 
 func newL1MessageTx(enqueueIndex uint64) types.L1MessageTx {
 	return types.L1MessageTx{
-		Nonce:  enqueueIndex,
-		Gas:    0,
-		To:     &common.Address{},
-		Value:  big.NewInt(0),
-		Data:   nil,
-		Sender: common.Address{},
+		QueueIndex: enqueueIndex,
+		Gas:        0,
+		To:         &common.Address{},
+		Value:      big.NewInt(0),
+		Data:       nil,
+		Sender:     common.Address{},
 	}
 }
 
@@ -45,7 +45,7 @@ func TestReadWriteL1Message(t *testing.T) {
 	db := NewMemoryDatabase()
 	WriteL1Messages(db, []types.L1MessageTx{msg})
 	got := ReadL1Message(db, enqueueIndex)
-	if got == nil || got.Nonce != enqueueIndex {
+	if got == nil || got.QueueIndex != enqueueIndex {
 		t.Fatal("L1 message mismatch", "expected", enqueueIndex, "got", got)
 	}
 }
@@ -72,8 +72,8 @@ func TestIterateL1Message(t *testing.T) {
 		}
 
 		got := it.L1Message()
-		if got.Nonce != msgs[ii].Nonce {
-			t.Fatal("Invalid result", "expected", msgs[ii].Nonce, "got", got.Nonce)
+		if got.QueueIndex != msgs[ii].QueueIndex {
+			t.Fatal("Invalid result", "expected", msgs[ii].QueueIndex, "got", got.QueueIndex)
 		}
 	}
 
@@ -101,7 +101,7 @@ func TestReadL1MessageTxRange(t *testing.T) {
 		t.Fatal("Invalid length", "expected", 3, "got", len(got))
 	}
 
-	if got[0].Nonce != 101 || got[1].Nonce != 103 || got[2].Nonce != 200 {
+	if got[0].QueueIndex != 101 || got[1].QueueIndex != 103 || got[2].QueueIndex != 200 {
 		t.Fatal("Invalid result", "got", got)
 	}
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -358,11 +358,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if contractCreation {
 		ret, _, st.gas, vmerr = st.evm.Create(sender, st.data, st.gas, st.value)
 	} else {
-		// dont increment nonce for l1 messages
-		if !st.msg.IsL1MessageTx() {
-			// Increment the nonce for the next transaction
-			st.state.SetNonce(msg.From(), st.state.GetNonce(sender.Address())+1)
-		}
+		// Increment the nonce for the next transaction
+		st.state.SetNonce(msg.From(), st.state.GetNonce(sender.Address())+1)
 		ret, st.gas, vmerr = st.evm.Call(sender, st.to(), st.data, st.gas, st.value)
 	}
 

--- a/core/types/l1_message_tx.go
+++ b/core/types/l1_message_tx.go
@@ -10,23 +10,23 @@ const L1MessageTxType = 0x7E
 
 // payload, RLP encoded
 type L1MessageTx struct {
-	Nonce  uint64
-	Gas    uint64          // gas limit
-	To     *common.Address // can not be nil, we do not allow contract creation from L1
-	Value  *big.Int
-	Data   []byte
-	Sender common.Address
+	QueueIndex uint64
+	Gas        uint64          // gas limit
+	To         *common.Address // can not be nil, we do not allow contract creation from L1
+	Value      *big.Int
+	Data       []byte
+	Sender     common.Address
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *L1MessageTx) copy() TxData {
 	cpy := &L1MessageTx{
-		Nonce:  tx.Nonce,
-		Gas:    tx.Gas,
-		To:     copyAddressPtr(tx.To),
-		Value:  new(big.Int),
-		Data:   common.CopyBytes(tx.Data),
-		Sender: tx.Sender,
+		QueueIndex: tx.QueueIndex,
+		Gas:        tx.Gas,
+		To:         copyAddressPtr(tx.To),
+		Value:      new(big.Int),
+		Data:       common.CopyBytes(tx.Data),
+		Sender:     tx.Sender,
 	}
 	if tx.Value != nil {
 		cpy.Value.Set(tx.Value)
@@ -44,7 +44,8 @@ func (tx *L1MessageTx) gasFeeCap() *big.Int    { return new(big.Int) }
 func (tx *L1MessageTx) gasTipCap() *big.Int    { return new(big.Int) }
 func (tx *L1MessageTx) gasPrice() *big.Int     { return new(big.Int) }
 func (tx *L1MessageTx) value() *big.Int        { return tx.Value }
-func (tx *L1MessageTx) nonce() uint64          { return tx.Nonce }
+func (tx *L1MessageTx) nonce() uint64          { return 0 }
+func (tx *L1MessageTx) queueIndex() uint64     { return tx.QueueIndex }
 func (tx *L1MessageTx) to() *common.Address    { return tx.To }
 
 func (tx *L1MessageTx) rawSignatureValues() (v, r, s *big.Int) {

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -49,7 +49,8 @@ type txJSON struct {
 	// Only used for encoding:
 	Hash common.Hash `json:"hash"`
 
-	Sender common.Address `json:"sender,omitempty"`
+	Sender     common.Address  `json:"sender,omitempty"`
+	QueueIndex *hexutil.Uint64 `json:"queueIndex,omitempty"`
 }
 
 // MarshalJSON marshals as JSON with a hash.
@@ -97,7 +98,7 @@ func (t *Transaction) MarshalJSON() ([]byte, error) {
 		enc.R = (*hexutil.Big)(tx.R)
 		enc.S = (*hexutil.Big)(tx.S)
 	case *L1MessageTx:
-		enc.Nonce = (*hexutil.Uint64)(&tx.Nonce)
+		enc.QueueIndex = (*hexutil.Uint64)(&tx.QueueIndex)
 		enc.Gas = (*hexutil.Uint64)(&tx.Gas)
 		enc.To = t.To()
 		enc.Value = (*hexutil.Big)(tx.Value)
@@ -277,7 +278,7 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.Nonce == nil {
 			return errors.New("missing required field 'nonce' in transaction")
 		}
-		itx.Nonce = uint64(*dec.Nonce)
+		itx.QueueIndex = uint64(*dec.QueueIndex)
 		if dec.Gas == nil {
 			return errors.New("missing required field 'gas' in transaction")
 		}

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -275,8 +275,8 @@ func (t *Transaction) UnmarshalJSON(input []byte) error {
 	case L1MessageTxType:
 		var itx L1MessageTx
 		inner = &itx
-		if dec.Nonce == nil {
-			return errors.New("missing required field 'nonce' in transaction")
+		if dec.QueueIndex == nil {
+			return errors.New("missing required field 'queueIndex' in transaction")
 		}
 		itx.QueueIndex = uint64(*dec.QueueIndex)
 		if dec.Gas == nil {

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -472,12 +472,12 @@ func TestTransactionCoding(t *testing.T) {
 			// L1MessageTx
 			isL1MessageTx = true
 			txdata = &L1MessageTx{
-				Nonce:  i,
-				Gas:    123457,
-				To:     &recipient,
-				Value:  big.NewInt(10),
-				Data:   []byte("abcdef"),
-				Sender: addr,
+				QueueIndex: i,
+				Gas:        123457,
+				To:         &recipient,
+				Value:      big.NewInt(10),
+				Data:       []byte("abcdef"),
+				Sender:     addr,
 			}
 		}
 		var tx *Transaction
@@ -513,20 +513,20 @@ func TestBridgeTxHash(t *testing.T) {
 	to := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 	tx := NewTx(
 		&L1MessageTx{
-			Sender: sender,
-			Nonce:  1,
-			Value:  big.NewInt(2),
-			Gas:    3,
-			To:     &to,
-			Data:   []byte{1, 2, 3, 4},
+			Sender:     sender,
+			QueueIndex: 1,
+			Value:      big.NewInt(2),
+			Gas:        3,
+			To:         &to,
+			Data:       []byte{1, 2, 3, 4},
 		},
 	)
 	// assert equal
 	if tx.Hash() != common.HexToHash("0x1cebed6d90ef618f60eec1b7edc0df36b298a237c219f0950081acfb72eac6be") {
 		t.Errorf("hash does not match bridge contract")
 	}
-
 }
+
 func encodeDecodeJSON(tx *Transaction) (*Transaction, error) {
 	data, err := json.Marshal(tx)
 	if err != nil {


### PR DESCRIPTION
increment the sender's nonce for every l1 message that gets executed, l1 messenger's account nonce should be equal to the number of bridged messages

add field `queueIndex` to reflect queueIndex from l1 queue contract. nonce just returns 0 now 