### PR TITLE
fix: disable pruning and prefetch if not flags are provided

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -437,7 +437,7 @@ var (
 		Usage: "Percentage of cache memory allowance to use for snapshot caching (default = 10% full mode, 20% archive mode)",
 		Value: 10,
 	}
-	CacheNoPrefetchFlag = cli.BoolTFlag{
+	CacheNoPrefetchFlag = cli.BoolFlag{
 		Name:  "cache.noprefetch",
 		Usage: "Disable heuristic state prefetch during block import (less CPU and disk IO, more time waiting for data)",
 	}
@@ -1745,15 +1745,15 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		stack.Config().L1Confirmations = rpc.FinalizedBlockNumber
 		log.Info("Setting flag", "--l1.sync.startblock", "4038000")
 		stack.Config().L1DeploymentBlock = 4038000
-		// double check correct config
+		// disable pruning
 		if ctx.GlobalString(GCModeFlag.Name) != GCModeArchive {
 			log.Crit("Must use --gcmode=archive")
 		}
-		log.Info("Setting flag", "--gcmode", ctx.GlobalString(GCModeFlag.Name))
-		if !ctx.GlobalBool(CacheNoPrefetchFlag.Name) {
-			log.Crit("Must use --cache.noprefetch")
-		}
-		log.Info("Setting flag", "--cache.noprefetch", ctx.GlobalBool(CacheNoPrefetchFlag.Name))
+		log.Info("Pruning disabled")
+		cfg.NoPruning = true
+		// disable prefetch
+		log.Info("Prefetch disabled")
+		cfg.NoPrefetch = true
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 1337

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 50        // Patch version component of the current release
+	VersionPatch = 51        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

https://github.com/scroll-tech/go-ethereum/pull/482 updated the config defaults, but failed to set `cfg.NoPrefetch` if `--cache.noprefetch` was not provided. This PR fixes this.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
