### PR TITLE
Fix: Makefile requirements url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 
 devtools:
 	env GOBIN= go install golang.org/x/tools/cmd/stringer@latest
-	env GOBIN= go install github.com/kevinburke/go-bindata/go-bindata@latest
+	env GOBIN= go install github.com/kevinburke/go-bindata@latest
 	env GOBIN= go install github.com/fjl/gencodec@latest
 	env GOBIN= go install github.com/golang/protobuf/protoc-gen-go@latest
 	env GOBIN= go install ./cmd/abigen


### PR DESCRIPTION
Scroll variant's abigen binary is the prerequisite to development.
Currently, ```make devtools``` will fail due to updated Github projects url. Discovered this when recompiling abigen binary.

This simple commit fixed the url reference in Makefile.