### PR TITLE
fix: seal block if single tx overflows

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -273,6 +273,12 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	return worker
 }
 
+// getCCC returns a pointer to this worker's CCC instance.
+// Only used in tests.
+func (w *worker) getCCC() *circuitcapacitychecker.CircuitCapacityChecker {
+	return w.circuitCapacityChecker
+}
+
 // setEtherbase sets the etherbase used to initialize the block coinbase field.
 func (w *worker) setEtherbase(addr common.Address) {
 	w.mu.Lock()
@@ -1065,13 +1071,23 @@ loop:
 			log.Trace("Circuit capacity limit reached for a single tx", "tx", tx.Hash().String(), "queueIndex", queueIndex)
 			log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "row consumption overflow")
 			w.current.nextL1MsgIndex = queueIndex + 1
-			txs.Shift()
+
+			// after `ErrTxRowConsumptionOverflow`, ccc might not revert updates
+			// associated with this transaction so we cannot pack more transactions.
+			// TODO: fix this in ccc and change these lines back to `txs.Shift()`
+			circuitCapacityReached = true
+			break loop
 
 		case (errors.Is(err, circuitcapacitychecker.ErrTxRowConsumptionOverflow) && !tx.IsL1MessageTx()):
 			// Circuit capacity check: L2MessageTx row consumption too high, skip the account.
 			// This is also useful for skipping "problematic" L2MessageTxs.
 			log.Trace("Circuit capacity limit reached for a single tx", "tx", tx.Hash().String())
-			txs.Pop()
+
+			// after `ErrTxRowConsumptionOverflow`, ccc might not revert updates
+			// associated with this transaction so we cannot pack more transactions.
+			// TODO: fix this in ccc and change these lines back to `txs.Pop()`
+			circuitCapacityReached = true
+			break loop
 
 		case (errors.Is(err, circuitcapacitychecker.ErrUnknown) && tx.IsL1MessageTx()):
 			// Circuit capacity check: unknown circuit capacity checker error for L1MessageTx,
@@ -1080,12 +1096,22 @@ loop:
 			log.Trace("Unknown circuit capacity checker error for L1MessageTx", "tx", tx.Hash().String(), "queueIndex", queueIndex)
 			log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			w.current.nextL1MsgIndex = queueIndex + 1
-			txs.Shift()
+
+			// after `ErrUnknown`, ccc might not revert updates associated
+			// with this transaction so we cannot pack more transactions.
+			// TODO: fix this in ccc and change these lines back to `txs.Shift()`
+			circuitCapacityReached = true
+			break loop
 
 		case (errors.Is(err, circuitcapacitychecker.ErrUnknown) && !tx.IsL1MessageTx()):
 			// Circuit capacity check: unknown circuit capacity checker error for L2MessageTx, skip the account
 			log.Trace("Unknown circuit capacity checker error for L2MessageTx", "tx", tx.Hash().String())
-			txs.Pop()
+
+			// after `ErrUnknown`, ccc might not revert updates associated
+			// with this transaction so we cannot pack more transactions.
+			// TODO: fix this in ccc and change these lines back to `txs.Pop()`
+			circuitCapacityReached = true
+			break loop
 
 		default:
 			// Strange error, discard the transaction and get the next in line (note, the

--- a/miner/worker_test.go
+++ b/miner/worker_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/ethdb"
 	"github.com/scroll-tech/go-ethereum/event"
 	"github.com/scroll-tech/go-ethereum/params"
+	"github.com/scroll-tech/go-ethereum/rollup/circuitcapacitychecker"
 	"github.com/scroll-tech/go-ethereum/rollup/sync_service"
 )
 
@@ -732,7 +733,7 @@ func TestL1MsgCorrectOrder(t *testing.T) {
 	}
 }
 
-func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, withL2Tx bool, callback func(i int, block *types.Block, db ethdb.Database) bool) {
+func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, withL2Tx bool, callback func(i int, block *types.Block, db ethdb.Database, w *worker) bool) {
 	var (
 		engine      consensus.Engine
 		chainConfig *params.ChainConfig
@@ -777,6 +778,9 @@ func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, withL2Tx bool, callba
 	// Start mining!
 	w.start()
 
+	// call once before first block
+	callback(0, nil, db, w)
+
 	// timeout for all blocks
 	globalTimeout := time.After(3 * time.Second)
 
@@ -790,8 +794,8 @@ func l1MessageTest(t *testing.T, msgs []types.L1MessageTx, withL2Tx bool, callba
 		select {
 		case ev := <-sub.Chan():
 			block := ev.Data.(core.NewMinedBlockEvent).Block
-			// TODO
-			if callback(ii, block, db) {
+
+			if done := callback(ii, block, db, w); done {
 				return
 			}
 
@@ -811,21 +815,28 @@ func TestL1SingleMessageOverGasLimit(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},    // different sender
 	}
 
-	l1MessageTest(t, msgs, false, func(_i int, block *types.Block, db ethdb.Database) bool {
-		// skip #0, include #1 and #2
-		assert.Equal(2, len(block.Transactions()))
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database, w *worker) bool {
+		switch blockNum {
+		case 0:
+			return false
+		case 1:
+			// skip #0, include #1 and #2
+			assert.Equal(2, len(block.Transactions()))
 
-		assert.True(block.Transactions()[0].IsL1MessageTx())
-		assert.Equal(uint64(1), block.Transactions()[0].AsL1MessageTx().QueueIndex)
-		assert.True(block.Transactions()[1].IsL1MessageTx())
-		assert.Equal(uint64(2), block.Transactions()[1].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[0].IsL1MessageTx())
+			assert.Equal(uint64(1), block.Transactions()[0].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[1].IsL1MessageTx())
+			assert.Equal(uint64(2), block.Transactions()[1].AsL1MessageTx().QueueIndex)
 
-		// db is updated correctly
-		queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
-		assert.NotNil(queueIndex)
-		assert.Equal(uint64(3), *queueIndex)
+			// db is updated correctly
+			queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
+			assert.NotNil(queueIndex)
+			assert.Equal(uint64(3), *queueIndex)
 
-		return true
+			return true
+		default:
+			return true
+		}
 	})
 }
 
@@ -840,8 +851,10 @@ func TestL1CombinedMessagesOverGasLimit(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},   // different sender
 	}
 
-	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database) bool {
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database, w *worker) bool {
 		switch blockNum {
+		case 0:
+			return false
 		case 1:
 			// block #1 only includes 1 message
 			assert.Equal(1, len(block.Transactions()))
@@ -882,23 +895,30 @@ func TestLargeL1MessageSkipPayloadCheck(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}}, // different sender
 	}
 
-	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database) bool {
-		// include #0, #1 and #2
-		assert.Equal(3, len(block.Transactions()))
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database, w *worker) bool {
+		switch blockNum {
+		case 0:
+			return false
+		case 1:
+			// include #0, #1 and #2
+			assert.Equal(3, len(block.Transactions()))
 
-		assert.True(block.Transactions()[0].IsL1MessageTx())
-		assert.Equal(uint64(0), block.Transactions()[0].AsL1MessageTx().QueueIndex)
-		assert.True(block.Transactions()[1].IsL1MessageTx())
-		assert.Equal(uint64(1), block.Transactions()[1].AsL1MessageTx().QueueIndex)
-		assert.True(block.Transactions()[2].IsL1MessageTx())
-		assert.Equal(uint64(2), block.Transactions()[2].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[0].IsL1MessageTx())
+			assert.Equal(uint64(0), block.Transactions()[0].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[1].IsL1MessageTx())
+			assert.Equal(uint64(1), block.Transactions()[1].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[2].IsL1MessageTx())
+			assert.Equal(uint64(2), block.Transactions()[2].AsL1MessageTx().QueueIndex)
 
-		// db is updated correctly
-		queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
-		assert.NotNil(queueIndex)
-		assert.Equal(uint64(3), *queueIndex)
+			// db is updated correctly
+			queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
+			assert.NotNil(queueIndex)
+			assert.Equal(uint64(3), *queueIndex)
 
-		return true
+			return true
+		default:
+			return true
+		}
 	})
 }
 
@@ -913,22 +933,29 @@ func TestSkipMessageWithStrangeError(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},
 	}
 
-	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database) bool {
-		// skip #0, include #1 and #2
-		assert.Equal(2, len(block.Transactions()))
-		assert.True(block.Transactions()[0].IsL1MessageTx())
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database, w *worker) bool {
+		switch blockNum {
+		case 0:
+			return false
+		case 1:
+			// skip #0, include #1 and #2
+			assert.Equal(2, len(block.Transactions()))
+			assert.True(block.Transactions()[0].IsL1MessageTx())
 
-		assert.True(block.Transactions()[0].IsL1MessageTx())
-		assert.Equal(uint64(1), block.Transactions()[0].AsL1MessageTx().QueueIndex)
-		assert.True(block.Transactions()[1].IsL1MessageTx())
-		assert.Equal(uint64(2), block.Transactions()[1].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[0].IsL1MessageTx())
+			assert.Equal(uint64(1), block.Transactions()[0].AsL1MessageTx().QueueIndex)
+			assert.True(block.Transactions()[1].IsL1MessageTx())
+			assert.Equal(uint64(2), block.Transactions()[1].AsL1MessageTx().QueueIndex)
 
-		// db is updated correctly
-		queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
-		assert.NotNil(queueIndex)
-		assert.Equal(uint64(3), *queueIndex)
+			// db is updated correctly
+			queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
+			assert.NotNil(queueIndex)
+			assert.Equal(uint64(3), *queueIndex)
 
-		return true
+			return true
+		default:
+			return false
+		}
 	})
 }
 
