### PR TITLE
fix(tracing): fix ZktrieTracer race condition

### DIFF
--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -345,7 +345,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 				m = make(map[string][]hexutil.Bytes)
 				env.StorageProofs[addrStr] = m
 				if zktrieTracer.Available() {
-					env.zkTrieTracer[addrStr] = zktrieTracer
+					env.zkTrieTracer[addrStr] = state.NewProofTracer(trie)
 				}
 			} else if _, existed := m[keyStr]; existed {
 				// still need to touch tracer for deletion

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 3         // Patch version component of the current release
+	VersionPatch = 4         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
In `getTxResult`, working thread created a `ZkTrieTracer` object for marking deletion proof, and there is a shared object of the same type in the `traceEnv`. If the thread found the shared object is not existed yet, [it set the object it just created as the shared one](https://github.com/scroll-tech/go-ethereum/blob/1f167bd730c57af18ae25c25bcb7a255de048d05/eth/tracers/api_blocktrace.go#L348) and this behavior has created an race condition. since there is a calling of `proof`, which have written to the tracer object without any rw protection.

The shared object must be initailized by creating a new one and the one created by working thread [would merge its data to the shared object (with rw protecting)](https://github.com/scroll-tech/go-ethereum/blob/1f167bd730c57af18ae25c25bcb7a255de048d05/eth/tracers/api_blocktrace.go#L381) when everything has set.