### PR TITLE
Add Archimedes hard fork block number for Scroll Alpha

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -275,7 +275,7 @@ var (
 		BerlinBlock:         big.NewInt(0),
 		LondonBlock:         big.NewInt(0),
 		ArrowGlacierBlock:   nil,
-		ArchimedesBlock:     nil,
+		ArchimedesBlock:     big.NewInt(2444711),
 		ShanghaiBlock:       nil,
 		Clique: &CliqueConfig{
 			Period: 3,

--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	VersionMajor = 3       // Major version component of the current release
-	VersionMinor = 1       // Minor version component of the current release
-	VersionPatch = 12      // Patch version component of the current release
+	VersionMinor = 2       // Minor version component of the current release
+	VersionPatch = 0       // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Enable Archimedes when running with the `--scroll-alpha` flag.


## 2. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes