### PR TITLE
fix: decode subcircuit row usage as integer

### DIFF
--- a/core/types/gen_row_consumption_json.go
+++ b/core/types/gen_row_consumption_json.go
@@ -5,29 +5,25 @@ package types
 import (
 	"encoding/json"
 	"errors"
-
-	"github.com/scroll-tech/go-ethereum/common/hexutil"
 )
-
-var _ = (*subCircuitRowUsageMarshaling)(nil)
 
 // MarshalJSON marshals as JSON.
 func (s SubCircuitRowUsage) MarshalJSON() ([]byte, error) {
 	type SubCircuitRowUsage struct {
-		Name      string         `json:"name" gencodec:"required"`
-		RowNumber hexutil.Uint64 `json:"row_number" gencodec:"required"`
+		Name      string `json:"name" gencodec:"required"`
+		RowNumber uint64 `json:"row_number" gencodec:"required"`
 	}
 	var enc SubCircuitRowUsage
 	enc.Name = s.Name
-	enc.RowNumber = hexutil.Uint64(s.RowNumber)
+	enc.RowNumber = s.RowNumber
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (s *SubCircuitRowUsage) UnmarshalJSON(input []byte) error {
 	type SubCircuitRowUsage struct {
-		Name      *string         `json:"name" gencodec:"required"`
-		RowNumber *hexutil.Uint64 `json:"row_number" gencodec:"required"`
+		Name      *string `json:"name" gencodec:"required"`
+		RowNumber *uint64 `json:"row_number" gencodec:"required"`
 	}
 	var dec SubCircuitRowUsage
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -40,6 +36,6 @@ func (s *SubCircuitRowUsage) UnmarshalJSON(input []byte) error {
 	if dec.RowNumber == nil {
 		return errors.New("missing required field 'row_number' for SubCircuitRowUsage")
 	}
-	s.RowNumber = uint64(*dec.RowNumber)
+	s.RowNumber = *dec.RowNumber
 	return nil
 }

--- a/core/types/row_consumption.go
+++ b/core/types/row_consumption.go
@@ -1,24 +1,15 @@
 package types
 
-import (
-	"github.com/scroll-tech/go-ethereum/common/hexutil"
-)
-
 type RowUsage struct {
 	IsOk            bool                 `json:"is_ok"`
 	RowNumber       uint64               `json:"row_number"`
 	RowUsageDetails []SubCircuitRowUsage `json:"row_usage_details"`
 }
 
-//go:generate gencodec -type SubCircuitRowUsage -field-override subCircuitRowUsageMarshaling -out gen_row_consumption_json.go
+//go:generate gencodec -type SubCircuitRowUsage -out gen_row_consumption_json.go
 type SubCircuitRowUsage struct {
 	Name      string `json:"name" gencodec:"required"`
 	RowNumber uint64 `json:"row_number" gencodec:"required"`
 }
 
 type RowConsumption []SubCircuitRowUsage
-
-// field type overrides for gencodec
-type subCircuitRowUsageMarshaling struct {
-	RowNumber hexutil.Uint64
-}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 4         // Patch version component of the current release
+	VersionPatch = 5         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Decode `RowNumber` as `uint64`. Previously it failed with this error:

```
ERROR[08-02|03:28:01.816] fail to json unmarshal apply_tx result   id=1                TxHash=0xff74e3fde6f99d13bf567da2963d16239fef68f8746f4c3915645beeb3e45fe4 err="json: cannot unmarshal non-string into Go struct field RowUsage.acc_row_usage.row_usage_details of type hexutil.Uint64"
```


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
