### PR TITLE
fix(worker): set row consumption for genesis and empty blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -280,6 +280,9 @@ func NewBlockChain(db ethdb.Database, cacheConfig *CacheConfig, chainConfig *par
 	// initialize L1 message index for genesis block
 	rawdb.WriteFirstQueueIndexNotInL2Block(db, bc.genesisBlock.Hash(), 0)
 
+	// initialize row consumption for genesis block
+	rawdb.WriteBlockRowConsumption(db, bc.genesisBlock.Hash(), &types.RowConsumption{})
+
 	var nilBlock *types.Block
 	bc.currentBlock.Store(nilBlock)
 	bc.currentFastBlock.Store(nilBlock)
@@ -699,6 +702,7 @@ func (bc *BlockChain) ResetWithGenesisBlock(genesis *types.Block) error {
 	rawdb.WriteTd(batch, genesis.Hash(), genesis.NumberU64(), genesis.Difficulty())
 	rawdb.WriteBlock(batch, genesis)
 	rawdb.WriteFirstQueueIndexNotInL2Block(batch, genesis.Hash(), 0)
+	rawdb.WriteBlockRowConsumption(batch, genesis.Hash(), &types.RowConsumption{})
 	if err := batch.Write(); err != nil {
 		log.Crit("Failed to write genesis block", "err", err)
 	}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -353,6 +353,7 @@ func (g *Genesis) Commit(db ethdb.Database) (*types.Block, error) {
 	rawdb.WriteHeadHeaderHash(db, block.Hash())
 	rawdb.WriteChainConfig(db, block.Hash(), config)
 	rawdb.WriteFirstQueueIndexNotInL2Block(db, block.Hash(), 0)
+	rawdb.WriteBlockRowConsumption(db, block.Hash(), &types.RowConsumption{})
 	return block, nil
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -768,6 +768,9 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 	env.l1TxCount = 0
 	env.maxL1Index = 0
 
+	// make sure accRows is not nil, even for empty blocks
+	env.accRows = &types.RowConsumption{}
+
 	// Swap out the old work with the new one, terminating any leftover prefetcher
 	// processes in the mean time and starting a new one.
 	if w.current != nil && w.current.state != nil {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 8         // Patch version component of the current release
+	VersionPatch = 9         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Make sure that genesis and empty blocks all have row consumption set in DB.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
