### PR TITLE
feat: expose `scroll_getBlockTraceByNumberOrHash` on the geth console

### DIFF
--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -855,7 +855,13 @@ web3._extend({
 	property: 'scroll',
 	methods: [
 		new web3._extend.Method({
-			name: 'getBlockTraceByNumberOrHash',
+			name: 'getBlockTraceByNumber',
+			call: 'scroll_getBlockTraceByNumberOrHash',
+			params: 1,
+			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
+		}),
+		new web3._extend.Method({
+			name: 'getBlockTraceByHash',
 			call: 'scroll_getBlockTraceByNumberOrHash',
 			params: 1
 		})

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -30,6 +30,7 @@ var Modules = map[string]string{
 	"txpool":   TxpoolJs,
 	"les":      LESJs,
 	"vflux":    VfluxJs,
+	"scroll":   ScrollJs,
 }
 
 const CliqueJs = `
@@ -845,6 +846,19 @@ web3._extend({
 			name: 'requestStats',
 			getter: 'vflux_requestStats'
 		}),
+	]
+});
+`
+
+const ScrollJs = `
+web3._extend({
+	property: 'scroll',
+	methods: [
+		new web3._extend.Method({
+			name: 'getBlockTraceByNumberOrHash',
+			call: 'scroll_getBlockTraceByNumberOrHash',
+			params: 1
+		})
 	]
 });
 `

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 3       // Major version component of the current release
 	VersionMinor = 3       // Minor version component of the current release
-	VersionPatch = 0       // Patch version component of the current release
+	VersionPatch = 1       // Patch version component of the current release
 	VersionMeta  = "alpha" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Expose `scroll_getBlockTraceByNumberOrHash` on the geth IPC console as `scroll.getBlockTraceByNumber` and `scroll.getBlockTraceByHash`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [X] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes