### PR TITLE
feat(sdk): support compressed response

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -54,6 +54,11 @@ func NewClient(c *rpc.Client) *Client {
 	return &Client{c}
 }
 
+// SetHeader expose the function, in able to set http header.
+func (ec *Client) SetHeader(key, value string) {
+	ec.c.SetHeader(key, value)
+}
+
 func (ec *Client) Close() {
 	ec.c.Close()
 }

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -203,7 +203,7 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	}
 
 	// if encoding is set use it.
-	return newDecodeCompression(req.Header.Get("Accept-Encoding"), resp.Body)
+	return newDecodeCompression(resp.Header.Get("Content-Encoding"), resp.Body)
 }
 
 // httpServerConn turns a HTTP connection into a Conn.
@@ -223,12 +223,12 @@ func newDecodeCompression(decoding string, rc io.ReadCloser) (io.ReadCloser, err
 			return nil, err
 		}
 		res = gz
-	case "zlib", "deflate":
-		zb, err := zlib.NewReader(rc)
+	case "deflate":
+		zl, err := zlib.NewReader(rc)
 		if err != nil {
 			return nil, err
 		}
-		res = zb
+		res = zl
 	default:
 		res = rc
 	}

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -231,7 +231,7 @@ func newEncodeCompression(encoding string, w io.Writer) io.Writer {
 
 func newDecodeCompression(decoding string, rc io.ReadCloser) (io.ReadCloser, error) {
 	tps := strings.Split(strings.TrimSpace(strings.ToLower(decoding)), ",")
-	var res = rc
+	var res io.ReadCloser
 	switch tps[0] {
 	case "gzip":
 		gz, err := gzip.NewReader(rc)


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Enable use compression algorithm, support: gzip, zlib(deflate)
i.g:

- use curl:

`
curl --location 'http://localhost:8545' -H 'Content-Type: application/json' --compressed --data '{"jsonrpc": "2.0", "method": "scroll_getBlockTraceByNumberOrHash","params": ["0x2ca4"],"id": 1}' -v -w '%{size_download}'
`

- use by SDK:

`
client, err := ethclient.Dial("http://localhost:8545")

assert.NoError(t, err)

client.SetHeader("Accept-Encoding", "gzip")
`

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