@@ -943,18 +970,59 @@ func TestSkipAllL1MessagesInBlock(t *testing.T) {
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}, Value: big.NewInt(1)},
 	}
 
-	l1MessageTest(t, msgs, true, func(blockNum int, block *types.Block, db ethdb.Database) bool {
-		// skip all 3 L1 messages, include 1 L2 tx
-		assert.Equal(1, len(block.Transactions()))
-		assert.False(block.Transactions()[0].IsL1MessageTx())
+	l1MessageTest(t, msgs, true, func(blockNum int, block *types.Block, db ethdb.Database, w *worker) bool {
+		switch blockNum {
+		case 0:
+			return false
+		case 1:
+			// skip all 3 L1 messages, include 1 L2 tx
+			assert.Equal(1, len(block.Transactions()))
+			assert.False(block.Transactions()[0].IsL1MessageTx())
 
-		// db is updated correctly
-		// note: this should return 0 but on the signer we store 3 instead so
-		// that we do not process the same messages again for the next block.
-		queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
-		assert.NotNil(queueIndex)
-		assert.Equal(uint64(3), *queueIndex)
+			// db is updated correctly
+			// note: this should return 0 but on the signer we store 3 instead so
+			// that we do not process the same messages again for the next block.
+			queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
+			assert.NotNil(queueIndex)
+			assert.Equal(uint64(3), *queueIndex)
 
-		return true
+			return true
+		default:
+			return true
+		}
+	})
+}
+
+func TestOversizedTxThenNormal(t *testing.T) {
+	assert := assert.New(t)
+
+	msgs := []types.L1MessageTx{
+		{QueueIndex: 0, Gas: 25100, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},
+	}
+
+	l1MessageTest(t, msgs, false, func(blockNum int, block *types.Block, db ethdb.Database, w *worker) bool {
+		switch blockNum {
+		case 0:
+			// schedule to skip 2nd call to ccc
+			w.getCCC().ScheduleError(2, circuitcapacitychecker.ErrTxRowConsumptionOverflow)
+			return false
+		case 1:
+			// include #0, skip #1, then terminate
+			assert.Equal(1, len(block.Transactions()))
+
+			assert.True(block.Transactions()[0].IsL1MessageTx())
+			assert.Equal(uint64(0), block.Transactions()[0].AsL1MessageTx().QueueIndex)
+
+			// db is updated correctly
+			queueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(db, block.Hash())
+			assert.NotNil(queueIndex)
+			assert.Equal(uint64(2), *queueIndex)
+
+			return true
+		default:
+			return true
+		}
 	})
 }

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 38        // Patch version component of the current release
+	VersionPatch = 39        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

After we run `ccc` and get an error, we revert all state changes:

https://github.com/scroll-tech/go-ethereum/blob/626ae08ebf39004b04c42cc09a760f4c98f83d98/miner/worker.go#L893-L898

However, `ccc` internally maintains some state that is not reverted. As a result, if we continue to add txs to the block, we get such errors:

```
thread '<unnamed>' panicked at 'inconsistent sload: step proof 1766847170092282960410376565589572629199724816441630535569796515255295180, local statedb 1766847170092282936596459892185702160975285250786472294303038209972465637, result 1766847170092282960410376565589572629199724816441630535569796515255295180 in contract 0x4a23db3b8ddc60cde5f90f0734c9fd15cbadd27c, key 0', /root/.cargo/git/checkouts/zkevm-circuits-462c2cba34f9b301/87cae11/bus-mapping/src/evm/opcodes/sload.rs:67:17
...
TRACE[08-17|03:29:28.667] Unknown circuit capacity checker error for L2MessageTx tx=0x3ab635dce7c255a976ff48e7bd0e6490d25bd27abec496efae9a1d398ea833a1
```

This leads to discarding transactions unnecessarily. This PR changes the behaviour so that the `worker` does not continue to block any more transactions after a ccc error. We can change back to the original behaviour once this is fixed in the ccc.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
