### PR TITLE
fix: correctly initialize ZkTrieTracer for ccc

### DIFF
--- a/core/trace.go
+++ b/core/trace.go
@@ -337,10 +337,12 @@ func (env *TraceEnv) getTxResult(state *state.StateDB, index int, block *types.B
 			if !existed {
 				m = make(map[string][]hexutil.Bytes)
 				env.StorageProofs[addrStr] = m
-				if zktrieTracer.Available() {
-					env.ZkTrieTracer[addrStr] = state.NewProofTracer(trie)
-				}
-			} else if proof, existed := m[keyStr]; existed {
+			}
+			if zktrieTracer.Available() && !env.ZkTrieTracer[addrStr].Available() {
+				env.ZkTrieTracer[addrStr] = state.NewProofTracer(trie)
+			}
+
+			if proof, existed := m[keyStr]; existed {
 				txm[keyStr] = proof
 				// still need to touch tracer for deletion
 				if isDelete && zktrieTracer.Available() {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 19        // Patch version component of the current release
+	VersionPatch = 20        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
The `traceEnv` in capacity checker would be used for outputing mutiple block traces and the storage proof of [some instrinsic proof s would be added](https://github.com/scroll-tech/go-ethereum/blob/53963e6171e62f7cf8c602500881260f4ed040ec/core/trace.go#L407) after one block trace has been output. This may [block the initialization of zktrietracer](https://github.com/scroll-tech/go-ethereum/blob/53963e6171e62f7cf8c602500881260f4ed040ec/core/trace.go#L336) in the next block and cause a panic