### PR TITLE
fix: Initialize nextL1MsgIndex before commit

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 24        // Patch version component of the current release
+	VersionPatch = 25        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

- In `commitNewWork`, we initialized `env.nextL1MsgIndex` at [L1210](https://github.com/scroll-tech/go-ethereum/blob/69dd39afbaa612943c701e2f809581df80312d58/miner/worker.go#L1210)
- However, `commit` might be called at [L1200](https://github.com/scroll-tech/go-ethereum/blob/69dd39afbaa612943c701e2f809581df80312d58/miner/worker.go#L1200), in which case `env.nextL1MsgIndex` would be left at its initial value `0`.
- As a result, at [L714](https://github.com/scroll-tech/go-ethereum/blob/69dd39afbaa612943c701e2f809581df80312d58/miner/worker.go#L714), we will set this value to `0` in DB, violating the "L1 message order" consensus rule.

This PR moves `env.nextL1MsgIndex` initialization into `makeCurrent`. This ensures that this value is always properly initialized.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
