### PR TITLE
Archimedes hard fork: Disable sha2, ripemd, blake2f precompiles

### DIFF
--- a/cmd/puppeth/genesis.go
+++ b/cmd/puppeth/genesis.go
@@ -158,7 +158,7 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 	for address, account := range genesis.Alloc {
 		spec.setAccount(address, account)
 	}
-/*
+
 	spec.setPrecompile(1, &alethGenesisSpecBuiltin{Name: "ecrecover",
 		Linear: &alethGenesisSpecLinearPricing{Base: 3000}})
 	spec.setPrecompile(2, &alethGenesisSpecBuiltin{Name: "sha256",
@@ -196,7 +196,7 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 			StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
 		})
 	}
-	*/
+	
 	return spec, nil
 }
 

--- a/cmd/puppeth/genesis.go
+++ b/cmd/puppeth/genesis.go
@@ -46,6 +46,7 @@ type alethGenesisSpec struct {
 		ConstantinopleForkBlock    *hexutil.Big           `json:"constantinopleForkBlock,omitempty"`
 		ConstantinopleFixForkBlock *hexutil.Big           `json:"constantinopleFixForkBlock,omitempty"`
 		IstanbulForkBlock          *hexutil.Big           `json:"istanbulForkBlock,omitempty"`
+		PlaceholderForkBlock       *hexutil.Big           `json:"placeholderForkBlock,omitempty"`
 		MinGasLimit                hexutil.Uint64         `json:"minGasLimit"`
 		MaxGasLimit                hexutil.Uint64         `json:"maxGasLimit"`
 		TieBreakingGas             bool                   `json:"tieBreakingGas"`
@@ -135,6 +136,9 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 	if num := genesis.Config.IstanbulBlock; num != nil {
 		spec.Params.IstanbulForkBlock = (*hexutil.Big)(num)
 	}
+	if num := genesis.Config.PlaceholderBlock; num != nil {
+		spec.Params.PlaceholderForkBlock = (*hexutil.Big)(num)
+	}
 	spec.Params.NetworkID = (hexutil.Uint64)(genesis.Config.ChainID.Uint64())
 	spec.Params.ChainID = (hexutil.Uint64)(genesis.Config.ChainID.Uint64())
 	spec.Params.MaximumExtraDataSize = (hexutil.Uint64)(params.MaximumExtraDataSize)
@@ -161,41 +165,41 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 
 	spec.setPrecompile(1, &alethGenesisSpecBuiltin{Name: "ecrecover",
 		Linear: &alethGenesisSpecLinearPricing{Base: 3000}})
-	// spec.setPrecompile(2, &alethGenesisSpecBuiltin{Name: "sha256",
-	// 	Linear: &alethGenesisSpecLinearPricing{Base: 60, Word: 12}})
-	// spec.setPrecompile(3, &alethGenesisSpecBuiltin{Name: "ripemd160",
-	// 	Linear: &alethGenesisSpecLinearPricing{Base: 600, Word: 120}})
+	spec.setPrecompile(2, &alethGenesisSpecBuiltin{Name: "sha256",
+		Linear: &alethGenesisSpecLinearPricing{Base: 60, Word: 12}})
+	spec.setPrecompile(3, &alethGenesisSpecBuiltin{Name: "ripemd160",
+		Linear: &alethGenesisSpecLinearPricing{Base: 600, Word: 120}})
 	spec.setPrecompile(4, &alethGenesisSpecBuiltin{Name: "identity",
 		Linear: &alethGenesisSpecLinearPricing{Base: 15, Word: 3}})
-	// if genesis.Config.ByzantiumBlock != nil {
-	// 	spec.setPrecompile(5, &alethGenesisSpecBuiltin{Name: "modexp",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
-	// 	spec.setPrecompile(6, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_add",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-	// 		Linear:        &alethGenesisSpecLinearPricing{Base: 500}})
-	// 	spec.setPrecompile(7, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_mul",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-	// 		Linear:        &alethGenesisSpecLinearPricing{Base: 40000}})
-	// 	spec.setPrecompile(8, &alethGenesisSpecBuiltin{Name: "alt_bn128_pairing_product",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
-	// }
-	// if genesis.Config.IstanbulBlock != nil {
-	// 	if genesis.Config.ByzantiumBlock == nil {
-	// 		return nil, errors.New("invalid genesis, istanbul fork is enabled while byzantium is not")
-	// 	}
-	// 	spec.setPrecompile(6, &alethGenesisSpecBuiltin{
-	// 		Name:          "alt_bn128_G1_add",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-	// 	}) // Aleth hardcoded the gas policy
-	// 	spec.setPrecompile(7, &alethGenesisSpecBuiltin{
-	// 		Name:          "alt_bn128_G1_mul",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-	// 	}) // Aleth hardcoded the gas policy
-	// 	spec.setPrecompile(9, &alethGenesisSpecBuiltin{
-	// 		Name:          "blake2_compression",
-	// 		StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
-	// 	})
-	// }
+	if genesis.Config.ByzantiumBlock != nil {
+		spec.setPrecompile(5, &alethGenesisSpecBuiltin{Name: "modexp",
+			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
+		spec.setPrecompile(6, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_add",
+			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+			Linear:        &alethGenesisSpecLinearPricing{Base: 500}})
+		spec.setPrecompile(7, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_mul",
+			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+			Linear:        &alethGenesisSpecLinearPricing{Base: 40000}})
+		spec.setPrecompile(8, &alethGenesisSpecBuiltin{Name: "alt_bn128_pairing_product",
+			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
+	}
+	if genesis.Config.IstanbulBlock != nil {
+		if genesis.Config.ByzantiumBlock == nil {
+			return nil, errors.New("invalid genesis, istanbul fork is enabled while byzantium is not")
+		}
+		spec.setPrecompile(6, &alethGenesisSpecBuiltin{
+			Name:          "alt_bn128_G1_add",
+			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+		}) // Aleth hardcoded the gas policy
+		spec.setPrecompile(7, &alethGenesisSpecBuiltin{
+			Name:          "alt_bn128_G1_mul",
+			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+		}) // Aleth hardcoded the gas policy
+		spec.setPrecompile(9, &alethGenesisSpecBuiltin{
+			Name:          "blake2_compression",
+			StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
+		})
+	}
 	return spec, nil
 }
 

--- a/cmd/puppeth/genesis.go
+++ b/cmd/puppeth/genesis.go
@@ -196,7 +196,6 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 			StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
 		})
 	}
