### PR TITLE
fix: exclude L1 message from block payload size validation

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3353,6 +3353,8 @@ func TestL1MessageValidationFailure(t *testing.T) {
 	// initialize genesis
 	config := params.AllEthashProtocolChanges
 	config.Scroll.L1Config.NumL1MessagesPerBlock = 1
+	maxPayload := 1024
+	config.Scroll.MaxTxPayloadBytesPerBlock = &maxPayload
 
 	genspec := &Genesis{
 		Config: config,
@@ -3365,7 +3367,10 @@ func TestL1MessageValidationFailure(t *testing.T) {
 
 	// initialize L1 message DB
 	msgs := []types.L1MessageTx{
-		{QueueIndex: 0, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		// large L1 message, should not count against block payload limit
+		{QueueIndex: 0, Gas: 25100, To: &common.Address{1}, Data: make([]byte, 1025), Sender: common.Address{2}},
+
+		// normal L1 messages
 		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
 		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
 	}

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -335,7 +335,9 @@ func (b *Block) PayloadSize() common.StorageSize {
 	// add up all txs sizes
 	var totalSize common.StorageSize
 	for _, tx := range b.transactions {
-		totalSize += tx.Size()
+		if !tx.IsL1MessageTx() {
+			totalSize += tx.Size()
+		}
 	}
 	return totalSize
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -999,7 +999,7 @@ loop:
 			continue
 		}
 		// Error may be ignored here. The error has already been checked
-		// during transaction acceptance is the transaction pool.
+		// during transaction acceptance in the transaction pool.
 		//
 		// We use the eip155 signer regardless of the current hf.
 		from, _ := types.Sender(w.current.signer, tx)
@@ -1046,15 +1046,18 @@ loop:
 		case errors.Is(err, nil):
 			// Everything ok, collect the logs and shift in the next transaction from the same account
 			coalescedLogs = append(coalescedLogs, logs...)
+			w.current.tcount++
+			txs.Shift()
+
 			if tx.IsL1MessageTx() {
 				queueIndex := tx.AsL1MessageTx().QueueIndex
 				log.Debug("Including L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String())
 				w.current.l1TxCount++
 				w.current.nextL1MsgIndex = queueIndex + 1
+			} else {
+				// only consider block size limit for L2 transactions
+				w.current.blockSize += tx.Size()
 			}
-			w.current.tcount++
-			w.current.blockSize += tx.Size()
-			txs.Shift()
 
 		case errors.Is(err, core.ErrTxTypeNotSupported):
 			// Pop the unsupported transaction without shifting in the next from the account

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 46        // Patch version component of the current release
+	VersionPatch = 47        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 45        // Patch version component of the current release
+	VersionPatch = 46        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Currently, both `worker` and `block_validator` consider L1 messages when enforcing the block payload size limit. This is wrong (an unnecessary over-estimation), since L1 messages are not part of the batch payload.

It is risky to merge this fix in this form. It has the risk that we produce a block that's valid according to the updated size limit, but is still rejected by old-version nodes. This risk is limited by the fact that we currently only allow 10 L1 messages per block. An alternative, safer roll-out is:
1. First merge only the `block_validator` part.
2. Once most nodes have upgraded, merge the `worker` part.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [X] Yes
