### PR TITLE
fix: disable commitNewWork on follower nodes

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1159,6 +1159,10 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
+	if !w.isRunning() {
+		return
+	}
+
 	tstart := time.Now()
 	parent := w.chain.CurrentBlock()
 	w.circuitCapacityChecker.Reset()

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 40        // Patch version component of the current release
+	VersionPatch = 41        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Running `commitNewWork` on follower node leads to multiple CCC-related issues, including

```
thread '<unnamed>' panicked at 'inconsistent sload: step proof 3753, local statedb 3754, result 3753 in contract 0x5300000000000000000000000000000000000000, key 1', /root/.cargo/git/checkouts/zkevm-circuits-462c2cba34f9b301/5af677c/bus-mapping/src/evm/opcodes/sload.rs:67:17
```

and

```
"thread '<unnamed>' panicked at 'not implemented: deployment collision at 0x5c7be735f3a9239abd0b59d5835e3cf8876d7141, account Account { nonce: 1, balance: 0, storage: {0: 35940223813451288888154746062574522564772172934997231769793101789348069638182, 1: 37680265890343619592812265685783106969967569747917633321368323638165336227848}, code_hash: 0x1fedc402d47b1949d64731348225a794ab0defa0c8f559005977c5a0c2175987, keccak_code_hash: 0xfcbd231b725e7e6514e69ab4e8b31b6786cf7ed988a247e11c9fdef5120eb1e2, code_size: 9514 }', /root/.cargo/git/checkouts/zkevm-circuits-462c2cba34f9b301/87cae11/bus-mapping/src/evm/opcodes.rs:639:9"
```


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
