### PR TITLE
fix: add missing term when merging two deletion proofs

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/trie/zktrie_deletionproof.go
+++ b/trie/zktrie_deletionproof.go
@@ -58,6 +58,10 @@ func (t *ProofTracer) Merge(another *ProofTracer) *ProofTracer {
 		t.rawPaths[k] = v
 	}
 
+	for k, v := range another.emptyTermPaths {
+		t.emptyTermPaths[k] = v
+	}
+
 	return t
 }
 


### PR DESCRIPTION
This fix an issue in PR #330. The new field `emptyTerPaths` is not consider in `Merge` so it would cause the tracer panic later.
