### PR TITLE
feat(block_validator): check payload size during block validation

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -57,6 +57,10 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if !v.config.Scroll.IsValidTxCount(len(block.Transactions())) {
 		return consensus.ErrInvalidTxCount
 	}
+	// Check if block size is smaller than the max size
+	if !v.config.Scroll.IsValidBlockSize(block.Size()) {
+		return ErrInvalidBlockSize
+	}
 	// Header validity is known at this point, check the uncles and transactions
 	header := block.Header()
 	if err := v.engine.VerifyUncles(v.bc, block); err != nil {

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -57,9 +57,9 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 	if !v.config.Scroll.IsValidTxCount(len(block.Transactions())) {
 		return consensus.ErrInvalidTxCount
 	}
-	// Check if block size is smaller than the max size
-	if !v.config.Scroll.IsValidBlockSize(block.Size()) {
-		return ErrInvalidBlockSize
+	// Check if block payload size is smaller than the max size
+	if !v.config.Scroll.IsValidBlockSize(block.PayloadSize()) {
+		return ErrInvalidBlockPayloadSize
 	}
 	// Header validity is known at this point, check the uncles and transactions
 	header := block.Header()

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3244,8 +3244,6 @@ func TestBlockPayloadSizeLimit(t *testing.T) {
 	config := params.TestChainConfig
 	config.Scroll.MaxTxPayloadBytesPerBlock = new(int)
 	*config.Scroll.MaxTxPayloadBytesPerBlock = 150
-	config.Scroll.MaxTxPerBlock = new(int)
-	*config.Scroll.MaxTxPerBlock = 3
 
 	var (
 		engine  = ethash.NewFaker()

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3239,6 +3239,67 @@ func TestTransactionCountLimit(t *testing.T) {
 	}
 }
 
+func TestBlockPayloadSizeLimit(t *testing.T) {
+	// Create config that allows at most 150 bytes per block payload
+	config := params.TestChainConfig
+	config.Scroll.MaxTxPayloadBytesPerBlock = new(int)
+	*config.Scroll.MaxTxPayloadBytesPerBlock = 150
+
+	var (
+		engine  = ethash.NewFaker()
+		db      = rawdb.NewMemoryDatabase()
+		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		address = crypto.PubkeyToAddress(key.PublicKey)
+		funds   = big.NewInt(1000000000000000)
+		gspec   = &Genesis{Config: config, Alloc: GenesisAlloc{address: {Balance: funds}}}
+		genesis = gspec.MustCommit(db)
+	)
+
+	addTx := func(b *BlockGen) {
+		tx := types.NewTransaction(b.TxNonce(address), address, big.NewInt(0), 50000, b.header.BaseFee, nil)
+		signed, _ := types.SignTx(tx, types.HomesteadSigner{}, key)
+		b.AddTx(signed)
+	}
+
+	// Initialize blockchain
+	blockchain, err := NewBlockChain(db, nil, config, engine, vm.Config{}, nil, nil)
+	if err != nil {
+		t.Fatalf("failed to create new chain manager: %v", err)
+	}
+	defer blockchain.Stop()
+
+	// Insert empty block
+	block1, _ := GenerateChain(config, genesis, ethash.NewFaker(), db, 1, func(i int, b *BlockGen) {
+		// empty
+	})
+
+	if _, err := blockchain.InsertChain(block1); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+
+	// Insert block with 1 transaction
+	block2, _ := GenerateChain(config, genesis, ethash.NewFaker(), db, 1, func(i int, b *BlockGen) {
+		addTx(b)
+	})
+
+	if _, err := blockchain.InsertChain(block2); err != nil {
+		t.Fatalf("failed to insert chain: %v", err)
+	}
+
+	// Insert block with 2 transactions
+	block3, _ := GenerateChain(config, genesis, ethash.NewFaker(), db, 1, func(i int, b *BlockGen) {
+		addTx(b)
+		addTx(b)
+	})
+
+	_, err = blockchain.InsertChain(block3)
+
+	if !errors.Is(err, ErrInvalidBlockPayloadSize) {
+		t.Fatalf("error mismatch: have: %v, want: %v", err, ErrInvalidBlockPayloadSize)
+	}
+
+}
+
 func TestEIP3651(t *testing.T) {
 	var (
 		addraa = common.HexToAddress("0x000000000000000000000000000000000000aaaa")

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3244,6 +3244,8 @@ func TestBlockPayloadSizeLimit(t *testing.T) {
 	config := params.TestChainConfig
 	config.Scroll.MaxTxPayloadBytesPerBlock = new(int)
 	*config.Scroll.MaxTxPayloadBytesPerBlock = 150
+	config.Scroll.MaxTxPerBlock = new(int)
+	*config.Scroll.MaxTxPerBlock = 3
 
 	var (
 		engine  = ethash.NewFaker()
@@ -3297,7 +3299,6 @@ func TestBlockPayloadSizeLimit(t *testing.T) {
 	if !errors.Is(err, ErrInvalidBlockPayloadSize) {
 		t.Fatalf("error mismatch: have: %v, want: %v", err, ErrInvalidBlockPayloadSize)
 	}
-
 }
 
 func TestEIP3651(t *testing.T) {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3244,6 +3244,7 @@ func TestBlockPayloadSizeLimit(t *testing.T) {
 	config := params.TestChainConfig
 	config.Scroll.MaxTxPayloadBytesPerBlock = new(int)
 	*config.Scroll.MaxTxPayloadBytesPerBlock = 150
+	config.Scroll.MaxTxPerBlock = nil
 
 	var (
 		engine  = ethash.NewFaker()

--- a/core/error.go
+++ b/core/error.go
@@ -26,7 +26,7 @@ var (
 	// ErrKnownBlock is returned when a block to import is already known locally.
 	ErrKnownBlock = errors.New("block already known")
 
-	// ErrInvalidBlockSize is returned when a block to import has an invalid block payload size
+	// ErrInvalidBlockPayloadSize is returned when a block to import has an oversized payload.
 	ErrInvalidBlockPayloadSize = errors.New("invalid block payload size")
 
 	// ErrBannedHash is returned if a block to import is on the banned list.

--- a/core/error.go
+++ b/core/error.go
@@ -26,8 +26,8 @@ var (
 	// ErrKnownBlock is returned when a block to import is already known locally.
 	ErrKnownBlock = errors.New("block already known")
 
-	// ErrInvalidBlockSize is returned when a block to import has an invalid block size
-	ErrInvalidBlockSize = errors.New("invalid block size")
+	// ErrInvalidBlockSize is returned when a block to import has an invalid block payload size
+	ErrInvalidBlockPayloadSize = errors.New("invalid block payload size")
 
 	// ErrBannedHash is returned if a block to import is on the banned list.
 	ErrBannedHash = errors.New("banned hash")

--- a/core/error.go
+++ b/core/error.go
@@ -26,6 +26,9 @@ var (
 	// ErrKnownBlock is returned when a block to import is already known locally.
 	ErrKnownBlock = errors.New("block already known")
 
+	// ErrInvalidBlockSize is returned when a block to import has an invalid block size
+	ErrInvalidBlockSize = errors.New("invalid block size")
+
 	// ErrBannedHash is returned if a block to import is on the banned list.
 	ErrBannedHash = errors.New("banned hash")
 

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -329,8 +329,8 @@ func (b *Block) Size() common.StorageSize {
 func (b *Block) PayloadSize() common.StorageSize {
 	// add up all txs sizes
 	var totalSize common.StorageSize
-	for i := range b.transactions {
-		totalSize += b.transactions[i].Size()
+	for _, tx := range b.transactions {
+		totalSize += tx.Size()
 	}
 	return totalSize
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -325,6 +325,16 @@ func (b *Block) Size() common.StorageSize {
 	return common.StorageSize(c)
 }
 
+// PayloadSize returns the sum of all transactions in a block.
+func (b *Block) PayloadSize() common.StorageSize {
+	// add up all txs sizes
+	var totalSize common.StorageSize
+	for i := range b.transactions {
+		totalSize += b.transactions[i].Size()
+	}
+	return totalSize
+}
+
 // SanityCheck can be used to prevent that unbounded fields are
 // stuffed with junk data to add processing overhead
 func (b *Block) SanityCheck() error {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 0         // Patch version component of the current release
+	VersionPatch = 1         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Check payload size during block validation.

Previously, the configuration `MaxTxPayloadBytesPerBlock` was used in `miner/worker.go`. However, when receiving a new block from a peer, this limit was not enforced. This PR fixes this.

Note: The purpose of `MaxTxPayloadBytesPerBlock` is to ensure that any L2 block is not too big to be committed on L1.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [X] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [X] Yes