### PR TITLE
feat(trace): add storage proof about l1fee (baseFee, overhead, scalar) and withdraw root into trace

### DIFF
--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -427,8 +427,10 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 		env.StorageProofs[rcfg.L2MessageQueueAddress.String()] = make(map[string][]hexutil.Bytes)
 	}
 	if _, existed := env.StorageProofs[rcfg.L2MessageQueueAddress.String()][rcfg.WithdrawTrieRootSlot.String()]; !existed {
-		if proof, _, err := statedb.GetStorageTrieProof(rcfg.L2MessageQueueAddress, rcfg.WithdrawTrieRootSlot); err != nil {
+		if trie, err := statedb.GetStorageTrieForProof(rcfg.L2MessageQueueAddress); err != nil {
 			log.Error("Storage proof for WithdrawTrieRootSlot not available", "error", err)
+		} else if proof, _ := statedb.GetSecureTrieProof(trie, rcfg.WithdrawTrieRootSlot); err != nil {
+			log.Error("Get storage proof for WithdrawTrieRootSlot failed", "error", err)
 		} else {
 			wrappedProof := make([]hexutil.Bytes, len(proof))
 			for i, bt := range proof {

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -340,14 +340,8 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 	}
 
 	var l1Fee uint64
-	var l1FeeDetail *types.L1FeeFactors
 	if result.L1Fee != nil {
-		l1Fee = result.L1Fee.Fee.Uint64()
-		l1FeeDetail = &types.L1FeeFactors{
-			BaseFee:  result.L1Fee.BaseFee.Uint64(),
-			OverHead: result.L1Fee.OverHead.Uint64(),
-			Scalar:   result.L1Fee.Scalar.Uint64(),
-		}
+		l1Fee = result.L1Fee.Uint64()
 	}
 	env.executionResults[index] = &types.ExecutionResult{
 		From:           sender,
@@ -355,7 +349,6 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 		AccountCreated: createdAcc,
 		AccountsAfter:  after,
 		L1Fee:          l1Fee,
-		L1FeeDetail:    l1FeeDetail,
 		Gas:            result.UsedGas,
 		Failed:         result.Failed(),
 		ReturnValue:    fmt.Sprintf("%x", returnVal),

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -318,7 +318,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 	proofStorages := tracer.UpdatedStorages()
 	proofStorages[rcfg.L1GasPriceOracleAddress] = vm.Storage(
 		map[common.Hash]common.Hash{
-			rcfg.L1BaseFeeSlot: {},
+			rcfg.L1BaseFeeSlot: {}, // notice we do not need the right value here
 			rcfg.OverheadSlot:  {},
 			rcfg.ScalarSlot:    {},
 		})

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -290,6 +290,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 
 	// merge required proof data
 	proofAccounts := tracer.UpdatedAccounts()
+	proofAccounts[vmenv.FeeRecipient()] = struct{}{}
 	proofAccounts[rcfg.L1GasPriceOracleAddress] = struct{}{}
 	for addr := range proofAccounts {
 		addrStr := addr.String()

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 3       // Major version component of the current release
 	VersionMinor = 2       // Minor version component of the current release
-	VersionPatch = 0       // Patch version component of the current release
+	VersionPatch = 1       // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
This PR added proofs of zktrie into `storageProofs` of block trace. So circuit can prove the reading op from predeployed contract `L1GasPriceOracleAddress` about the l1 fee factors  (baseFee, overhead and scalar), and `	L2MessageQueueAddress` about the withdraw root 

~~The factors deriding l1fee for current transaction should be included in the block trace so circuit can verify the calculating. So we add all the required factors (baseFee, overhead and scalar) for calculating l1fee , which are storaged in `L1GasPriceOracleAddress` contract, into `ExecutionResult`. we also made efforts to [export these factors from `StateTransaction`](https://github.com/scroll-tech/go-ethereum/blob/6d8c2ebf762a1a932e1a9290ce62906cfbdc9080/core/state_transition.go#L74).~~

~~Moreover, we notice all of these reading of the storages from predeployed contracts require corresponding proofs of zktrie being added into `storageProofs` of block trace.~~


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204547993466425