### PR TITLE
refactor(trace): wrap the core routine in `CreateTraceEnv`

### DIFF
--- a/core/trace.go
+++ b/core/trace.go
@@ -66,7 +66,7 @@ type txTraceTask struct {
 	index   int
 }
 
-func CreateTraceEnvDirect(chainConfig *params.ChainConfig, logConfig *vm.LogConfig, blockCtx vm.BlockContext, startL1QueueIndex uint64, coinbase common.Address, statedb *state.StateDB, rootBefore common.Hash, block *types.Block, commitAfterApply bool) *TraceEnv {
+func createTraceEnvHelper(chainConfig *params.ChainConfig, logConfig *vm.LogConfig, blockCtx vm.BlockContext, startL1QueueIndex uint64, coinbase common.Address, statedb *state.StateDB, rootBefore common.Hash, block *types.Block, commitAfterApply bool) *TraceEnv {
 	return &TraceEnv{
 		logConfig:        logConfig,
 		commitAfterApply: commitAfterApply,
@@ -116,13 +116,13 @@ func CreateTraceEnv(chainConfig *params.ChainConfig, chainContext ChainContext, 
 		log.Error("missing FirstQueueIndexNotInL2Block for block during trace call", "number", parent.NumberU64(), "hash", parent.Hash())
 		return nil, fmt.Errorf("missing FirstQueueIndexNotInL2Block for block during trace call: hash=%v, parentHash=%vv", block.Hash(), parent.Hash())
 	}
-	env := CreateTraceEnvDirect(
+	env := createTraceEnvHelper(
 		chainConfig,
 		&vm.LogConfig{
 			EnableMemory:     false,
 			EnableReturnData: true,
 		},
-		NewEVMBlockContext(block.Header(), chainContext, nil),
+		NewEVMBlockContext(block.Header(), chainContext, chainConfig, nil),
 		*startL1QueueIndex,
 		coinbase,
 		statedb,

--- a/core/trace.go
+++ b/core/trace.go
@@ -59,12 +59,9 @@ type txTraceTask struct {
 	index   int
 }
 
-func CreateTraceEnvDirect(chainConfig *params.ChainConfig, blockCtx vm.BlockContext, coinbase common.Address, statedb *state.StateDB, rootBefore common.Hash, block *types.Block, commitAfterApply bool) *TraceEnv {
+func CreateTraceEnvDirect(chainConfig *params.ChainConfig, logConfig *vm.LogConfig, blockCtx vm.BlockContext, coinbase common.Address, statedb *state.StateDB, rootBefore common.Hash, block *types.Block, commitAfterApply bool) *TraceEnv {
 	return &TraceEnv{
-		logConfig: &vm.LogConfig{
-			EnableMemory:     false,
-			EnableReturnData: true,
-		},
+		logConfig:        logConfig,
 		commitAfterApply: commitAfterApply,
 		chainConfig:      chainConfig,
 		coinbase:         coinbase,
@@ -97,6 +94,10 @@ func CreateTraceEnv(chainConfig *params.ChainConfig, chainContext ChainContext, 
 
 	env := CreateTraceEnvDirect(
 		chainConfig,
+		&vm.LogConfig{
+			EnableMemory:     false,
+			EnableReturnData: true,
+		},
 		NewEVMBlockContext(block.Header(), chainContext, nil),
 		coinbase,
 		statedb,

--- a/core/trace.go
+++ b/core/trace.go
@@ -66,7 +66,7 @@ type txTraceTask struct {
 	index   int
 }
 
-func createTraceEnvHelper(chainConfig *params.ChainConfig, logConfig *vm.LogConfig, blockCtx vm.BlockContext, startL1QueueIndex uint64, coinbase common.Address, statedb *state.StateDB, rootBefore common.Hash, block *types.Block, commitAfterApply bool) *TraceEnv {
+func CreateTraceEnvHelper(chainConfig *params.ChainConfig, logConfig *vm.LogConfig, blockCtx vm.BlockContext, startL1QueueIndex uint64, coinbase common.Address, statedb *state.StateDB, rootBefore common.Hash, block *types.Block, commitAfterApply bool) *TraceEnv {
 	return &TraceEnv{
 		logConfig:        logConfig,
 		commitAfterApply: commitAfterApply,
@@ -116,7 +116,7 @@ func CreateTraceEnv(chainConfig *params.ChainConfig, chainContext ChainContext, 
 		log.Error("missing FirstQueueIndexNotInL2Block for block during trace call", "number", parent.NumberU64(), "hash", parent.Hash())
 		return nil, fmt.Errorf("missing FirstQueueIndexNotInL2Block for block during trace call: hash=%v, parentHash=%vv", block.Hash(), parent.Hash())
 	}
-	env := createTraceEnvHelper(
+	env := CreateTraceEnvHelper(
 		chainConfig,
 		&vm.LogConfig{
 			EnableMemory:     false,

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 43        // Patch version component of the current release
+	VersionPatch = 44        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
This PR induce a new entry `CreateTraceEnvDirect`, which wrap the core process in `CreateTraceEnv` so developer (the `geth_util` in zkevm-circuit) can use the more `direct` entry for creating the trace enviroment and tailor it later

Regression test has been made by dumping some traces (uniswapv2) and passing the mock prove in supercircuit