### PR TITLE
fix(ethclient): support WithdrawalsHash in Scroll Go SDK

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -85,6 +85,10 @@ type Header struct {
 
 	// BaseFee was added by EIP-1559 and is ignored in legacy headers.
 	BaseFee *big.Int `json:"baseFeePerGas" rlp:"optional"`
+
+	// WithdrawalsHash was added by EIP-4895 and is ignored in legacy headers.
+	// Included for Ethereum compatibility in Scroll SDK
+	WithdrawalsHash *common.Hash `json:"withdrawalsRoot" rlp:"optional"`
 }
 
 // field type overrides for gencodec

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -16,23 +16,24 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase    common.Address `json:"miner"            gencodec:"required"`
-		Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom       Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty  *hexutil.Big   `json:"difficulty"       gencodec:"required"`
-		Number      *hexutil.Big   `json:"number"           gencodec:"required"`
-		GasLimit    hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed     hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time        hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra       hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest   common.Hash    `json:"mixHash"`
-		Nonce       BlockNonce     `json:"nonce"`
-		BaseFee     *hexutil.Big   `json:"baseFeePerGas" rlp:"optional"`
-		Hash        common.Hash    `json:"hash"`
+		ParentHash      common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash       common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase        common.Address `json:"miner"            gencodec:"required"`
+		Root            common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash          common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash     common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom           Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty      *hexutil.Big   `json:"difficulty"       gencodec:"required"`
+		Number          *hexutil.Big   `json:"number"           gencodec:"required"`
+		GasLimit        hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed         hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time            hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
+		Extra           hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest       common.Hash    `json:"mixHash"`
+		Nonce           BlockNonce     `json:"nonce"`
+		BaseFee         *hexutil.Big   `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash *common.Hash   `json:"withdrawalsRoot" rlp:"optional"`
+		Hash            common.Hash    `json:"hash"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -51,6 +52,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.MixDigest = h.MixDigest
 	enc.Nonce = h.Nonce
 	enc.BaseFee = (*hexutil.Big)(h.BaseFee)
+	enc.WithdrawalsHash = h.WithdrawalsHash
 	enc.Hash = h.Hash()
 	return json.Marshal(&enc)
 }
@@ -58,22 +60,23 @@ func (h Header) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash  *common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash   *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase    *common.Address `json:"miner"            gencodec:"required"`
-		Root        *common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash      *common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom       *Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty  *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number      *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit    *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed     *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time        *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra       *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest   *common.Hash    `json:"mixHash"`
-		Nonce       *BlockNonce     `json:"nonce"`
-		BaseFee     *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		ParentHash      *common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash       *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase        *common.Address `json:"miner"            gencodec:"required"`
+		Root            *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash          *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash     *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom           *Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty      *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number          *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit        *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed         *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time            *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
+		Extra           *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest       *common.Hash    `json:"mixHash"`
+		Nonce           *BlockNonce     `json:"nonce"`
+		BaseFee         *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -139,6 +142,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.BaseFee != nil {
 		h.BaseFee = (*big.Int)(dec.BaseFee)
+	}
+	if dec.WithdrawalsHash != nil {
+		h.WithdrawalsHash = dec.WithdrawalsHash
 	}
 	return nil
 }

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 2         // Patch version component of the current release
+	VersionPatch = 3         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Adds `withdrawalsHash` to `Header` in block.go so Scroll SDK can return compatible block hashes. Before, hash mismatches would occur for services using both L1 and L2 SDKs. 


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
