### PR TITLE
fix: do not overwrite correct L1 index on signer startup

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1186,9 +1186,28 @@ func (bc *BlockChain) writeBlockWithoutState(block *types.Block, td *big.Int) (e
 	// note: we can insert blocks with header-only ancestors here,
 	// so queueIndex might not yet be available in DB.
 	if queueIndex != nil {
+		numProcessed := block.NumL1MessagesProcessed(*queueIndex)
 		// do not overwrite the index written by the miner worker
 		if index := rawdb.ReadFirstQueueIndexNotInL2Block(bc.db, block.Hash()); index == nil {
-			rawdb.WriteFirstQueueIndexNotInL2Block(batch, block.Hash(), *queueIndex+uint64(block.NumL1MessagesProcessed(*queueIndex)))
+			newIndex := *queueIndex + uint64(block.NumL1MessagesProcessed(*queueIndex))
+			log.Trace(
+				"Blockchain.writeBlockWithoutState WriteFirstQueueIndexNotInL2Block",
+				"number", block.Number(),
+				"hash", block.Hash().String(),
+				"queueIndex", *queueIndex,
+				"numProcessed", numProcessed,
+				"newIndex", newIndex,
+			)
+			rawdb.WriteFirstQueueIndexNotInL2Block(batch, block.Hash(), newIndex)
+		} else {
+			log.Trace(
+				"Blockchain.writeBlockWithoutState WriteFirstQueueIndexNotInL2Block: not overwriting existing index",
+				"number", block.Number(),
+				"hash", block.Hash().String(),
+				"queueIndex", *queueIndex,
+				"numProcessed", numProcessed,
+				"index", *index,
+			)
 		}
 	}
 
@@ -1253,9 +1272,28 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		// so the parent will always be inserted first.
 		log.Crit("Queue index in DB is nil", "parent", block.ParentHash(), "hash", block.Hash())
 	}
+	numProcessed := block.NumL1MessagesProcessed(*queueIndex)
 	// do not overwrite the index written by the miner worker
 	if index := rawdb.ReadFirstQueueIndexNotInL2Block(bc.db, block.Hash()); index == nil {
-		rawdb.WriteFirstQueueIndexNotInL2Block(blockBatch, block.Hash(), *queueIndex+uint64(block.NumL1MessagesProcessed(*queueIndex)))
+		newIndex := *queueIndex + uint64(block.NumL1MessagesProcessed(*queueIndex))
+		log.Trace(
+			"Blockchain.writeBlockWithState WriteFirstQueueIndexNotInL2Block",
+			"number", block.Number(),
+			"hash", block.Hash().String(),
+			"queueIndex", *queueIndex,
+			"numProcessed", numProcessed,
+			"newIndex", newIndex,
+		)
+		rawdb.WriteFirstQueueIndexNotInL2Block(blockBatch, block.Hash(), newIndex)
+	} else {
+		log.Trace(
+			"Blockchain.writeBlockWithState WriteFirstQueueIndexNotInL2Block: not overwriting existing index",
+			"number", block.Number(),
+			"hash", block.Hash().String(),
+			"queueIndex", *queueIndex,
+			"numProcessed", numProcessed,
+			"index", *index,
+		)
 	}
 
 	if err := blockBatch.Write(); err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1186,10 +1186,10 @@ func (bc *BlockChain) writeBlockWithoutState(block *types.Block, td *big.Int) (e
 	// note: we can insert blocks with header-only ancestors here,
 	// so queueIndex might not yet be available in DB.
 	if queueIndex != nil {
-		numProcessed := block.NumL1MessagesProcessed(*queueIndex)
+		numProcessed := uint64(block.NumL1MessagesProcessed(*queueIndex))
 		// do not overwrite the index written by the miner worker
 		if index := rawdb.ReadFirstQueueIndexNotInL2Block(bc.db, block.Hash()); index == nil {
-			newIndex := *queueIndex + uint64(block.NumL1MessagesProcessed(*queueIndex))
+			newIndex := *queueIndex + numProcessed
 			log.Trace(
 				"Blockchain.writeBlockWithoutState WriteFirstQueueIndexNotInL2Block",
 				"number", block.Number(),
@@ -1272,10 +1272,10 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		// so the parent will always be inserted first.
 		log.Crit("Queue index in DB is nil", "parent", block.ParentHash(), "hash", block.Hash())
 	}
-	numProcessed := block.NumL1MessagesProcessed(*queueIndex)
+	numProcessed := uint64(block.NumL1MessagesProcessed(*queueIndex))
 	// do not overwrite the index written by the miner worker
 	if index := rawdb.ReadFirstQueueIndexNotInL2Block(bc.db, block.Hash()); index == nil {
-		newIndex := *queueIndex + uint64(block.NumL1MessagesProcessed(*queueIndex))
+		newIndex := *queueIndex + numProcessed
 		log.Trace(
 			"Blockchain.writeBlockWithState WriteFirstQueueIndexNotInL2Block",
 			"number", block.Number(),

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -705,7 +705,21 @@ func (w *worker) resultLoop() {
 				// Note: This accounts for both included and skipped messages. This
 				// way, if a block only skips messages, we won't reprocess the same
 				// messages from the next block.
+				log.Trace(
+					"Worker WriteFirstQueueIndexNotInL2Block",
+					"number", block.Number(),
+					"hash", hash.String(),
+					"task.nextL1MsgIndex", task.nextL1MsgIndex,
+				)
 				rawdb.WriteFirstQueueIndexNotInL2Block(w.eth.ChainDb(), hash, task.nextL1MsgIndex)
+			} else {
+				log.Trace(
+					"Worker WriteFirstQueueIndexNotInL2Block: not overwriting existing index",
+					"number", block.Number(),
+					"hash", hash.String(),
+					"index", *index,
+					"task.nextL1MsgIndex", task.nextL1MsgIndex,
+				)
 			}
 			// Store circuit row consumption.
 			log.Trace(

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -698,11 +698,15 @@ func (w *worker) resultLoop() {
 				}
 				logs = append(logs, receipt.Logs...)
 			}
-			// Store first L1 queue index not processed by this block.
-			// Note: This accounts for both included and skipped messages. This
-			// way, if a block only skips messages, we won't reprocess the same
-			// messages from the next block.
-			rawdb.WriteFirstQueueIndexNotInL2Block(w.eth.ChainDb(), hash, task.nextL1MsgIndex)
+			// It's possible that we've stored L1 queue index for this block previously,
+			// in this case do not overwrite it.
+			if index := rawdb.ReadFirstQueueIndexNotInL2Block(w.eth.ChainDb(), hash); index == nil {
+				// Store first L1 queue index not processed by this block.
+				// Note: This accounts for both included and skipped messages. This
+				// way, if a block only skips messages, we won't reprocess the same
+				// messages from the next block.
+				rawdb.WriteFirstQueueIndexNotInL2Block(w.eth.ChainDb(), hash, task.nextL1MsgIndex)
+			}
 			// Store circuit row consumption.
 			log.Trace(
 				"Worker write block row consumption",

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 22        // Patch version component of the current release
+	VersionPatch = 23        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 23        // Patch version component of the current release
+	VersionPatch = 24        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

After restarting the signer it sometimes overwrites `FirstQueueIndexNotInL2Block` of the tip block with `0`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
