### PR TITLE
fix(trace): fix storage proof of l1gas price oracle

### DIFF
--- a/core/vm/logger_trace.go
+++ b/core/vm/logger_trace.go
@@ -95,7 +95,7 @@ func traceLastNAddressAccount(n int) traceFunc {
 		address := common.Address(stack.data[stack.len()-1-n].Bytes20())
 		state := getWrappedAccountForAddr(l, address)
 		extraData.StateList = append(extraData.StateList, state)
-		l.statesAffected[scope.Contract.Address()] = struct{}{}
+		l.statesAffected[address] = struct{}{}
 
 		return nil
 	}

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -321,7 +321,6 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 	// merge required proof data
 	proofAccounts := tracer.UpdatedAccounts()
 	proofAccounts[vmenv.FeeRecipient()] = struct{}{}
-	proofAccounts[rcfg.L1GasPriceOracleAddress] = struct{}{}
 	for addr := range proofAccounts {
 		addrStr := addr.String()
 
@@ -350,12 +349,6 @@ func (api *API) getTxResult(env *traceEnv, state *state.StateDB, index int, bloc
 	}
 
 	proofStorages := tracer.UpdatedStorages()
-	proofStorages[rcfg.L1GasPriceOracleAddress] = vm.Storage(
-		map[common.Hash]common.Hash{
-			rcfg.L1BaseFeeSlot: {}, // notice we do not need the right value here
-			rcfg.OverheadSlot:  {},
-			rcfg.ScalarSlot:    {},
-		})
 	for addr, keys := range proofStorages {
 		if _, existed := txStorageTrace.StorageProofs[addr.String()]; !existed {
 			txStorageTrace.StorageProofs[addr.String()] = make(map[string][]hexutil.Bytes)
@@ -450,32 +443,46 @@ func (api *API) fillBlockTrace(env *traceEnv, block *types.Block) (*types.BlockT
 		txs[i] = types.NewTransactionData(tx, block.NumberU64(), api.backend.ChainConfig())
 	}
 
-	if _, existed := env.Proofs[rcfg.L2MessageQueueAddress.String()]; !existed {
-		if proof, err := statedb.GetProof(rcfg.L2MessageQueueAddress); err != nil {
-			log.Error("Proof for L2MessageQueueAddress not available", "error", err)
-		} else {
-			wrappedProof := make([]hexutil.Bytes, len(proof))
-			for i, bt := range proof {
-				wrappedProof[i] = bt
-			}
-			env.Proofs[rcfg.L2MessageQueueAddress.String()] = wrappedProof
-		}
+	intrinsicStorageProofs := map[common.Address][]common.Hash{
+		rcfg.L2MessageQueueAddress: {rcfg.WithdrawTrieRootSlot},
+		rcfg.L1GasPriceOracleAddress: {
+			rcfg.L1BaseFeeSlot,
+			rcfg.OverheadSlot,
+			rcfg.ScalarSlot,
+		},
 	}
 
-	if _, existed := env.StorageProofs[rcfg.L2MessageQueueAddress.String()]; !existed {
-		env.StorageProofs[rcfg.L2MessageQueueAddress.String()] = make(map[string][]hexutil.Bytes)
-	}
-	if _, existed := env.StorageProofs[rcfg.L2MessageQueueAddress.String()][rcfg.WithdrawTrieRootSlot.String()]; !existed {
-		if trie, err := statedb.GetStorageTrieForProof(rcfg.L2MessageQueueAddress); err != nil {
-			log.Error("Storage proof for WithdrawTrieRootSlot not available", "error", err)
-		} else if proof, _ := statedb.GetSecureTrieProof(trie, rcfg.WithdrawTrieRootSlot); err != nil {
-			log.Error("Get storage proof for WithdrawTrieRootSlot failed", "error", err)
-		} else {
-			wrappedProof := make([]hexutil.Bytes, len(proof))
-			for i, bt := range proof {
-				wrappedProof[i] = bt
+	for addr, storages := range intrinsicStorageProofs {
+		if _, existed := env.Proofs[addr.String()]; !existed {
+			if proof, err := statedb.GetProof(addr); err != nil {
+				log.Error("Proof for intrinstic address not available", "error", err, "address", addr)
+			} else {
+				wrappedProof := make([]hexutil.Bytes, len(proof))
+				for i, bt := range proof {
+					wrappedProof[i] = bt
+				}
+				env.Proofs[addr.String()] = wrappedProof
 			}
-			env.StorageProofs[rcfg.L2MessageQueueAddress.String()][rcfg.WithdrawTrieRootSlot.String()] = wrappedProof
+		}
+
+		if _, existed := env.StorageProofs[addr.String()]; !existed {
+			env.StorageProofs[addr.String()] = make(map[string][]hexutil.Bytes)
+		}
+
+		for _, slot := range storages {
+			if _, existed := env.StorageProofs[addr.String()][slot.String()]; !existed {
+				if trie, err := statedb.GetStorageTrieForProof(addr); err != nil {
+					log.Error("Storage proof for intrinstic address not available", "error", err, "address", addr)
+				} else if proof, _ := statedb.GetSecureTrieProof(trie, slot); err != nil {
+					log.Error("Get storage proof for intrinstic address failed", "error", err, "address", addr, "slot", slot)
+				} else {
+					wrappedProof := make([]hexutil.Bytes, len(proof))
+					for i, bt := range proof {
+						wrappedProof[i] = bt
+					}
+					env.StorageProofs[addr.String()][slot.String()] = wrappedProof
+				}
+			}
 		}
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 2         // Minor version component of the current release
-	VersionPatch = 6         // Patch version component of the current release
+	VersionPatch = 8         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
The [code here in `api_trace.go`](https://github.com/scroll-tech/go-ethereum/blob/3cf5ba882dd89b5b532341f775dd4bb98db2209a/eth/tracers/api_blocktrace.go#L353) enforce the proof for storage slots in `L1GasPriceOracle` contract being collected:

~~~ go

	proofStorages := tracer.UpdatedStorages()
	proofStorages[rcfg.L1GasPriceOracleAddress] = vm.Storage(
		map[common.Hash]common.Hash{
			rcfg.L1BaseFeeSlot: {}, // notice we do not need the right value here
			rcfg.OverheadSlot:  {},
			rcfg.ScalarSlot:    {},
		})
	for addr, keys := range proofStorages {

~~~

There is an issue: when some slot of `L1GasPriceOracle` is updated in the tx, the code here in fact rewrite the data obtained from `tracer.UpdatedStorages`. For example, if the `slot(0)` of `L1GasPriceOracle` is touched, it would be dropped in the block trace because of the problematic code.

This patch fix the issue above and move all the collection of storage proofs from each evaluation of tx results to the end of filling block result. So we also save a little cost.
