### PR TITLE
fix: use correct hash for ccc write in worker

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -111,7 +111,8 @@ func (v *BlockValidator) ValidateBody(block *types.Block) error {
 		log.Trace(
 			"Validator write block row consumption",
 			"id", v.circuitCapacityChecker.ID,
-			"sealHash", block.Hash().String(),
+			"number", block.NumberU64(),
+			"hash", block.Hash().String(),
 			"rowConsumption", rowConsumption,
 		)
 		rawdb.WriteBlockRowConsumption(v.db, block.Hash(), rowConsumption)
@@ -272,7 +273,7 @@ func (v *BlockValidator) validateCircuitRowConsumption(block *types.Block) (*typ
 	log.Trace(
 		"Validator apply ccc for block",
 		"id", v.circuitCapacityChecker.ID,
-		"number", block.Number(),
+		"number", block.NumberU64(),
 		"hash", block.Hash().String(),
 		"len(txs)", block.Transactions().Len(),
 	)
@@ -291,13 +292,13 @@ func (v *BlockValidator) validateCircuitRowConsumption(block *types.Block) (*typ
 	defer v.cMu.Unlock()
 
 	v.circuitCapacityChecker.Reset()
-	log.Trace("Validator reset ccc")
+	log.Trace("Validator reset ccc", "id", v.circuitCapacityChecker.ID)
 	rc, err := v.circuitCapacityChecker.ApplyBlock(traces)
 
 	log.Trace(
 		"Validator apply ccc for block result",
 		"id", v.circuitCapacityChecker.ID,
-		"number", block.Number(),
+		"number", block.NumberU64(),
 		"hash", block.Hash().String(),
 		"len(txs)", block.Transactions().Len(),
 		"rc", rc,

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 17        // Patch version component of the current release
+	VersionPatch = 18        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Previously we used `sealHash` to write to DB. However, the correct block hash is the one after sealing. To use this, this PR moved DB updates from `taskLoop` to `resultLoop`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
