### PR TITLE
Fix transaction DA cost under-estimation

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -22,10 +22,10 @@ import (
 )
 
 const (
-	VersionMajor = 3       // Major version component of the current release
-	VersionMinor = 3       // Minor version component of the current release
-	VersionPatch = 0       // Patch version component of the current release
-	VersionMeta  = "alpha" // Version metadata to append to the version string
+	VersionMajor = 4         // Major version component of the current release
+	VersionMinor = 0         // Minor version component of the current release
+	VersionPatch = 0         // Patch version component of the current release
+	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -17,6 +17,15 @@ var (
 	// transaction to the L1 fee calculation routine. The signature is accounted
 	// for externally
 	errTransactionSigned = errors.New("transaction is signed")
+
+	// txExtraDataBytes is the number of bytes that we commit to L1 in addition
+	// to the RLP-encoded unsigned transaction. Note that these are all assumed
+	// to be non-zero.
+	// - tx length prefix: 4 bytes
+	// - sig.r: 32 bytes + 1 byte rlp prefix
+	// - sig.s: 32 bytes + 1 byte rlp prefix
+	// - sig.v:  3 bytes + 1 byte rlp prefix
+	txExtraDataBytes = uint64(74)
 )
 
 // Message represents the interface of a message.
@@ -115,7 +124,7 @@ func CalculateL1Fee(data []byte, overhead, l1GasPrice *big.Int, scalar *big.Int)
 func CalculateL1GasUsed(data []byte, overhead *big.Int) *big.Int {
 	zeroes, ones := zeroesAndOnes(data)
 	zeroesGas := zeroes * params.TxDataZeroGas
-	onesGas := (ones + 68) * params.TxDataNonZeroGasEIP2028
+	onesGas := (ones + txExtraDataBytes) * params.TxDataNonZeroGasEIP2028
 	l1Gas := new(big.Int).SetUint64(zeroesGas + onesGas)
 	return new(big.Int).Add(l1Gas, overhead)
 }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Account for (1) 3-byte-long chain ID, (2) transaction length prefix when calculating DA costs for L2 transactions. For details please see the comments.

References:
- Gas on Optimism: https://hackmd.io/@rajivpoc/SJzAVsB15
- RLP spec: https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp
- Scroll batch encoding: [code](https://github.com/scroll-tech/scroll/blob/f6f11be0cfd1db0da45745f83988f89817ee9994/common/types/batch.go#L168)


## 2. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes

