### PR TITLE
feat(abigen): add `--contract` flag to specify a given contract

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -101,7 +101,7 @@ var (
 	}
 	contractFlag = cli.StringFlag{
 		Name:  "contract",
-		Usage: "Use this flag can just translate specified contract",
+		Usage: "Name of the contract to generate the bindings for",
 	}
 )
 

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -230,10 +230,10 @@ func abigen(c *cli.Context) error {
 		}
 		// Gather all non-excluded contract for binding
 		for name, contract := range contracts {
-			// fully qualified name is of the form <solFilePath>:<type>
+			// The fully qualified name is of the form <solFilePath>:<type>
 			nameParts := strings.Split(name, ":")
 			typeName := nameParts[len(nameParts)-1]
-			// If contract flag is used and then choose the specified.
+			// If a contract name is provided then ignore all other contracts
 			if c.GlobalIsSet(contractFlag.Name) && c.GlobalString(contractFlag.Name) != typeName {
 				continue
 			}

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -234,7 +234,7 @@ func abigen(c *cli.Context) error {
 			nameParts := strings.Split(name, ":")
 			typeName := nameParts[len(nameParts)-1]
 			// If contract flag is used and then choose the specified.
-			if c.IsSet(contractFlag.Name) && c.String(contractFlag.Name) != typeName {
+			if c.GlobalIsSet(contractFlag.Name) && c.GlobalString(contractFlag.Name) != typeName {
 				continue
 			}
 			if exclude[strings.ToLower(name)] {

--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -99,6 +99,10 @@ var (
 		Name:  "alias",
 		Usage: "Comma separated aliases for function and event renaming, e.g. original1=alias1, original2=alias2",
 	}
+	contractFlag = cli.StringFlag{
+		Name:  "contract",
+		Usage: "Use this flag can just translate specified contract",
+	}
 )
 
 func init() {
@@ -117,6 +121,7 @@ func init() {
 		outFlag,
 		langFlag,
 		aliasFlag,
+		contractFlag,
 	}
 	app.Action = utils.MigrateFlags(abigen)
 	cli.CommandHelpTemplate = flags.OriginCommandHelpTemplate
@@ -225,6 +230,13 @@ func abigen(c *cli.Context) error {
 		}
 		// Gather all non-excluded contract for binding
 		for name, contract := range contracts {
+			// fully qualified name is of the form <solFilePath>:<type>
+			nameParts := strings.Split(name, ":")
+			typeName := nameParts[len(nameParts)-1]
+			// If contract flag is used and then choose the specified.
+			if c.IsSet(contractFlag.Name) && c.String(contractFlag.Name) != typeName {
+				continue
+			}
 			if exclude[strings.ToLower(name)] {
 				continue
 			}
@@ -235,11 +247,10 @@ func abigen(c *cli.Context) error {
 			abis = append(abis, string(abi))
 			bins = append(bins, contract.Code)
 			sigs = append(sigs, contract.Hashes)
-			nameParts := strings.Split(name, ":")
-			types = append(types, nameParts[len(nameParts)-1])
+			types = append(types, typeName)
 
 			libPattern := crypto.Keccak256Hash([]byte(name)).String()[2:36]
-			libs[libPattern] = nameParts[len(nameParts)-1]
+			libs[libPattern] = typeName
 		}
 	}
 	// Extract all aliases from the flags


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
i.g: `abigen --contract L1ScrollMessenger` cmd it just translate L1ScrollMessenger contract.
This flag can help to fix this kind of [error](http://jenkins.scroll.tech:8080/blue/organizations/jenkins/scroll-tests%2Fscroll/detail/scroll/5169/pipeline).
...


## 2. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes

