### PR TITLE
fix: do not reuse same snapshot twice

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -853,6 +853,8 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 
 	// revert to snapshot for calling `core.ApplyMessage` again, (both `traceEnv.GetBlockTrace` & `core.ApplyTransaction` will call `core.ApplyMessage`)
 	w.current.state.RevertToSnapshot(snap)
+	// create new snapshot for `core.ApplyTransaction`
+	snap = w.current.state.Snapshot()
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 15        // Patch version component of the current release
+	VersionPatch = 16        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Previously in `worker.go`, we created a snapshot, we traced the tx, reverted to the snapshot, and executed the transaction. If the execution fails, we'd try to revert to the same snapshot again, which would lead to errors like

```
panic: revision id 27 cannot be reverted
```

In this PR we create a new snapshot for the actual transaction execution.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
