### PR TITLE
fix(trace): change l1Fee type from uint64 to *big.Int

### DIFF
--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -44,10 +44,10 @@ type StorageTrace struct {
 // while replaying a transaction in debug mode as well as transaction
 // execution status, the amount of gas used and the return value
 type ExecutionResult struct {
-	L1Fee       uint64 `json:"l1Fee,omitempty"`
-	Gas         uint64 `json:"gas"`
-	Failed      bool   `json:"failed"`
-	ReturnValue string `json:"returnValue"`
+	L1Fee       *big.Int `json:"l1Fee,omitempty"`
+	Gas         uint64   `json:"gas"`
+	Failed      bool     `json:"failed"`
+	ReturnValue string   `json:"returnValue"`
 	// Sender's account state (before Tx)
 	From *AccountWrapper `json:"from,omitempty"`
 	// Receiver's account state (before Tx)

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -44,10 +44,10 @@ type StorageTrace struct {
 // while replaying a transaction in debug mode as well as transaction
 // execution status, the amount of gas used and the return value
 type ExecutionResult struct {
-	L1Fee       *big.Int `json:"l1Fee,omitempty"`
-	Gas         uint64   `json:"gas"`
-	Failed      bool     `json:"failed"`
-	ReturnValue string   `json:"returnValue"`
+	L1Fee       *hexutil.Big `json:"l1Fee,omitempty"`
+	Gas         uint64       `json:"gas"`
+	Failed      bool         `json:"failed"`
+	ReturnValue string       `json:"returnValue"`
 	// Sender's account state (before Tx)
 	From *AccountWrapper `json:"from,omitempty"`
 	// Receiver's account state (before Tx)

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -930,6 +930,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 			Failed:      result.Failed(),
 			ReturnValue: returnVal,
 			StructLogs:  vm.FormatLogs(tracer.StructLogs()),
+			L1Fee:       result.L1Fee,
 		}, nil
 
 	case Tracer:

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -930,7 +930,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 			Failed:      result.Failed(),
 			ReturnValue: returnVal,
 			StructLogs:  vm.FormatLogs(tracer.StructLogs()),
-			L1Fee:       result.L1Fee,
+			L1Fee:       (*hexutil.Big)(result.L1Fee),
 		}, nil
 
 	case Tracer:

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -384,16 +384,12 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 		}
 	}
 
-	var l1Fee uint64
-	if result.L1Fee != nil {
-		l1Fee = result.L1Fee.Uint64()
-	}
 	env.executionResults[index] = &types.ExecutionResult{
 		From:           sender,
 		To:             receiver,
 		AccountCreated: createdAcc,
 		AccountsAfter:  after,
-		L1Fee:          l1Fee,
+		L1Fee:          result.L1Fee,
 		Gas:            result.UsedGas,
 		Failed:         result.Failed(),
 		ReturnValue:    fmt.Sprintf("%x", returnVal),

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -389,7 +389,7 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 		To:             receiver,
 		AccountCreated: createdAcc,
 		AccountsAfter:  after,
-		L1Fee:          result.L1Fee,
+		L1Fee:          (*hexutil.Big)(result.L1Fee),
 		Gas:            result.UsedGas,
 		Failed:         result.Failed(),
 		ReturnValue:    fmt.Sprintf("%x", returnVal),

--- a/eth/tracers/api_blocktrace_test.go
+++ b/eth/tracers/api_blocktrace_test.go
@@ -164,10 +164,12 @@ func checkStructLogs(t *testing.T, expect []*txTraceResult, actual []*types.Exec
 	assert.Equal(t, len(expect), len(actual))
 	for i, val := range expect {
 		trace1, trace2 := val.Result.(*types.ExecutionResult), actual[i]
+		assert.Equal(t, trace1.L1Fee, trace2.L1Fee)
 		assert.Equal(t, trace1.Failed, trace2.Failed)
 		assert.Equal(t, trace1.Gas, trace2.Gas)
 		assert.Equal(t, trace1.ReturnValue, trace2.ReturnValue)
 		assert.Equal(t, len(trace1.StructLogs), len(trace2.StructLogs))
+		// TODO: compare other fields
 
 		for i, opcode := range trace1.StructLogs {
 			data1, err := json.Marshal(opcode)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -218,6 +218,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
+				L1Fee:       big.NewInt(0),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -235,6 +236,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
+				L1Fee:       big.NewInt(0),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -264,6 +266,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
+				L1Fee:       big.NewInt(0),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -281,6 +284,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
+				L1Fee:       big.NewInt(0),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -334,6 +338,7 @@ func TestTraceTransaction(t *testing.T) {
 		t.Errorf("Failed to trace transaction %v", err)
 	}
 	if !reflect.DeepEqual(result, &types.ExecutionResult{
+		L1Fee:       big.NewInt(0),
 		Gas:         params.TxGas,
 		Failed:      false,
 		ReturnValue: "",

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -218,7 +218,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
-				L1Fee:       big.NewInt(0),
+				L1Fee:       (*hexutil.Big)(big.NewInt(0)),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -236,7 +236,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
-				L1Fee:       big.NewInt(0),
+				L1Fee:       (*hexutil.Big)(big.NewInt(0)),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -266,7 +266,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
-				L1Fee:       big.NewInt(0),
+				L1Fee:       (*hexutil.Big)(big.NewInt(0)),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -284,7 +284,7 @@ func TestTraceCall(t *testing.T) {
 			config:    nil,
 			expectErr: nil,
 			expect: &types.ExecutionResult{
-				L1Fee:       big.NewInt(0),
+				L1Fee:       (*hexutil.Big)(big.NewInt(0)),
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
@@ -338,7 +338,7 @@ func TestTraceTransaction(t *testing.T) {
 		t.Errorf("Failed to trace transaction %v", err)
 	}
 	if !reflect.DeepEqual(result, &types.ExecutionResult{
-		L1Fee:       big.NewInt(0),
+		L1Fee:       (*hexutil.Big)(big.NewInt(0)),
 		Gas:         params.TxGas,
 		Failed:      false,
 		ReturnValue: "",

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 0         // Patch version component of the current release
+	VersionPatch = 1         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

In the traces we convert `l1Fee` into `uint64`. However, it is possible for `l1Fee` to overflow `uint64`, so it's best to keep it as `*big.Int`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [x] Yes

This change might be a breaking change for consumers of the tracing API, since `l1Fee` is now a hex string, not a number.
