### PR TITLE
Fix db inspect command

### DIFF
--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -323,6 +323,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		preimages       stat
 		bloomBits       stat
 		cliqueSnaps     stat
+		l1Messages      stat
+		lastL1Message   stat
 
 		// Ancient store statistics
 		ancientHeadersSize  common.StorageSize
@@ -382,6 +384,10 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			bloomBits.Add(size)
 		case bytes.HasPrefix(key, []byte("clique-")) && len(key) == 7+common.HashLength:
 			cliqueSnaps.Add(size)
+		case bytes.HasPrefix(key, L1MessagePrefix) && len(key) == len(L1MessagePrefix)+8:
+			l1Messages.Add(size)
+		case bytes.HasPrefix(key, LastL1MessageInL2BlockPrefix) && len(key) == len(LastL1MessageInL2BlockPrefix)+common.HashLength:
+			lastL1Message.Add(size)
 		case bytes.HasPrefix(key, []byte("cht-")) ||
 			bytes.HasPrefix(key, []byte("chtIndexV2-")) ||
 			bytes.HasPrefix(key, []byte("chtRootV2-")): // Canonical hash trie
@@ -396,7 +402,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 				databaseVersionKey, headHeaderKey, headBlockKey, headFastBlockKey, lastPivotKey,
 				fastTrieProgressKey, snapshotDisabledKey, SnapshotRootKey, snapshotJournalKey,
 				snapshotGeneratorKey, snapshotRecoveryKey, txIndexTailKey, fastTxLookupLimitKey,
-				uncleanShutdownKey, badBlockKey,
+				uncleanShutdownKey, badBlockKey, syncedL1BlockNumberKey,
 			} {
 				if bytes.Equal(key, meta) {
 					metadata.Add(size)
@@ -444,6 +450,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Storage snapshot", storageSnaps.Size(), storageSnaps.Count()},
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
+		{"Key-Value store", "L1 messages", l1Messages.Size(), l1Messages.Count()},
+		{"Key-Value store", "Last L1 message", lastL1Message.Size(), lastL1Message.Count()},
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},
 		{"Ancient store", "Receipt lists", ancientReceiptsSize.String(), ancients.String()},


### PR DESCRIPTION
Note, there's still a small mismatch due to [this](https://github.com/scroll-tech/zktrie/blob/6bd8534a4707f50090d88f373ab71ced4e8ad2fa/trie/zk_trie_impl.go#L44) entry.

```
$ l2geth --datadir "./l2geth-datadir" db inspect                                                                                          
INFO [04-15|18:48:33.499] Maximum peer count                       ETH=50 LES=0 total=50
INFO [04-15|18:48:33.500] Set global gas cap                       cap=50,000,000
INFO [04-15|18:48:33.500] Allocated cache and file handles         database=/Users/peter/work/scroll/run-node-test/l2geth-datadir/geth/chaindata cache=512.00MiB handles=5120 readonly=true
INFO [04-15|18:48:33.504] Opened ancient database                  database=/Users/peter/work/scroll/run-node-test/l2geth-datadir/geth/chaindata/ancient readonly=true
+-----------------+--------------------+-----------+-------+
|    DATABASE     |      CATEGORY      |   SIZE    | ITEMS |
+-----------------+--------------------+-----------+-------+
| Key-Value store | Headers            | 702.00 B  |     1 |
| Key-Value store | Bodies             | 44.00 B   |     1 |
| Key-Value store | Receipt lists      | 42.00 B   |     1 |
| Key-Value store | Difficulties       | 43.00 B   |     1 |
| Key-Value store | Block number->hash | 42.00 B   |     1 |
| Key-Value store | Block hash->number | 41.00 B   |     1 |
| Key-Value store | Transaction index  | 0.00 B    |     0 |
| Key-Value store | Bloombit index     | 0.00 B    |     0 |
| Key-Value store | Contract codes     | 12.05 KiB |     6 |
| Key-Value store | Trie nodes         | 5.14 KiB  |    43 |
| Key-Value store | Trie preimages     | 0.00 B    |     0 |
| Key-Value store | Account snapshot   | 0.00 B    |     0 |
| Key-Value store | Storage snapshot   | 0.00 B    |     0 |
| Key-Value store | Clique snapshots   | 320.00 B  |     1 |
| Key-Value store | Singleton metadata | 637.00 B  |     6 |
| Ancient store   | Headers            | 6.00 B    |     0 |
| Ancient store   | Bodies             | 6.00 B    |     0 |
| Ancient store   | Receipt lists      | 6.00 B    |     0 |
| Ancient store   | Difficulties       | 6.00 B    |     0 |
| Ancient store   | Block number->hash | 6.00 B    |     0 |
| Light client    | CHT trie nodes     | 0.00 B    |     0 |
| Light client    | Bloom trie nodes   | 0.00 B    |     0 |
+-----------------+--------------------+-----------+-------+
|                         TOTAL        | 19.09 KIB |       |
+-----------------+--------------------+-----------+-------+
ERROR[04-15|18:48:33.505] Database contains unaccounted data       size=44.00B count=1
```