### PR TITLE
feat: add startL1QueueIndex field to traces

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -266,7 +266,7 @@ func (v *BlockValidator) createTraceEnv(block *types.Block) (*TraceEnv, error) {
 		return nil, err
 	}
 
-	return CreateTraceEnv(v.config, v.bc, v.engine, statedb, parent, block, true)
+	return CreateTraceEnv(v.config, v.bc, v.engine, v.db, statedb, parent, block, true)
 }
 
 func (v *BlockValidator) validateCircuitRowConsumption(block *types.Block) (*types.RowConsumption, error) {

--- a/core/trace.go
+++ b/core/trace.go
@@ -48,8 +48,8 @@ type TraceEnv struct {
 	ExecutionResults []*types.ExecutionResult
 
 	// StartL1QueueIndex is the next L1 message queue index that this block can process.
-	// Example: If the parent block included QueueIndex=10, then StartL1QueueIndex will
-	// be 11.
+	// Example: If the parent block included QueueIndex=9, then StartL1QueueIndex will
+	// be 10.
 	StartL1QueueIndex uint64
 }
 

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -11,16 +11,17 @@ import (
 
 // BlockTrace contains block execution traces and results required for rollers.
 type BlockTrace struct {
-	ChainID          uint64             `json:"chainID"`
-	Version          string             `json:"version"`
-	Coinbase         *AccountWrapper    `json:"coinbase"`
-	Header           *Header            `json:"header"`
-	Transactions     []*TransactionData `json:"transactions"`
-	StorageTrace     *StorageTrace      `json:"storageTrace"`
-	TxStorageTraces  []*StorageTrace    `json:"txStorageTraces,omitempty"`
-	ExecutionResults []*ExecutionResult `json:"executionResults"`
-	MPTWitness       *json.RawMessage   `json:"mptwitness,omitempty"`
-	WithdrawTrieRoot common.Hash        `json:"withdraw_trie_root,omitempty"`
+	ChainID           uint64             `json:"chainID"`
+	Version           string             `json:"version"`
+	Coinbase          *AccountWrapper    `json:"coinbase"`
+	Header            *Header            `json:"header"`
+	Transactions      []*TransactionData `json:"transactions"`
+	StorageTrace      *StorageTrace      `json:"storageTrace"`
+	TxStorageTraces   []*StorageTrace    `json:"txStorageTraces,omitempty"`
+	ExecutionResults  []*ExecutionResult `json:"executionResults"`
+	MPTWitness        *json.RawMessage   `json:"mptwitness,omitempty"`
+	WithdrawTrieRoot  common.Hash        `json:"withdraw_trie_root,omitempty"`
+	StartL1QueueIndex uint64             `json:"startL1QueueIndex"`
 }
 
 // StorageTrace stores proofs of storage needed by storage circuit

--- a/eth/tracers/api_blocktrace.go
+++ b/eth/tracers/api_blocktrace.go
@@ -65,5 +65,6 @@ func (api *API) createTraceEnv(ctx context.Context, config *TraceConfig, block *
 	if err != nil {
 		return nil, err
 	}
-	return core.CreateTraceEnv(api.backend.ChainConfig(), api.chainContext(ctx), api.backend.Engine(), statedb, parent, block, true)
+	chaindb := api.backend.ChainDb()
+	return core.CreateTraceEnv(api.backend.ChainConfig(), api.chainContext(ctx), api.backend.Engine(), chaindb, statedb, parent, block, true)
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -763,7 +763,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 	// don't commit the state during tracing for circuit capacity checker, otherwise we cannot revert.
 	// and even if we don't commit the state, the `refund` value will still be correct, as explained in `CommitTransaction`
 	commitStateAfterApply := false
-	traceEnv, err := core.CreateTraceEnv(w.chainConfig, w.chain, w.engine, state, parent,
+	traceEnv, err := core.CreateTraceEnv(w.chainConfig, w.chain, w.engine, w.eth.ChainDb(), state, parent,
 		// new block with a placeholder tx, for traceEnv's ExecutionResults length & TxStorageTraces length
 		types.NewBlockWithHeader(header).WithBody([]*types.Transaction{types.NewTx(&types.LegacyTx{})}, nil),
 		commitStateAfterApply)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 33        // Patch version component of the current release
+	VersionPatch = 34        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Add `startL1QueueIndex` field to traces. This value will be used by the provers to calculate `numL1Messages`, which counts both the number of included and skipped L1 messages.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
