### PR TITLE
fix: upgrade libzkp to use scroll-prover `v0.5.6`

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 28        // Patch version component of the current release
+	VersionPatch = 29        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.lock
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "ark-std",
  "env_logger 0.10.0",
@@ -396,7 +396,7 @@ checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -1060,7 +1060,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -1237,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1450,7 +1450,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -1490,7 +1490,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "env_logger 0.9.3",
  "gobuild 0.1.0-alpha.2 (git+https://github.com/scroll-tech/gobuild.git)",
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "env_logger 0.9.3",
  "eth-types",
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2302,7 +2302,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "bus-mapping",
  "eth-types",
@@ -2769,7 +2769,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.4.0"
-source = "git+https://github.com/scroll-tech/scroll-prover?tag=v0.5.3#337089ac40bac756d88b9ae30a3be1f82538b216"
+source = "git+https://github.com/scroll-tech/scroll-prover?tag=v0.5.6#e4ac08a856684de12ce4fe8ce4f3fb7f45f87043"
 dependencies = [
  "aggregator",
  "anyhow",
@@ -4010,7 +4010,7 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 [[package]]
 name = "types"
 version = "0.4.0"
-source = "git+https://github.com/scroll-tech/scroll-prover?tag=v0.5.3#337089ac40bac756d88b9ae30a3be1f82538b216"
+source = "git+https://github.com/scroll-tech/scroll-prover?tag=v0.5.6#e4ac08a856684de12ce4fe8ce4f3fb7f45f87043"
 dependencies = [
  "base64 0.13.1",
  "blake2",
@@ -4486,7 +4486,7 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.3#2c8c749b3e4a61e89028289f4ff93157c5671d7b"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.5.6#aa2d252c260781e5ddfa309b36f7543df68d142e"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.toml
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.toml
@@ -20,8 +20,8 @@ maingate = { git = "https://github.com/scroll-tech/halo2wrong", branch = "halo2-
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves.git", branch = "0.3.1-derive-serde" }
 
 [dependencies]
-prover = { git = "https://github.com/scroll-tech/scroll-prover", tag = "v0.5.3" }
-types = { git = "https://github.com/scroll-tech/scroll-prover", tag = "v0.5.3" }
+prover = { git = "https://github.com/scroll-tech/scroll-prover", tag = "v0.5.6" }
+types = { git = "https://github.com/scroll-tech/scroll-prover", tag = "v0.5.6" }
 
 log = "0.4"
 env_logger = "0.9.0"


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

upgrade libzkp to use scroll-prover `v0.5.6`.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [x] Yes
