### PR TITLE
fix: enable worker but skip CCC on follower nodes

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -914,9 +914,10 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 
 		// revert to snapshot for calling `core.ApplyMessage` again, (both `traceEnv.GetBlockTrace` & `core.ApplyTransaction` will call `core.ApplyMessage`)
 		w.current.state.RevertToSnapshot(snap)
-		// create new snapshot for `core.ApplyTransaction`
-		snap = w.current.state.Snapshot()
 	}
+
+	// create new snapshot for `core.ApplyTransaction`
+	snap = w.current.state.Snapshot()
 
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -873,11 +873,12 @@ func (w *worker) updateSnapshot() {
 }
 
 func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Address) ([]*types.Log, error) {
-	snap := w.current.state.Snapshot()
 	var accRows *types.RowConsumption
 
 	// do not do CCC checks on follower nodes
 	if w.isRunning() {
+		snap := w.current.state.Snapshot()
+
 		log.Trace(
 			"Worker apply ccc for tx",
 			"id", w.circuitCapacityChecker.ID,
@@ -917,7 +918,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	}
 
 	// create new snapshot for `core.ApplyTransaction`
-	snap = w.current.state.Snapshot()
+	snap := w.current.state.Snapshot()
 
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -874,45 +874,50 @@ func (w *worker) updateSnapshot() {
 
 func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Address) ([]*types.Log, error) {
 	snap := w.current.state.Snapshot()
+	var accRows *types.RowConsumption
 
-	log.Trace(
-		"Worker apply ccc for tx",
-		"id", w.circuitCapacityChecker.ID,
-		"txhash", tx.Hash(),
-	)
+	// do not do CCC checks on follower nodes
+	if w.isRunning() {
+		log.Trace(
+			"Worker apply ccc for tx",
+			"id", w.circuitCapacityChecker.ID,
+			"txhash", tx.Hash(),
+		)
 
-	// 1. we have to check circuit capacity before `core.ApplyTransaction`,
-	// because if the tx can be successfully executed but circuit capacity overflows, it will be inconvenient to revert.
-	// 2. even if we don't commit to the state during the tracing (which means `clearJournalAndRefund` is not called during the tracing),
-	// the `refund` value will still be correct, because:
-	// 2.1 when starting handling the first tx, `state.refund` is 0 by default,
-	// 2.2 after tracing, the state is either committed in `core.ApplyTransaction`, or reverted, so the `state.refund` can be cleared,
-	// 2.3 when starting handling the following txs, `state.refund` comes as 0
-	traces, err := w.current.traceEnv.GetBlockTrace(
-		types.NewBlockWithHeader(w.current.header).WithBody([]*types.Transaction{tx}, nil),
-	)
-	if err != nil {
-		// `w.current.traceEnv.State` & `w.current.state` share a same pointer to the state, so only need to revert `w.current.state`
+		// 1. we have to check circuit capacity before `core.ApplyTransaction`,
+		// because if the tx can be successfully executed but circuit capacity overflows, it will be inconvenient to revert.
+		// 2. even if we don't commit to the state during the tracing (which means `clearJournalAndRefund` is not called during the tracing),
+		// the `refund` value will still be correct, because:
+		// 2.1 when starting handling the first tx, `state.refund` is 0 by default,
+		// 2.2 after tracing, the state is either committed in `core.ApplyTransaction`, or reverted, so the `state.refund` can be cleared,
+		// 2.3 when starting handling the following txs, `state.refund` comes as 0
+		traces, err := w.current.traceEnv.GetBlockTrace(
+			types.NewBlockWithHeader(w.current.header).WithBody([]*types.Transaction{tx}, nil),
+		)
+		if err != nil {
+			// `w.current.traceEnv.State` & `w.current.state` share a same pointer to the state, so only need to revert `w.current.state`
+			w.current.state.RevertToSnapshot(snap)
+			return nil, err
+		}
+		accRows, err = w.circuitCapacityChecker.ApplyTransaction(traces)
+		if err != nil {
+			// `w.current.traceEnv.State` & `w.current.state` share a same pointer to the state, so only need to revert `w.current.state`
+			w.current.state.RevertToSnapshot(snap)
+			return nil, err
+		}
+		log.Trace(
+			"Worker apply ccc for tx result",
+			"id", w.circuitCapacityChecker.ID,
+			"txhash", tx.Hash(),
+			"accRows", accRows,
+		)
+
+		// revert to snapshot for calling `core.ApplyMessage` again, (both `traceEnv.GetBlockTrace` & `core.ApplyTransaction` will call `core.ApplyMessage`)
 		w.current.state.RevertToSnapshot(snap)
-		return nil, err
+		// create new snapshot for `core.ApplyTransaction`
+		snap = w.current.state.Snapshot()
 	}
-	accRows, err := w.circuitCapacityChecker.ApplyTransaction(traces)
-	if err != nil {
-		// `w.current.traceEnv.State` & `w.current.state` share a same pointer to the state, so only need to revert `w.current.state`
-		w.current.state.RevertToSnapshot(snap)
-		return nil, err
-	}
-	log.Trace(
-		"Worker apply ccc for tx result",
-		"id", w.circuitCapacityChecker.ID,
-		"txhash", tx.Hash(),
-		"accRows", accRows,
-	)
 
-	// revert to snapshot for calling `core.ApplyMessage` again, (both `traceEnv.GetBlockTrace` & `core.ApplyTransaction` will call `core.ApplyMessage`)
-	w.current.state.RevertToSnapshot(snap)
-	// create new snapshot for `core.ApplyTransaction`
-	snap = w.current.state.Snapshot()
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
@@ -1159,10 +1164,6 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	w.mu.RLock()
 	defer w.mu.RUnlock()
 
-	if !w.isRunning() {
-		return
-	}
-
 	tstart := time.Now()
 	parent := w.chain.CurrentBlock()
 	w.circuitCapacityChecker.Reset()
@@ -1334,7 +1335,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 func (w *worker) commit(uncles []*types.Header, interval func(), update bool, start time.Time) error {
 	// set w.current.accRows for empty-but-not-genesis block
 	if (w.current.header.Number.Uint64() != 0) &&
-		(w.current.accRows == nil || len(*w.current.accRows) == 0) {
+		(w.current.accRows == nil || len(*w.current.accRows) == 0) && w.isRunning() {
 		log.Trace(
 			"Worker apply ccc for empty block",
 			"id", w.circuitCapacityChecker.ID,

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 42        // Patch version component of the current release
+	VersionPatch = 43        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Recently, we've been getting `"block not found"` errors for any RPC operation involving `pending` blocks (e.g. `eth_estimateGas`, or `eth_getBlockByNumber`). The root cause is that since https://github.com/scroll-tech/go-ethereum/pull/472, `worker.updateSnapshot()` is never called, and thus `worker.pendingBlock()` returns `nil`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
