### PR TITLE
fix: update worker nextL1MsgIndex for unknown errors

### DIFF
--- a/core/trace.go
+++ b/core/trace.go
@@ -158,7 +158,13 @@ func (env *TraceEnv) GetBlockTrace(block *types.Block) (*types.BlockTrace, error
 					case errCh <- err:
 					default:
 					}
-					log.Error("failed to trace tx", "txHash", txs[task.index].Hash().String())
+					log.Error(
+						"failed to trace tx",
+						"txHash", txs[task.index].Hash().String(),
+						"blockHash", block.Hash().String(),
+						"blockNumber", block.NumberU64(),
+						"err", err,
+					)
 				}
 			}
 		}()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -978,6 +978,7 @@ loop:
 				"expected", w.current.nextL1MsgIndex,
 				"got", tx.AsL1MessageTx().QueueIndex,
 			)
+			break
 		}
 		if !tx.IsL1MessageTx() && !w.chainConfig.Scroll.IsValidBlockSize(w.current.blockSize+tx.Size()) {
 			log.Trace("Block size limit reached", "have", w.current.blockSize, "want", w.chainConfig.Scroll.MaxTxPayloadBytesPerBlock, "tx", tx.Size())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1093,6 +1093,7 @@ loop:
 			if tx.IsL1MessageTx() {
 				queueIndex := tx.AsL1MessageTx().QueueIndex
 				log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "strange error", "err", err)
+				w.current.nextL1MsgIndex = queueIndex + 1
 			}
 			txs.Shift()
 		}

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -732,7 +732,7 @@ func TestL1MsgCorrectOrder(t *testing.T) {
 	}
 }
 
-func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, callback func(i int, block *types.Block, db ethdb.Database) bool) {
+func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, withL2Tx bool, callback func(i int, block *types.Block, db ethdb.Database) bool) {
 	var (
 		engine      consensus.Engine
 		chainConfig *params.ChainConfig
@@ -770,13 +770,19 @@ func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, callback func(i int, 
 	sub := w.mux.Subscribe(core.NewMinedBlockEvent{})
 	defer sub.Unsubscribe()
 
+	if withL2Tx {
+		b.txPool.AddLocal(b.newRandomTx(false))
+	}
+
 	// Start mining!
 	w.start()
 
+	// timeout for all blocks
+	globalTimeout := time.After(3 * time.Second)
+
 	for ii := 1; true; ii++ {
-		// timeout for all blocks
 		select {
-		case <-time.After(3 * time.Second):
+		case <-globalTimeout:
 			t.Fatalf("timeout")
 		default:
 		}
@@ -805,7 +811,7 @@ func TestL1SingleMessageOverGasLimit(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},    // different sender
 	}
 
-	l1MessageTest(t, msgs, func(_i int, block *types.Block, db ethdb.Database) bool {
+	l1MessageTest(t, msgs, false, func(_i int, block *types.Block, db ethdb.Database) bool {
 		// skip #0, include #1 and #2
 		assert.Equal(2, len(block.Transactions()))
 
@@ -834,7 +840,7 @@ func TestL1CombinedMessagesOverGasLimit(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},   // different sender
 	}
 
-	l1MessageTest(t, msgs, func(blockNum int, block *types.Block, db ethdb.Database) bool {
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database) bool {
 		switch blockNum {
 		case 1:
 			// block #1 only includes 1 message
@@ -876,7 +882,7 @@ func TestLargeL1MessageSkipPayloadCheck(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}}, // different sender
 	}
 
-	l1MessageTest(t, msgs, func(blockNum int, block *types.Block, db ethdb.Database) bool {
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database) bool {
 		// include #0, #1 and #2
 		assert.Equal(3, len(block.Transactions()))
 
@@ -888,6 +894,33 @@ func TestLargeL1MessageSkipPayloadCheck(t *testing.T) {
 		assert.Equal(uint64(2), block.Transactions()[2].AsL1MessageTx().QueueIndex)
 
 		// db is updated correctly
+		queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
+		assert.NotNil(queueIndex)
+		assert.Equal(uint64(3), *queueIndex)
+
+		return true
+	})
+}
+
+func TestSkipAllL1MessagesInBlock(t *testing.T) {
+	assert := assert.New(t)
+
+	// messages are skipped because of `Value`
+	// TODO: trigger skipping in some other way after this behaviour is changed
+	msgs := []types.L1MessageTx{
+		{QueueIndex: 0, Gas: 25100, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}, Value: big.NewInt(1)},
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}, Value: big.NewInt(1)},
+		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}, Value: big.NewInt(1)},
+	}
+
+	l1MessageTest(t, msgs, true, func(blockNum int, block *types.Block, db ethdb.Database) bool {
+		// skip all 3 L1 messages, include 1 L2 tx
+		assert.Equal(1, len(block.Transactions()))
+		assert.False(block.Transactions()[0].IsL1MessageTx())
+
+		// db is updated correctly
+		// note: this should return 0 but on the signer we store 3 instead so
+		// that we do not process the same messages again for the next block.
 		queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
 		assert.NotNil(queueIndex)
 		assert.Equal(uint64(3), *queueIndex)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 37        // Patch version component of the current release
+	VersionPatch = 38        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 36        // Patch version component of the current release
+	VersionPatch = 37        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 35        // Patch version component of the current release
+	VersionPatch = 36        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 34        // Patch version component of the current release
+	VersionPatch = 35        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 33        // Patch version component of the current release
+	VersionPatch = 34        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

The worker fails to update `w.current.nextL1MsgIndex` if it encounters an unknown execution error. This would lead to `"Unexpected L1 message queue index in worker"`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
