### PR TITLE
refactor(ccc): log ccc error in Rust

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 5         // Patch version component of the current release
+	VersionPatch = 6         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/src/lib.rs
+++ b/rollup/circuitcapacitychecker/libzkp/src/lib.rs
@@ -79,10 +79,10 @@ pub mod checker {
                     )
                 })
                 .estimate_circuit_capacity(&[traces.clone()])
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
                     panic!(
-                        "id: {:?}, fail to estimate_circuit_capacity in apply_tx, block_hash: {:?}, tx_hash: {:?}",
-                        id, traces.header.hash, traces.transactions[0].tx_hash
+                        "id: {:?}, fail to estimate_circuit_capacity in apply_tx, block_hash: {:?}, tx_hash: {:?}, error: {:?}",
+                        id, traces.header.hash, traces.transactions[0].tx_hash, e
                     )
                 })
         });
@@ -126,10 +126,10 @@ pub mod checker {
                     )
                 })
                 .estimate_circuit_capacity(&[traces.clone()])
-                .unwrap_or_else(|_| {
+                .unwrap_or_else(|e| {
                     panic!(
-                        "id: {:?}, fail to estimate_circuit_capacity in apply_block, block_hash: {:?}",
-                        id, traces.header.hash
+                        "id: {:?}, fail to estimate_circuit_capacity in apply_block, block_hash: {:?}, error: {:?}",
+                        id, traces.header.hash, e
                     )
                 })
         });


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Currently we panic without logging the actual error, e.g.

```
ERROR[08-02|05:08:30.134] fail to apply_tx in CircuitCapacityChecker id=1                TxHash=0xff74e3fde6f99d13bf567da2963d16239fef68f8746f4c3915645beeb3e45fe4 err="Any { .. }"
[2023-08-02T05:08:30.156Z DEBUG prover::zkevm::circuit::builder] building partial statedb
thread '<unnamed>' panicked at 'id: 1, fail to estimate_circuit_capacity in apply_tx, block_hash: Some(0x9b482058300008067a24ba84ae8136312985908f79c150ad2d9c13abd08a127b), tx_hash: 0xff74e3fde6f99d13bf567da2963d16239fef68f8746f4c3915645beeb3e45fe4', src/lib.rs:83:21
```


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
