### PR TITLE
fix(miner): fix repeatedly processing dropped txs in a new block

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -286,8 +286,6 @@ type TxPool struct {
 	spammers *prque.Prque
 
 	changesSinceReorg int // A counter for how many drops we've performed in-between reorg.
-
-	removeMu sync.RWMutex // mutex for `TxPool.RemoveTx`
 }
 
 type txpoolResetRequest struct {
@@ -1028,8 +1026,8 @@ func (pool *TxPool) Has(hash common.Hash) bool {
 // RemoveTx is similar to removeTx, but with locking to prevent concurrency.
 // Note: currently should only be called by miner/worker.go.
 func (pool *TxPool) RemoveTx(hash common.Hash, outofbound bool) {
-	pool.removeMu.Lock()
-	defer pool.removeMu.Unlock()
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
 
 	pool.removeTx(hash, outofbound)
 }

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -286,6 +286,8 @@ type TxPool struct {
 	spammers *prque.Prque
 
 	changesSinceReorg int // A counter for how many drops we've performed in-between reorg.
+
+	removeMu sync.RWMutex // mutex for `TxPool.RemoveTx`
 }
 
 type txpoolResetRequest struct {
@@ -409,7 +411,7 @@ func (pool *TxPool) loop() {
 				if time.Since(pool.beats[addr]) > pool.config.Lifetime {
 					list := pool.queue[addr].Flatten()
 					for _, tx := range list {
-						pool.RemoveTx(tx.Hash(), true)
+						pool.removeTx(tx.Hash(), true)
 					}
 					queuedEvictionMeter.Mark(int64(len(list)))
 				}
@@ -471,7 +473,7 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 		// pool.priced is sorted by GasFeeCap, so we have to iterate through pool.all instead
 		drop := pool.all.RemotesBelowTip(price)
 		for _, tx := range drop {
-			pool.RemoveTx(tx.Hash(), false)
+			pool.removeTx(tx.Hash(), false)
 		}
 		pool.priced.Removed(len(drop))
 	}
@@ -741,7 +743,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 		for _, tx := range drop {
 			log.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap())
 			underpricedTxMeter.Mark(1)
-			pool.RemoveTx(tx.Hash(), false)
+			pool.removeTx(tx.Hash(), false)
 		}
 	}
 	// Try to replace an existing transaction in the pending pool
@@ -1023,9 +1025,18 @@ func (pool *TxPool) Has(hash common.Hash) bool {
 	return pool.all.Get(hash) != nil
 }
 
-// RemoveTx removes a single transaction from the queue, moving all subsequent
-// transactions back to the future queue.
+// RemoveTx is similar to removeTx, but with locking to prevent concurrency.
+// Note: currently should only be called by miner/worker.go.
 func (pool *TxPool) RemoveTx(hash common.Hash, outofbound bool) {
+	pool.removeMu.Lock()
+	defer pool.removeMu.Unlock()
+
+	pool.removeTx(hash, outofbound)
+}
+
+// removeTx removes a single transaction from the queue, moving all subsequent
+// transactions back to the future queue.
+func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 	// Fetch the transaction we wish to delete
 	tx := pool.all.Get(hash)
 	if tx == nil {
@@ -1530,7 +1541,7 @@ func (pool *TxPool) truncateQueue() {
 		// Drop all transactions if they are less than the overflow
 		if size := uint64(list.Len()); size <= drop {
 			for _, tx := range list.Flatten() {
-				pool.RemoveTx(tx.Hash(), true)
+				pool.removeTx(tx.Hash(), true)
 			}
 			drop -= size
 			queuedRateLimitMeter.Mark(int64(size))
@@ -1539,7 +1550,7 @@ func (pool *TxPool) truncateQueue() {
 		// Otherwise drop only last few transactions
 		txs := list.Flatten()
 		for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
-			pool.RemoveTx(txs[i].Hash(), true)
+			pool.removeTx(txs[i].Hash(), true)
 			drop--
 			queuedRateLimitMeter.Mark(1)
 		}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -409,7 +409,7 @@ func (pool *TxPool) loop() {
 				if time.Since(pool.beats[addr]) > pool.config.Lifetime {
 					list := pool.queue[addr].Flatten()
 					for _, tx := range list {
-						pool.removeTx(tx.Hash(), true)
+						pool.RemoveTx(tx.Hash(), true)
 					}
 					queuedEvictionMeter.Mark(int64(len(list)))
 				}
@@ -471,7 +471,7 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 		// pool.priced is sorted by GasFeeCap, so we have to iterate through pool.all instead
 		drop := pool.all.RemotesBelowTip(price)
 		for _, tx := range drop {
-			pool.removeTx(tx.Hash(), false)
+			pool.RemoveTx(tx.Hash(), false)
 		}
 		pool.priced.Removed(len(drop))
 	}
@@ -741,7 +741,7 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 		for _, tx := range drop {
 			log.Trace("Discarding freshly underpriced transaction", "hash", tx.Hash(), "gasTipCap", tx.GasTipCap(), "gasFeeCap", tx.GasFeeCap())
 			underpricedTxMeter.Mark(1)
-			pool.removeTx(tx.Hash(), false)
+			pool.RemoveTx(tx.Hash(), false)
 		}
 	}
 	// Try to replace an existing transaction in the pending pool
@@ -1023,9 +1023,9 @@ func (pool *TxPool) Has(hash common.Hash) bool {
 	return pool.all.Get(hash) != nil
 }
 
-// removeTx removes a single transaction from the queue, moving all subsequent
+// RemoveTx removes a single transaction from the queue, moving all subsequent
 // transactions back to the future queue.
-func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
+func (pool *TxPool) RemoveTx(hash common.Hash, outofbound bool) {
 	// Fetch the transaction we wish to delete
 	tx := pool.all.Get(hash)
 	if tx == nil {
@@ -1530,7 +1530,7 @@ func (pool *TxPool) truncateQueue() {
 		// Drop all transactions if they are less than the overflow
 		if size := uint64(list.Len()); size <= drop {
 			for _, tx := range list.Flatten() {
-				pool.removeTx(tx.Hash(), true)
+				pool.RemoveTx(tx.Hash(), true)
 			}
 			drop -= size
 			queuedRateLimitMeter.Mark(int64(size))
@@ -1539,7 +1539,7 @@ func (pool *TxPool) truncateQueue() {
 		// Otherwise drop only last few transactions
 		txs := list.Flatten()
 		for i := len(txs) - 1; i >= 0 && drop > 0; i-- {
-			pool.removeTx(txs[i].Hash(), true)
+			pool.RemoveTx(txs[i].Hash(), true)
 			drop--
 			queuedRateLimitMeter.Mark(1)
 		}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -448,7 +448,7 @@ func TestTransactionChainFork(t *testing.T) {
 	if _, err := pool.add(tx, false); err != nil {
 		t.Error("didn't expect error", err)
 	}
-	pool.RemoveTx(tx.Hash(), true)
+	pool.removeTx(tx.Hash(), true)
 
 	// reset the pool's internal state
 	resetState()

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -448,7 +448,7 @@ func TestTransactionChainFork(t *testing.T) {
 	if _, err := pool.add(tx, false); err != nil {
 		t.Error("didn't expect error", err)
 	}
-	pool.removeTx(tx.Hash(), true)
+	pool.RemoveTx(tx.Hash(), true)
 
 	// reset the pool's internal state
 	resetState()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -980,9 +980,10 @@ loop:
 			break
 		}
 
-		// skipped before, due to circuitcapacitychecker.ErrBlockRowConsumptionOverflow or circuitcapacitychecker.ErrUnknown
+		// If the l2tx is skipped before (due to circuitcapacitychecker.ErrBlockRowConsumptionOverflow or circuitcapacitychecker.ErrUnknown),
+		// it actually still stays in the txpool. We need to skip it again, instead of re-processing it.
+		// And after a while, it will be removed by txpool due to being too old.
 		if _, ok := w.skippedL2Txs[tx.Hash()]; ok {
-			// skip again, otherwise it will stuck in mempool
 			txs.Shift()
 			continue
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -200,7 +200,6 @@ type worker struct {
 	isLocalBlock func(block *types.Block) bool // Function used to determine whether the specified block is mined by local miner.
 
 	circuitCapacityChecker *circuitcapacitychecker.CircuitCapacityChecker
-	skippedL2Txs           map[common.Hash]struct{}
 
 	// Test hooks
 	newTaskHook  func(*task)                        // Method to call upon receiving a new sealing task.
@@ -234,7 +233,6 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		resubmitIntervalCh:     make(chan time.Duration),
 		resubmitAdjustCh:       make(chan *intervalAdjust, resubmitAdjustChanSize),
 		circuitCapacityChecker: circuitcapacitychecker.NewCircuitCapacityChecker(),
-		skippedL2Txs:           make(map[common.Hash]struct{}),
 	}
 	log.Info("created new worker", "CircuitCapacityChecker ID", worker.circuitCapacityChecker.ID)
 
@@ -979,15 +977,6 @@ loop:
 		if tx == nil {
 			break
 		}
-
-		// If the l2tx is skipped before (due to circuitcapacitychecker.ErrBlockRowConsumptionOverflow or circuitcapacitychecker.ErrUnknown),
-		// it actually still stays in the txpool. We need to skip it again, instead of re-processing it.
-		// And after a while, it will be removed by txpool due to being too old.
-		if _, ok := w.skippedL2Txs[tx.Hash()]; ok {
-			txs.Shift()
-			continue
-		}
-
 		// If we have collected enough transactions then we're done
 		// Originally we only limit l2txs count, but now strictly limit total txs number.
 		if !w.chainConfig.Scroll.IsValidTxCount(w.current.tcount + 1) {
@@ -1101,7 +1090,7 @@ loop:
 					// Skip L2 transaction and all other transactions from the same sender account
 					log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "first tx row consumption overflow")
 					txs.Pop()
-					w.skippedL2Txs[tx.Hash()] = struct{}{}
+					w.eth.TxPool().RemoveTx(tx.Hash(), true)
 				}
 
 				// Reset ccc so that we can process other transactions for this block
@@ -1137,7 +1126,7 @@ loop:
 			// Normally we would do `txs.Pop()` here.
 			// However, after `ErrUnknown`, ccc might remain in an
 			// inconsistent state, so we cannot pack more transactions.
-			w.skippedL2Txs[tx.Hash()] = struct{}{}
+			w.eth.TxPool().RemoveTx(tx.Hash(), true)
 			circuitCapacityReached = true
 			break loop
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1123,7 +1123,7 @@ loop:
 			log.Trace("Unknown circuit capacity checker error for L2MessageTx", "tx", tx.Hash().String())
 			log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			// TODO: propagate more info about the error from CCC
-			rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
+			rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 
 			// Normally we would do `txs.Pop()` here.
 			// However, after `ErrUnknown`, ccc might remain in an

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1122,6 +1122,8 @@ loop:
 			// Circuit capacity check: unknown circuit capacity checker error for L2MessageTx, skip the account
 			log.Trace("Unknown circuit capacity checker error for L2MessageTx", "tx", tx.Hash().String())
 			log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
+			// TODO: propagate more info about the error from CCC
+			rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 
 			// Normally we would do `txs.Pop()` here.
 			// However, after `ErrUnknown`, ccc might remain in an

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -200,6 +200,7 @@ type worker struct {
 	isLocalBlock func(block *types.Block) bool // Function used to determine whether the specified block is mined by local miner.
 
 	circuitCapacityChecker *circuitcapacitychecker.CircuitCapacityChecker
+	skippedL2Txs           map[common.Hash]struct{}
 
 	// Test hooks
 	newTaskHook  func(*task)                        // Method to call upon receiving a new sealing task.
@@ -233,6 +234,7 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 		resubmitIntervalCh:     make(chan time.Duration),
 		resubmitAdjustCh:       make(chan *intervalAdjust, resubmitAdjustChanSize),
 		circuitCapacityChecker: circuitcapacitychecker.NewCircuitCapacityChecker(),
+		skippedL2Txs:           make(map[common.Hash]struct{}),
 	}
 	log.Info("created new worker", "CircuitCapacityChecker ID", worker.circuitCapacityChecker.ID)
 
@@ -977,6 +979,14 @@ loop:
 		if tx == nil {
 			break
 		}
+
+		// skipped before, due to circuitcapacitychecker.ErrBlockRowConsumptionOverflow or circuitcapacitychecker.ErrUnknown
+		if _, ok := w.skippedL2Txs[tx.Hash()]; ok {
+			// skip again, otherwise it will stuck in mempool
+			txs.Shift()
+			continue
+		}
+
 		// If we have collected enough transactions then we're done
 		// Originally we only limit l2txs count, but now strictly limit total txs number.
 		if !w.chainConfig.Scroll.IsValidTxCount(w.current.tcount + 1) {
@@ -1090,6 +1100,7 @@ loop:
 					// Skip L2 transaction and all other transactions from the same sender account
 					log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "first tx row consumption overflow")
 					txs.Pop()
+					w.skippedL2Txs[tx.Hash()] = struct{}{}
 				}
 
 				// Reset ccc so that we can process other transactions for this block
@@ -1125,6 +1136,7 @@ loop:
 			// Normally we would do `txs.Pop()` here.
 			// However, after `ErrUnknown`, ccc might remain in an
 			// inconsistent state, so we cannot pack more transactions.
+			w.skippedL2Txs[tx.Hash()] = struct{}{}
 			circuitCapacityReached = true
 			break loop
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 55        // Patch version component of the current release
+	VersionPatch = 56        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

`txs.Shift()` and `txs.Pop()` will only drop the tx from the current `txs *types.TransactionsByPriceAndNonce`. However, the "dropped" tx is not really removed from the mempool, and will still be fed into `commitTransactions` when making a new block.
(You can verify this statement using https://github.com/scroll-tech/go-ethereum/pull/492. Can try and play around using https://github.com/HAOYUatHZ/ccc-tester, changing https://github.com/HAOYUatHZ/ccc-tester/blob/ccc/docker/l2geth/Dockerfile to `scrolltech/l2geth:scroll-v4.3.56-PoC`).

~~This PR removes the txs from the processing tx queue.~~ (update: This PR now removes the txs from the txpool. See discussion below.) Besides, it makes no sense to re-trace the tx, if such a single tx is already known `circuitcapacitychecker.ErrBlockRowConsumptionOverflow` or `circuitcapacitychecker.ErrUnknown`


**Note**: L1msg is not affected by this because we read and maintain the queue in db instead of reading directly from mempool.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
