### PR TITLE
test(worker): ensure that l1 messages are included in the correct order

### DIFF
--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -667,3 +667,67 @@ func TestExcludeL1MsgFromTxlimit(t *testing.T) {
 		t.Fatalf("timeout")
 	}
 }
+
+func TestL1MsgCorrectOrder(t *testing.T) {
+	assert := assert.New(t)
+	var (
+		engine      consensus.Engine
+		chainConfig *params.ChainConfig
+		db          = rawdb.NewMemoryDatabase()
+	)
+	chainConfig = params.AllCliqueProtocolChanges
+	chainConfig.Clique = &params.CliqueConfig{Period: 1, Epoch: 30000}
+	engine = clique.New(chainConfig.Clique, db)
+
+	chainConfig.Scroll.L1Config = &params.L1Config{
+		NumL1MessagesPerBlock: 10,
+	}
+
+	// Insert 3 l1msgs
+	l1msgs := []types.L1MessageTx{
+		{QueueIndex: 0, Gas: 21016, To: &common.Address{3}, Data: []byte{0x01}, Sender: common.Address{4}},
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 2, Gas: 21016, To: &common.Address{3}, Data: []byte{0x01}, Sender: common.Address{4}}}
+	rawdb.WriteL1Messages(db, l1msgs)
+
+	chainConfig.LondonBlock = big.NewInt(0)
+	w, b := newTestWorker(t, chainConfig, engine, db, 0)
+	defer w.close()
+
+	// This test chain imports the mined blocks.
+	b.genesis.MustCommit(db)
+	chain, _ := core.NewBlockChain(db, nil, b.chain.Config(), engine, vm.Config{
+		Debug:  true,
+		Tracer: vm.NewStructLogger(&vm.LogConfig{EnableMemory: true, EnableReturnData: true})}, nil, nil)
+	defer chain.Stop()
+
+	// Ignore empty commit here for less noise.
+	w.skipSealHook = func(task *task) bool {
+		return len(task.receipts) == 0
+	}
+
+	// Wait for mined blocks.
+	sub := w.mux.Subscribe(core.NewMinedBlockEvent{})
+	defer sub.Unsubscribe()
+
+	// Insert local tx
+	b.txPool.AddLocal(b.newRandomTx(true))
+
+	// Start mining!
+	w.start()
+
+	select {
+	case ev := <-sub.Chan():
+		block := ev.Data.(core.NewMinedBlockEvent).Block
+		if _, err := chain.InsertChain([]*types.Block{block}); err != nil {
+			t.Fatalf("failed to insert new mined block %d: %v", block.NumberU64(), err)
+		}
+		assert.Equal(4, len(block.Transactions()))
+		assert.True(block.Transactions()[0].IsL1MessageTx() && block.Transactions()[1].IsL1MessageTx() && block.Transactions()[2].IsL1MessageTx())
+		assert.Equal(uint64(0), block.Transactions()[0].AsL1MessageTx().QueueIndex)
+		assert.Equal(uint64(1), block.Transactions()[1].AsL1MessageTx().QueueIndex)
+		assert.Equal(uint64(2), block.Transactions()[2].AsL1MessageTx().QueueIndex)
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timeout")
+	}
+}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

We're using `NewTransactionsByPriceAndNonce` to include `L1MessageTx` transactions in a block. This data structure orders messages into queues, one queue per sender, each ordered by nonce. The heads (first tx in each queue) are ordered by gas price and insertion time.

Since `L1MessageTx` has `gasPrice = 0` and `nonce = 0`, `NewTransactionsByPriceAndNonce` should yield messages in their insertion order. This test check this.


## 2. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes

