### PR TITLE
Return error for disabled precompile calls

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	VersionMajor = 3       // Major version component of the current release
-	VersionMinor = 2       // Minor version component of the current release
-	VersionPatch = 1       // Patch version component of the current release
+	VersionMinor = 3       // Minor version component of the current release
+	VersionPatch = 0       // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

In https://github.com/scroll-tech/go-ethereum/pull/280 we disabled the `sha2`, `ripemd160`, `blake2f` precompiles as part of the Archimedes hard fork.

However, simply removing the precompiles will lead to accounts that just behave as normal non-contract accounts. That means that calling these precompiles will always succeed. This might lead to unexpected silent failures for dapps that rely on these precompiles.

In this PR I propose temporarily replacing these 3 precompiles with with another precompile that simply reverts.

```
> cast call --rpc-url "$SCROLL_L2_DEPLOYMENT_RPC" 0x0000000000000000000000000000000000000003 --data 0xaabb
Error: 
(code: -32000, message: sha256, ripemd160, blake2f precompiles temporarily disabled, data: None)
```


## 2. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes

