### PR TITLE
fix(ccc): Fix circuit capacity checker build error

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/impl.go
+++ b/rollup/circuitcapacitychecker/impl.go
@@ -87,8 +87,8 @@ func (ccc *CircuitCapacityChecker) ApplyTransaction(traces *types.BlockTrace) (*
 	if result.TxRowUsage == nil || result.AccRowUsage == nil {
 		log.Error("fail to apply_tx in CircuitCapacityChecker",
 			"id", ccc.ID, "TxHash", traces.Transactions[0].TxHash,
-			"len(result.TxRowUsage)", len(result.TxRowUsage),
-			"len(result.AccRowUsage)", len(result.AccRowUsage),
+			"result.TxRowUsage", result.TxRowUsage,
+			"result.AccRowUsage", result.AccRowUsage,
 			"err", "TxRowUsage or AccRowUsage is empty unexpectedly")
 		return nil, ErrUnknown
 	}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Fix errors:
```
Error: rollup/circuitcapacitychecker/impl.go:90:34: invalid argument: result.TxRowUsage (variable of type *types.RowUsage) for len
Error: rollup/circuitcapacitychecker/impl.go:91:35: invalid argument: result.AccRowUsage (variable of type *types.RowUsage) for len
```

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
