### PR TITLE
refactor(config): moved fee vault addr to rollup config

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/crypto/sha3"
 
 	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/rollup/rcfg"
 )
 
 // Genesis hashes to enforce below configs on.
@@ -284,6 +285,7 @@ var (
 			UseZktrie:                 true,
 			MaxTxPerBlock:             &ScrollMaxTxPerBlock,
 			MaxTxPayloadBytesPerBlock: &ScrollMaxTxPayloadBytesPerBlock,
+			FeeVaultAddress:           &rcfg.ScrollFeeVaultAddress,
 			EnableEIP2718:             false,
 			EnableEIP1559:             false,
 		},

--- a/params/config.go
+++ b/params/config.go
@@ -255,7 +255,6 @@ var (
 	}
 
 	// ScrollAlphaChainConfig contains the chain parameters to run a node on the Scroll Alpha test network.
-	ScrollFeeVaultAddress           = common.HexToAddress("0x5300000000000000000000000000000000000005")
 	ScrollMaxTxPerBlock             = 44
 	ScrollMaxTxPayloadBytesPerBlock = 120 * 1024
 
@@ -285,7 +284,6 @@ var (
 			UseZktrie:                 true,
 			MaxTxPerBlock:             &ScrollMaxTxPerBlock,
 			MaxTxPayloadBytesPerBlock: &ScrollMaxTxPayloadBytesPerBlock,
-			FeeVaultAddress:           &ScrollFeeVaultAddress,
 			EnableEIP2718:             false,
 			EnableEIP1559:             false,
 		},

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -19,7 +19,7 @@ var (
 	// ScrollFeeVaultAddress is the address of the L2TxFeeVault
 	// predeploy
 	// see scroll-tech/scroll/contracts/src/L2/predeploys/L2TxFeeVault.sol
-	ScrollFeeVaultAddress           = common.HexToAddress("0x5300000000000000000000000000000000000005")
+	ScrollFeeVaultAddress = common.HexToAddress("0x5300000000000000000000000000000000000005")
 
 	// L1GasPriceOracleAddress is the address of the L1GasPriceOracle
 	// predeploy

--- a/rollup/rcfg/config.go
+++ b/rollup/rcfg/config.go
@@ -16,6 +16,11 @@ var (
 	L2MessageQueueAddress = common.HexToAddress("0x5300000000000000000000000000000000000000")
 	WithdrawTrieRootSlot  = common.BigToHash(big.NewInt(0))
 
+	// ScrollFeeVaultAddress is the address of the L2TxFeeVault
+	// predeploy
+	// see scroll-tech/scroll/contracts/src/L2/predeploys/L2TxFeeVault.sol
+	ScrollFeeVaultAddress           = common.HexToAddress("0x5300000000000000000000000000000000000005")
+
 	// L1GasPriceOracleAddress is the address of the L1GasPriceOracle
 	// predeploy
 	// see scroll-tech/scroll/contracts/src/L2/predeploys/L1GasPriceOracle.sol


### PR DESCRIPTION
Currently we have L2 `ScrollFeeVaultAddress` in the L2 genesis configuration. However, this is a predeployed contract with a fixed address, so user does not need to configure it. We can move this config into rollup/rcfg/config.go