-	
 	return spec, nil
 }
 

--- a/cmd/puppeth/genesis.go
+++ b/cmd/puppeth/genesis.go
@@ -46,7 +46,6 @@ type alethGenesisSpec struct {
 		ConstantinopleForkBlock    *hexutil.Big           `json:"constantinopleForkBlock,omitempty"`
 		ConstantinopleFixForkBlock *hexutil.Big           `json:"constantinopleFixForkBlock,omitempty"`
 		IstanbulForkBlock          *hexutil.Big           `json:"istanbulForkBlock,omitempty"`
-		PlaceholderForkBlock       *hexutil.Big           `json:"placeholderForkBlock,omitempty"`
 		MinGasLimit                hexutil.Uint64         `json:"minGasLimit"`
 		MaxGasLimit                hexutil.Uint64         `json:"maxGasLimit"`
 		TieBreakingGas             bool                   `json:"tieBreakingGas"`
@@ -136,9 +135,6 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 	if num := genesis.Config.IstanbulBlock; num != nil {
 		spec.Params.IstanbulForkBlock = (*hexutil.Big)(num)
 	}
-	if num := genesis.Config.PlaceholderBlock; num != nil {
-		spec.Params.PlaceholderForkBlock = (*hexutil.Big)(num)
-	}
 	spec.Params.NetworkID = (hexutil.Uint64)(genesis.Config.ChainID.Uint64())
 	spec.Params.ChainID = (hexutil.Uint64)(genesis.Config.ChainID.Uint64())
 	spec.Params.MaximumExtraDataSize = (hexutil.Uint64)(params.MaximumExtraDataSize)
@@ -162,7 +158,7 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 	for address, account := range genesis.Alloc {
 		spec.setAccount(address, account)
 	}
-
+/*
 	spec.setPrecompile(1, &alethGenesisSpecBuiltin{Name: "ecrecover",
 		Linear: &alethGenesisSpecLinearPricing{Base: 3000}})
 	spec.setPrecompile(2, &alethGenesisSpecBuiltin{Name: "sha256",
@@ -200,6 +196,7 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 			StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
 		})
 	}
+	*/
 	return spec, nil
 }
 

--- a/cmd/puppeth/genesis.go
+++ b/cmd/puppeth/genesis.go
@@ -161,41 +161,41 @@ func newAlethGenesisSpec(network string, genesis *core.Genesis) (*alethGenesisSp
 
 	spec.setPrecompile(1, &alethGenesisSpecBuiltin{Name: "ecrecover",
 		Linear: &alethGenesisSpecLinearPricing{Base: 3000}})
-	spec.setPrecompile(2, &alethGenesisSpecBuiltin{Name: "sha256",
-		Linear: &alethGenesisSpecLinearPricing{Base: 60, Word: 12}})
-	spec.setPrecompile(3, &alethGenesisSpecBuiltin{Name: "ripemd160",
-		Linear: &alethGenesisSpecLinearPricing{Base: 600, Word: 120}})
+	// spec.setPrecompile(2, &alethGenesisSpecBuiltin{Name: "sha256",
+	// 	Linear: &alethGenesisSpecLinearPricing{Base: 60, Word: 12}})
+	// spec.setPrecompile(3, &alethGenesisSpecBuiltin{Name: "ripemd160",
+	// 	Linear: &alethGenesisSpecLinearPricing{Base: 600, Word: 120}})
 	spec.setPrecompile(4, &alethGenesisSpecBuiltin{Name: "identity",
 		Linear: &alethGenesisSpecLinearPricing{Base: 15, Word: 3}})
-	if genesis.Config.ByzantiumBlock != nil {
-		spec.setPrecompile(5, &alethGenesisSpecBuiltin{Name: "modexp",
-			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
-		spec.setPrecompile(6, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_add",
-			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-			Linear:        &alethGenesisSpecLinearPricing{Base: 500}})
-		spec.setPrecompile(7, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_mul",
-			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-			Linear:        &alethGenesisSpecLinearPricing{Base: 40000}})
-		spec.setPrecompile(8, &alethGenesisSpecBuiltin{Name: "alt_bn128_pairing_product",
-			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
-	}
-	if genesis.Config.IstanbulBlock != nil {
-		if genesis.Config.ByzantiumBlock == nil {
-			return nil, errors.New("invalid genesis, istanbul fork is enabled while byzantium is not")
-		}
-		spec.setPrecompile(6, &alethGenesisSpecBuiltin{
-			Name:          "alt_bn128_G1_add",
-			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-		}) // Aleth hardcoded the gas policy
-		spec.setPrecompile(7, &alethGenesisSpecBuiltin{
-			Name:          "alt_bn128_G1_mul",
-			StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
-		}) // Aleth hardcoded the gas policy
-		spec.setPrecompile(9, &alethGenesisSpecBuiltin{
-			Name:          "blake2_compression",
-			StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
-		})
-	}
+	// if genesis.Config.ByzantiumBlock != nil {
+	// 	spec.setPrecompile(5, &alethGenesisSpecBuiltin{Name: "modexp",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
+	// 	spec.setPrecompile(6, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_add",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+	// 		Linear:        &alethGenesisSpecLinearPricing{Base: 500}})
+	// 	spec.setPrecompile(7, &alethGenesisSpecBuiltin{Name: "alt_bn128_G1_mul",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+	// 		Linear:        &alethGenesisSpecLinearPricing{Base: 40000}})
+	// 	spec.setPrecompile(8, &alethGenesisSpecBuiltin{Name: "alt_bn128_pairing_product",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock)})
+	// }
+	// if genesis.Config.IstanbulBlock != nil {
+	// 	if genesis.Config.ByzantiumBlock == nil {
+	// 		return nil, errors.New("invalid genesis, istanbul fork is enabled while byzantium is not")
+	// 	}
+	// 	spec.setPrecompile(6, &alethGenesisSpecBuiltin{
+	// 		Name:          "alt_bn128_G1_add",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+	// 	}) // Aleth hardcoded the gas policy
+	// 	spec.setPrecompile(7, &alethGenesisSpecBuiltin{
+	// 		Name:          "alt_bn128_G1_mul",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.ByzantiumBlock),
+	// 	}) // Aleth hardcoded the gas policy
+	// 	spec.setPrecompile(9, &alethGenesisSpecBuiltin{
+	// 		Name:          "blake2_compression",
+	// 		StartingBlock: (*hexutil.Big)(genesis.Config.IstanbulBlock),
+	// 	})
+	// }
 	return spec, nil
 }
 

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -92,6 +92,8 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 }
 
+// PrecompiledContractsArchimedes contains the default set of pre-compiled Ethereum
+// contracts used in the Archimedes release. Same as Berlin but without sha2, blake2f, ripemd160
 var PrecompiledContractsArchimedes = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &ecrecover{},
 	common.BytesToAddress([]byte{4}): &dataCopy{},

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -92,6 +92,10 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 }
 
+var PrecompiledContractsPlaceholder = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{1}): &ecrecover{},
+}
+
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum
 // contracts specified in EIP-2537. These are exported for testing purposes.
 var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
@@ -107,10 +111,11 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 }
 
 var (
-	PrecompiledAddressesBerlin    []common.Address
-	PrecompiledAddressesIstanbul  []common.Address
-	PrecompiledAddressesByzantium []common.Address
-	PrecompiledAddressesHomestead []common.Address
+	PrecompiledAddressesPlaceholder []common.Address
+	PrecompiledAddressesBerlin      []common.Address
+	PrecompiledAddressesIstanbul    []common.Address
+	PrecompiledAddressesByzantium   []common.Address
+	PrecompiledAddressesHomestead   []common.Address
 )
 
 func init() {
@@ -126,11 +131,16 @@ func init() {
 	for k := range PrecompiledContractsBerlin {
 		PrecompiledAddressesBerlin = append(PrecompiledAddressesBerlin, k)
 	}
+	for k := range PrecompiledContractsPlaceholder {
+		PrecompiledAddressesPlaceholder = append(PrecompiledAddressesPlaceholder, k)
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsPlaceholder:
+		return PrecompiledAddressesPlaceholder
 	case rules.IsBerlin:
 		return PrecompiledAddressesBerlin
 	case rules.IsIstanbul:

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -94,6 +94,7 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 
 var PrecompiledContractsPlaceholder = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &ecrecover{},
+	common.BytesToAddress([]byte{4}): &dataCopy{},
 }
 
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -92,7 +92,7 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2F{},
 }
 
-var PrecompiledContractsPlaceholder = map[common.Address]PrecompiledContract{
+var PrecompiledContractsArchimedes = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &ecrecover{},
 	common.BytesToAddress([]byte{4}): &dataCopy{},
 	common.BytesToAddress([]byte{5}): &bigModExp{eip2565: true},
@@ -116,11 +116,11 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 }
 
 var (
-	PrecompiledAddressesPlaceholder []common.Address
-	PrecompiledAddressesBerlin      []common.Address
-	PrecompiledAddressesIstanbul    []common.Address
-	PrecompiledAddressesByzantium   []common.Address
-	PrecompiledAddressesHomestead   []common.Address
+	PrecompiledAddressesArchimedes []common.Address
+	PrecompiledAddressesBerlin     []common.Address
+	PrecompiledAddressesIstanbul   []common.Address
+	PrecompiledAddressesByzantium  []common.Address
+	PrecompiledAddressesHomestead  []common.Address
 )
 
 func init() {
@@ -136,16 +136,16 @@ func init() {
 	for k := range PrecompiledContractsBerlin {
 		PrecompiledAddressesBerlin = append(PrecompiledAddressesBerlin, k)
 	}
-	for k := range PrecompiledContractsPlaceholder {
-		PrecompiledAddressesPlaceholder = append(PrecompiledAddressesPlaceholder, k)
+	for k := range PrecompiledContractsArchimedes {
+		PrecompiledAddressesArchimedes = append(PrecompiledAddressesArchimedes, k)
 	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
-	case rules.IsPlaceholder:
-		return PrecompiledAddressesPlaceholder
+	case rules.IsArchimedes:
+		return PrecompiledAddressesArchimedes
 	case rules.IsBerlin:
 		return PrecompiledAddressesBerlin
 	case rules.IsIstanbul:

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -95,6 +95,10 @@ var PrecompiledContractsBerlin = map[common.Address]PrecompiledContract{
 var PrecompiledContractsPlaceholder = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{1}): &ecrecover{},
 	common.BytesToAddress([]byte{4}): &dataCopy{},
+	common.BytesToAddress([]byte{5}): &bigModExp{eip2565: true},
+	common.BytesToAddress([]byte{6}): &bn256AddIstanbul{},
+	common.BytesToAddress([]byte{7}): &bn256ScalarMulIstanbul{},
+	common.BytesToAddress([]byte{8}): &bn256PairingIstanbul{},
 }
 
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -46,6 +46,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsPlaceholder:
+		precompiles = PrecompiledContractsPlaceholder
 	case evm.chainRules.IsBerlin:
 		precompiles = PrecompiledContractsBerlin
 	case evm.chainRules.IsIstanbul:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -46,8 +46,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
-	case evm.chainRules.IsPlaceholder:
-		precompiles = PrecompiledContractsPlaceholder
+	case evm.chainRules.IsArchimedes:
+		precompiles = PrecompiledContractsArchimedes
 	case evm.chainRules.IsBerlin:
 		precompiles = PrecompiledContractsBerlin
 	case evm.chainRules.IsIstanbul:

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -68,7 +68,7 @@ func setDefaults(cfg *Config) {
 			MuirGlacierBlock:    new(big.Int),
 			BerlinBlock:         new(big.Int),
 			LondonBlock:         new(big.Int),
-			PlaceholderBlock:    new(big.Int),
+			ArchimedesBlock:     new(big.Int),
 		}
 	}
 

--- a/core/vm/runtime/runtime.go
+++ b/core/vm/runtime/runtime.go
@@ -68,6 +68,7 @@ func setDefaults(cfg *Config) {
 			MuirGlacierBlock:    new(big.Int),
 			BerlinBlock:         new(big.Int),
 			LondonBlock:         new(big.Int),
+			PlaceholderBlock:    new(big.Int),
 		}
 	}
 

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -201,7 +201,7 @@ func TestIsPrecompile(t *testing.T) {
 	chaincfg.ByzantiumBlock = big.NewInt(100)
 	chaincfg.IstanbulBlock = big.NewInt(200)
 	chaincfg.BerlinBlock = big.NewInt(300)
-	chaincfg.PlaceholderBlock = big.NewInt(400)
+	chaincfg.ArchimedesBlock = big.NewInt(400)
 	txCtx := vm.TxContext{GasPrice: big.NewInt(100000)}
 	tracer, err := newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
 	if err != nil {
@@ -227,7 +227,7 @@ func TestIsPrecompile(t *testing.T) {
 		t.Errorf("Tracer should consider blake2f as precompile in istanbul")
 	}
 
-	// placeholder fork should only have identity and ecrecover and no other precompiles
+	// archimedes fork should disable sha2, ripemd, blake2f precompiles
 	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
 	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
 	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -227,15 +227,25 @@ func TestIsPrecompile(t *testing.T) {
 		t.Errorf("Tracer should consider blake2f as precompile in istanbul")
 	}
 
-	// test blake2f disabled in archimedes
-	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
+	// test sha disabled in archimedes
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000002'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
 	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
 	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
 	if err != nil {
 		t.Error(err)
 	}
 	if string(res) != "false" {
-		t.Errorf("Tracer should not consider blake2f as precompile in scroll alpha")
+		t.Errorf("Tracer should not consider blake2f as precompile in archimedes")
+	}
+
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000003'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
+	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
+	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(res) != "false" {
+		t.Errorf("Tracer should not consider ripemd as precompile in archimedes")
 	}
 
 	// test blake2f disabled in archimedes
@@ -245,7 +255,7 @@ func TestIsPrecompile(t *testing.T) {
 		t.Error(err)
 	}
 	if string(res) != "false" {
-		t.Errorf("Tracer should not consider blake2f as precompile in scroll alpha")
+		t.Errorf("Tracer should not consider blake2f as precompile in archimedes")
 	}
 
 	// test ecrecover enabled in archimedes
@@ -255,7 +265,7 @@ func TestIsPrecompile(t *testing.T) {
 		t.Error(err)
 	}
 	if string(res) != "true" {
-		t.Errorf("Tracer should keep ecrecover as precompile in scroll alpha")
+		t.Errorf("Tracer should keep ecrecover as precompile in archimedes")
 	}
 }
 

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -227,7 +227,7 @@ func TestIsPrecompile(t *testing.T) {
 		t.Errorf("Tracer should consider blake2f as precompile in istanbul")
 	}
 
-	// archimedes fork should disable sha2, ripemd, blake2f precompiles
+	// test blake2f disabled in archimedes
 	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
 	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
 	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
@@ -235,27 +235,27 @@ func TestIsPrecompile(t *testing.T) {
 		t.Error(err)
 	}
 	if string(res) != "false" {
-		t.Errorf("Tracer should not consider blake2f as precompile in istanbul")
+		t.Errorf("Tracer should not consider blake2f as precompile in scroll alpha")
 	}
 
+	// test blake2f disabled in archimedes
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
+	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(res) != "false" {
+		t.Errorf("Tracer should not consider blake2f as precompile in scroll alpha")
+	}
+
+	// test ecrecover enabled in archimedes
 	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000001'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
-	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
 	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
 	if err != nil {
 		t.Error(err)
 	}
 	if string(res) != "true" {
 		t.Errorf("Tracer should keep ecrecover as precompile in scroll alpha")
-	}
-
-	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000004'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
-	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
-	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
-	if err != nil {
-		t.Error(err)
-	}
-	if string(res) != "true" {
-		t.Errorf("Tracer should keep identity as precompile in scroll alpha")
 	}
 }
 

--- a/eth/tracers/js/tracer_test.go
+++ b/eth/tracers/js/tracer_test.go
@@ -201,6 +201,7 @@ func TestIsPrecompile(t *testing.T) {
 	chaincfg.ByzantiumBlock = big.NewInt(100)
 	chaincfg.IstanbulBlock = big.NewInt(200)
 	chaincfg.BerlinBlock = big.NewInt(300)
+	chaincfg.PlaceholderBlock = big.NewInt(400)
 	txCtx := vm.TxContext{GasPrice: big.NewInt(100000)}
 	tracer, err := newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
 	if err != nil {
@@ -224,6 +225,37 @@ func TestIsPrecompile(t *testing.T) {
 	}
 	if string(res) != "true" {
 		t.Errorf("Tracer should consider blake2f as precompile in istanbul")
+	}
+
+	// placeholder fork should only have identity and ecrecover and no other precompiles
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000009'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
+	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
+	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(res) != "false" {
+		t.Errorf("Tracer should not consider blake2f as precompile in istanbul")
+	}
+
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000001'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
+	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
+	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(res) != "true" {
+		t.Errorf("Tracer should keep ecrecover as precompile in scroll alpha")
+	}
+
+	tracer, _ = newJsTracer("{addr: toAddress('0000000000000000000000000000000000000004'), res: null, step: function() { this.res = isPrecompiled(this.addr); }, fault: function() {}, result: function() { return this.res; }}", nil)
+	blockCtx = vm.BlockContext{BlockNumber: big.NewInt(450)}
+	res, err = runTrace(tracer, &vmContext{blockCtx, txCtx}, chaincfg)
+	if err != nil {
+		t.Error(err)
+	}
+	if string(res) != "true" {
+		t.Errorf("Tracer should keep identity as precompile in scroll alpha")
 	}
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -275,7 +275,7 @@ var (
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   nil,
-		ArchimedesBlock:     big.NewInt(0),
+		ArchimedesBlock:     nil,
 		Clique: &CliqueConfig{
 			Period: 3,
 			Epoch:  30000,

--- a/params/config.go
+++ b/params/config.go
@@ -275,6 +275,7 @@ var (
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   nil,
+		ArchimedesBlock:     big.NewInt(0),
 		Clique: &CliqueConfig{
 			Period: 3,
 			Epoch:  30000,

--- a/params/config.go
+++ b/params/config.go
@@ -411,7 +411,7 @@ type ChainConfig struct {
 	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
-	PlaceholderBlock    *big.Int `json:"placeholderBlock,omitempty"`    // Placeholder switch block (nil = no fork, 0 = already on placeholder)
+	ArchimedesBlock     *big.Int `json:"ArchimedesBlock,omitempty"`     // Archimedes switch block (nil = no fork, 0 = already on archimedes)
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
 	TerminalTotalDifficulty *big.Int `json:"terminalTotalDifficulty,omitempty"`
@@ -498,7 +498,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Placeholder: %v,Engine: %v, Scroll config: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Archimedes: %v,Engine: %v, Scroll config: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -514,7 +514,7 @@ func (c *ChainConfig) String() string {
 		c.BerlinBlock,
 		c.LondonBlock,
 		c.ArrowGlacierBlock,
-		c.PlaceholderBlock,
+		c.ArchimedesBlock,
 		engine,
 		c.Scroll,
 	)
@@ -587,8 +587,8 @@ func (c *ChainConfig) IsArrowGlacier(num *big.Int) bool {
 	return isForked(c.ArrowGlacierBlock, num)
 }
 
-func (c *ChainConfig) IsPlaceholder(num *big.Int) bool {
-	return isForked(c.PlaceholderBlock, num)
+func (c *ChainConfig) IsArchimedes(num *big.Int) bool {
+	return isForked(c.ArchimedesBlock, num)
 }
 
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.
@@ -640,7 +640,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "berlinBlock", block: c.BerlinBlock},
 		{name: "londonBlock", block: c.LondonBlock},
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
-		{name: "placeholderBlock", block: c.PlaceholderBlock, optional: true},
+		{name: "ArchimedesBlock", block: c.ArchimedesBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -713,8 +713,8 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	if isForkIncompatible(c.ArrowGlacierBlock, newcfg.ArrowGlacierBlock, head) {
 		return newCompatError("Arrow Glacier fork block", c.ArrowGlacierBlock, newcfg.ArrowGlacierBlock)
 	}
-	if isForkIncompatible(c.PlaceholderBlock, newcfg.PlaceholderBlock, head) {
-		return newCompatError("Placeholder fork block", c.PlaceholderBlock, newcfg.PlaceholderBlock)
+	if isForkIncompatible(c.ArchimedesBlock, newcfg.ArchimedesBlock, head) {
+		return newCompatError("Archimedes fork block", c.ArchimedesBlock, newcfg.ArchimedesBlock)
 	}
 	return nil
 }
@@ -783,7 +783,7 @@ type Rules struct {
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	IsBerlin, IsLondon, IsPlaceholder                       bool
+	IsBerlin, IsLondon, IsArchimedes                        bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -804,6 +804,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsIstanbul:       c.IsIstanbul(num),
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
-		IsPlaceholder:    c.IsPlaceholder(num),
+		IsArchimedes:     c.IsArchimedes(num),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -498,7 +498,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Engine: %v, Scroll config: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Berlin: %v, London: %v, Arrow Glacier: %v, Placeholder: %v,Engine: %v, Scroll config: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -514,6 +514,7 @@ func (c *ChainConfig) String() string {
 		c.BerlinBlock,
 		c.LondonBlock,
 		c.ArrowGlacierBlock,
+		c.PlaceholderBlock,
 		engine,
 		c.Scroll,
 	)
@@ -639,6 +640,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "berlinBlock", block: c.BerlinBlock},
 		{name: "londonBlock", block: c.LondonBlock},
 		{name: "arrowGlacierBlock", block: c.ArrowGlacierBlock, optional: true},
+		{name: "placeholderBlock", block: c.PlaceholderBlock, optional: true},
 	} {
 		if lastFork.name != "" {
 			// Next one must be higher number
@@ -710,6 +712,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.ArrowGlacierBlock, newcfg.ArrowGlacierBlock, head) {
 		return newCompatError("Arrow Glacier fork block", c.ArrowGlacierBlock, newcfg.ArrowGlacierBlock)
+	}
+	if isForkIncompatible(c.PlaceholderBlock, newcfg.PlaceholderBlock, head) {
+		return newCompatError("Placeholder fork block", c.PlaceholderBlock, newcfg.PlaceholderBlock)
 	}
 	return nil
 }

--- a/params/config.go
+++ b/params/config.go
@@ -292,7 +292,7 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
 		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: nil,
@@ -306,7 +306,7 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000},
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000},
 		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: nil,
@@ -315,7 +315,7 @@ var (
 			MaxTxPerBlock:   nil,
 		}}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
 		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: &common.Address{123},
@@ -325,7 +325,7 @@ var (
 		}}
 	TestRules = TestChainConfig.Rules(new(big.Int))
 
-	TestNoL1feeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
+	TestNoL1feeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
 		ScrollConfig{
 			UseZktrie:       false,
 			FeeVaultAddress: nil,
@@ -411,7 +411,7 @@ type ChainConfig struct {
 	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
 	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
 	ArrowGlacierBlock   *big.Int `json:"arrowGlacierBlock,omitempty"`   // Eip-4345 (bomb delay) switch block (nil = no fork, 0 = already activated)
-
+	PlaceholderBlock    *big.Int `json:"placeholderBlock,omitempty"`    // Placeholder switch block (nil = no fork, 0 = already on placeholder)
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
 	TerminalTotalDifficulty *big.Int `json:"terminalTotalDifficulty,omitempty"`
@@ -584,6 +584,10 @@ func (c *ChainConfig) IsLondon(num *big.Int) bool {
 // IsArrowGlacier returns whether num is either equal to the Arrow Glacier (EIP-4345) fork block or greater.
 func (c *ChainConfig) IsArrowGlacier(num *big.Int) bool {
 	return isForked(c.ArrowGlacierBlock, num)
+}
+
+func (c *ChainConfig) IsPlaceholder(num *big.Int) bool {
+	return isForked(c.PlaceholderBlock, num)
 }
 
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.
@@ -774,7 +778,7 @@ type Rules struct {
 	ChainID                                                 *big.Int
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
-	IsBerlin, IsLondon                                      bool
+	IsBerlin, IsLondon, IsPlaceholder                       bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -795,5 +799,6 @@ func (c *ChainConfig) Rules(num *big.Int) Rules {
 		IsIstanbul:       c.IsIstanbul(num),
 		IsBerlin:         c.IsBerlin(num),
 		IsLondon:         c.IsLondon(num),
+		IsPlaceholder:    c.IsPlaceholder(num),
 	}
 }

--- a/tests/init.go
+++ b/tests/init.go
@@ -197,6 +197,22 @@ var Forks = map[string]*params.ChainConfig{
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
 	},
+	"Placeholder": {
+		ChainID:             big.NewInt(1),
+		HomesteadBlock:      big.NewInt(0),
+		EIP150Block:         big.NewInt(0),
+		EIP155Block:         big.NewInt(0),
+		EIP158Block:         big.NewInt(0),
+		ByzantiumBlock:      big.NewInt(0),
+		ConstantinopleBlock: big.NewInt(0),
+		PetersburgBlock:     big.NewInt(0),
+		IstanbulBlock:       big.NewInt(0),
+		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ArrowGlacierBlock:   big.NewInt(0),
+		PlaceholderBlock:    big.NewInt(0),
+	},
 }
 
 // Returns the set of defined fork names

--- a/tests/init.go
+++ b/tests/init.go
@@ -197,7 +197,7 @@ var Forks = map[string]*params.ChainConfig{
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
 	},
-	"Placeholder": {
+	"Archimedes": {
 		ChainID:             big.NewInt(1),
 		HomesteadBlock:      big.NewInt(0),
 		EIP150Block:         big.NewInt(0),
@@ -211,7 +211,7 @@ var Forks = map[string]*params.ChainConfig{
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   big.NewInt(0),
-		PlaceholderBlock:    big.NewInt(0),
+		ArchimedesBlock:     big.NewInt(0),
 	},
 }
 


### PR DESCRIPTION
named archimedes 

support an earlier testnet release by pushing back implementation of some precompiles

tested locally as well