### PR TITLE
feat(api/rawdb): allow storing traces for skipped txs

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -130,6 +130,7 @@ var (
 		utils.MinerExtraDataFlag,
 		utils.MinerRecommitIntervalFlag,
 		utils.MinerNoVerifyFlag,
+		utils.MinerStoreSkippedTxTracesFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -192,6 +192,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerExtraDataFlag,
 			utils.MinerRecommitIntervalFlag,
 			utils.MinerNoVerifyFlag,
+			utils.MinerStoreSkippedTxTracesFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -491,6 +491,10 @@ var (
 		Name:  "miner.noverify",
 		Usage: "Disable remote sealing verification",
 	}
+	MinerStoreSkippedTxTracesFlag = cli.BoolFlag{
+		Name:  "miner.storeskippedtxtraces",
+		Usage: "Store the wrapped traces when storing a skipped tx",
+	}
 	// Account settings
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
@@ -1487,6 +1491,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.GlobalIsSet(MinerNoVerifyFlag.Name) {
 		cfg.Noverify = ctx.GlobalBool(MinerNoVerifyFlag.Name)
+	}
+	if ctx.GlobalIsSet(MinerStoreSkippedTxTracesFlag.Name) {
+		cfg.StoreSkippedTxTraces = ctx.GlobalBool(MinerStoreSkippedTxTracesFlag.Name)
 	}
 	if ctx.GlobalIsSet(LegacyMinerGasTargetFlag.Name) {
 		log.Warn("The generic --miner.gastarget flag is deprecated and will be removed in the future!")

--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -179,7 +179,7 @@ func (v *BlockValidator) ValidateL1Messages(block *types.Block) error {
 			l1msg := it.L1Message()
 			skippedTx := types.NewTx(&l1msg)
 			log.Debug("Skipped L1 message", "queueIndex", index, "tx", skippedTx.Hash().String(), "block", blockHash.String())
-			rawdb.WriteSkippedTransaction(v.db, skippedTx, "unknown", block.NumberU64(), &blockHash)
+			rawdb.WriteSkippedTransaction(v.db, skippedTx, nil, "unknown", block.NumberU64(), &blockHash)
 		}
 
 		queueIndex = txQueueIndex + 1

--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -62,16 +62,16 @@ type SkippedTransaction struct {
 	BlockHash *common.Hash
 }
 
-// SkippedTransactionV2 stores the SkippedTransaction object, along with the traces serialization.
+// SkippedTransactionV2 stores the SkippedTransaction object along with serialized traces.
 type SkippedTransactionV2 struct {
 	// Tx is the skipped transaction.
-	// We store the tx itself because otherwise geth will discard it after skipping.
+	// We store the tx itself otherwise geth will discard it after skipping.
 	Tx *types.Transaction
 
-	// Traces is the wrapped traces of the skipped transaction.
+	// Traces is the serialized wrapped traces of the skipped transaction.
 	// We only store it when `MinerStoreSkippedTxTracesFlag` is enabled, so it might be empty.
-	// Note that we don't use *types.BlockTrace directly because types.BlockTrace.StorageTrace.Proofs is of
-	// type map[string][]hexutil.Bytes, and is not RLP-serializable.
+	// Note that we do not directly utilize `*types.BlockTrace` due to the fact that
+	// types.BlockTrace.StorageTrace.Proofs is of type `map[string][]hexutil.Bytes`, which is not RLP-serializable.
 	TracesBytes []byte
 
 	// Reason is the skip reason.

--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -127,7 +127,7 @@ func ReadSkippedTransactionHash(db ethdb.Reader, index uint64) *common.Hash {
 
 // WriteSkippedTransaction writes a skipped transaction to the database and also updates the count and lookup index.
 // Note: The lookup index and count will include duplicates if there are chain reorgs.
-func WriteSkippedTransaction(db ethdb.Database, tx *types.Transaction, reason string, blockNumber uint64, blockHash *common.Hash) {
+func WriteSkippedTransaction(db ethdb.Database, tx *types.Transaction, traces *types.BlockTrace, reason string, blockNumber uint64, blockHash *common.Hash) {
 	// this method is not accessed concurrently, but just to be sure...
 	mu.Lock()
 	defer mu.Unlock()

--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -52,7 +52,7 @@ type SkippedTransaction struct {
 	Tx *types.Transaction
 
 	// Traces is the wrapped traces of the skipped transaction.
-	// We only store it when flag is enabled, so it may return nil.
+	// We only store it when `MinerStoreSkippedTxTracesFlag` is enabled, so it may return nil.
 	Traces *types.BlockTrace
 
 	// Reason is the skip reason.

--- a/core/rawdb/accessors_skipped_txs_test.go
+++ b/core/rawdb/accessors_skipped_txs_test.go
@@ -51,6 +51,16 @@ func TestReadWriteSkippedTransactionNoIndex(t *testing.T) {
 	}
 }
 
+func TestReadSkippedTransactionV1AsV2(t *testing.T) {
+	tx := newTestTransaction(123)
+	db := NewMemoryDatabase()
+	writeSkippedTransactionV1(db, tx, "random reason", 1, &common.Hash{1})
+	got := ReadSkippedTransaction(db, tx.Hash())
+	if got == nil || got.Tx.Hash() != tx.Hash() || got.Reason != "random reason" || got.BlockNumber != 1 || got.BlockHash == nil || *got.BlockHash != (common.Hash{1}) {
+		t.Fatal("Skipped transaction mismatch", "got", got)
+	}
+}
+
 func TestReadWriteSkippedTransaction(t *testing.T) {
 	tx := newTestTransaction(123)
 	db := NewMemoryDatabase()

--- a/core/rawdb/accessors_skipped_txs_test.go
+++ b/core/rawdb/accessors_skipped_txs_test.go
@@ -44,7 +44,7 @@ func newTestTransaction(queueIndex uint64) *types.Transaction {
 func TestReadWriteSkippedTransactionNoIndex(t *testing.T) {
 	tx := newTestTransaction(123)
 	db := NewMemoryDatabase()
-	writeSkippedTransaction(db, tx, "random reason", 1, &common.Hash{1})
+	writeSkippedTransaction(db, tx, nil, "random reason", 1, &common.Hash{1})
 	got := ReadSkippedTransaction(db, tx.Hash())
 	if got == nil || got.Tx.Hash() != tx.Hash() || got.Reason != "random reason" || got.BlockNumber != 1 || got.BlockHash == nil || *got.BlockHash != (common.Hash{1}) {
 		t.Fatal("Skipped transaction mismatch", "got", got)
@@ -54,7 +54,7 @@ func TestReadWriteSkippedTransactionNoIndex(t *testing.T) {
 func TestReadWriteSkippedTransaction(t *testing.T) {
 	tx := newTestTransaction(123)
 	db := NewMemoryDatabase()
-	WriteSkippedTransaction(db, tx, "random reason", 1, &common.Hash{1})
+	WriteSkippedTransaction(db, tx, nil, "random reason", 1, &common.Hash{1})
 	got := ReadSkippedTransaction(db, tx.Hash())
 	if got == nil || got.Tx.Hash() != tx.Hash() || got.Reason != "random reason" || got.BlockNumber != 1 || got.BlockHash == nil || *got.BlockHash != (common.Hash{1}) {
 		t.Fatal("Skipped transaction mismatch", "got", got)
@@ -78,7 +78,7 @@ func TestSkippedTransactionConcurrentUpdate(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			WriteSkippedTransaction(db, tx, "random reason", 1, &common.Hash{1})
+			WriteSkippedTransaction(db, tx, nil, "random reason", 1, &common.Hash{1})
 		}()
 	}
 	wg.Wait()
@@ -100,12 +100,12 @@ func TestIterateSkippedTransactions(t *testing.T) {
 	}
 
 	for _, tx := range txs {
-		WriteSkippedTransaction(db, tx, "random reason", 1, &common.Hash{1})
+		WriteSkippedTransaction(db, tx, nil, "random reason", 1, &common.Hash{1})
 	}
 
 	// simulate skipped L2 tx that's not included in the index
 	l2tx := newTestTransaction(6)
-	writeSkippedTransaction(db, l2tx, "random reason", 1, &common.Hash{1})
+	writeSkippedTransaction(db, l2tx, nil, "random reason", 1, &common.Hash{1})
 
 	it := IterateSkippedTransactionsFrom(db, 2)
 	defer it.Release()

--- a/eth/api.go
+++ b/eth/api.go
@@ -721,6 +721,9 @@ type RPCTransaction struct {
 	SkipReason      string       `json:"skipReason"`
 	SkipBlockNumber *hexutil.Big `json:"skipBlockNumber"`
 	SkipBlockHash   *common.Hash `json:"skipBlockHash,omitempty"`
+
+	// wrapped traces, currently only available for `scroll_getSkippedTransaction` API, when `MinerStoreSkippedTxTracesFlag` is set
+	Traces *types.BlockTrace `json:"traces,omitempty"`
 }
 
 // GetSkippedTransaction returns a skipped transaction by its hash.
@@ -729,17 +732,16 @@ func (api *ScrollAPI) GetSkippedTransaction(ctx context.Context, hash common.Has
 	if stx == nil {
 		return nil, nil
 	}
-	var traces *types.BlockTrace
-	if len(stx.TracesBytes) != 0 {
-		if err := json.Unmarshal(stx.TracesBytes, traces); err != nil {
-			return nil, fmt.Errorf("fail to Unmarshal traces for skipped tx, hash: %s, err: %w", hash.String(), err)
-		}
-	}
 	var rpcTx RPCTransaction
-	rpcTx.RPCTransaction = *ethapi.NewRPCTransaction(stx.Tx, traces, common.Hash{}, 0, 0, nil, api.eth.blockchain.Config())
+	rpcTx.RPCTransaction = *ethapi.NewRPCTransaction(stx.Tx, common.Hash{}, 0, 0, nil, api.eth.blockchain.Config())
 	rpcTx.SkipReason = stx.Reason
 	rpcTx.SkipBlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(stx.BlockNumber))
 	rpcTx.SkipBlockHash = stx.BlockHash
+	if len(stx.TracesBytes) != 0 {
+		if err := json.Unmarshal(stx.TracesBytes, rpcTx.Traces); err != nil {
+			return nil, fmt.Errorf("fail to Unmarshal traces for skipped tx, hash: %s, err: %w", hash.String(), err)
+		}
+	}
 	return &rpcTx, nil
 }
 

--- a/eth/api.go
+++ b/eth/api.go
@@ -729,7 +729,7 @@ func (api *ScrollAPI) GetSkippedTransaction(ctx context.Context, hash common.Has
 		return nil, nil
 	}
 	var rpcTx RPCTransaction
-	rpcTx.RPCTransaction = *ethapi.NewRPCTransaction(stx.Tx, common.Hash{}, 0, 0, nil, api.eth.blockchain.Config())
+	rpcTx.RPCTransaction = *ethapi.NewRPCTransaction(stx.Tx, stx.Traces, common.Hash{}, 0, 0, nil, api.eth.blockchain.Config())
 	rpcTx.SkipReason = stx.Reason
 	rpcTx.SkipBlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(stx.BlockNumber))
 	rpcTx.SkipBlockHash = stx.BlockHash

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1360,7 +1360,7 @@ func NewRPCTransaction(tx *types.Transaction, traces *types.BlockTrace, blockHas
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
 
-		Traces:   traces,
+		Traces: traces,
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = &blockHash

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1335,14 +1335,11 @@ type RPCTransaction struct {
 	// L1 message transaction fields:
 	Sender     common.Address  `json:"sender,omitempty"`
 	QueueIndex *hexutil.Uint64 `json:"queueIndex,omitempty"`
-
-	// wrapped traces, currently only available for `scroll_getSkippedTransaction` API, when `MinerStoreSkippedTxTracesFlag` is set
-	Traces *types.BlockTrace `json:"traces,omitempty"`
 }
 
 // NewRPCTransaction returns a transaction that will serialize to the RPC
 // representation, with the given location metadata set (if available).
-func NewRPCTransaction(tx *types.Transaction, traces *types.BlockTrace, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
+func NewRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber uint64, index uint64, baseFee *big.Int, config *params.ChainConfig) *RPCTransaction {
 	signer := types.MakeSigner(config, big.NewInt(0).SetUint64(blockNumber))
 	from, _ := types.Sender(signer, tx)
 	v, r, s := tx.RawSignatureValues()
@@ -1359,8 +1356,6 @@ func NewRPCTransaction(tx *types.Transaction, traces *types.BlockTrace, blockHas
 		V:        (*hexutil.Big)(v),
 		R:        (*hexutil.Big)(r),
 		S:        (*hexutil.Big)(s),
-
-		Traces: traces,
 	}
 	if blockHash != (common.Hash{}) {
 		result.BlockHash = &blockHash
@@ -1402,7 +1397,7 @@ func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, conf
 		baseFee = misc.CalcBaseFee(config, current)
 		blockNumber = current.Number.Uint64()
 	}
-	return NewRPCTransaction(tx, nil, common.Hash{}, blockNumber, 0, baseFee, config)
+	return NewRPCTransaction(tx, common.Hash{}, blockNumber, 0, baseFee, config)
 }
 
 // newRPCTransactionFromBlockIndex returns a transaction that will serialize to the RPC representation.
@@ -1411,7 +1406,7 @@ func newRPCTransactionFromBlockIndex(b *types.Block, index uint64, config *param
 	if index >= uint64(len(txs)) {
 		return nil
 	}
-	return NewRPCTransaction(txs[index], nil, b.Hash(), b.NumberU64(), index, b.BaseFee(), config)
+	return NewRPCTransaction(txs[index], b.Hash(), b.NumberU64(), index, b.BaseFee(), config)
 }
 
 // newRPCRawTransactionFromBlockIndex returns the bytes of a transaction given a block and a transaction index.
@@ -1634,7 +1629,7 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 		if err != nil {
 			return nil, err
 		}
-		return NewRPCTransaction(tx, nil, blockHash, blockNumber, index, header.BaseFee, s.b.ChainConfig()), nil
+		return NewRPCTransaction(tx, blockHash, blockNumber, index, header.BaseFee, s.b.ChainConfig()), nil
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1336,7 +1336,7 @@ type RPCTransaction struct {
 	Sender     common.Address  `json:"sender,omitempty"`
 	QueueIndex *hexutil.Uint64 `json:"queueIndex,omitempty"`
 
-	// wrapped traces, currently only available for `scroll_getSkippedTransaction` API, when flag is set
+	// wrapped traces, currently only available for `scroll_getSkippedTransaction` API, when `MinerStoreSkippedTxTracesFlag` is set
 	Traces *types.BlockTrace `json:"traces,omitempty"`
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -56,6 +56,8 @@ type Config struct {
 	GasPrice   *big.Int       // Minimum gas price for mining a transaction
 	Recommit   time.Duration  // The time interval for miner to re-create mining work.
 	Noverify   bool           // Disable remote mining solution verification(only useful in ethash).
+
+	StoreSkippedTxTraces bool // Whether store the wrapped traces when storing a skipped tx
 }
 
 // Miner creates blocks and searches for proof-of-work values.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1137,7 +1137,7 @@ loop:
 			if w.config.StoreSkippedTxTraces {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			} else {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)				
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			}
 			l1TxCccUnknownErrCounter.Inc(1)
 
@@ -1155,7 +1155,7 @@ loop:
 			if w.config.StoreSkippedTxTraces {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			} else {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)			
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			}
 			l2TxCccUnknownErrCounter.Inc(1)
 
@@ -1177,7 +1177,7 @@ loop:
 				if w.config.StoreSkippedTxTraces {
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
 				} else {
-					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)			
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
 				}
 				l1TxStrangeErrCounter.Inc(1)
 			}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1038,7 +1038,7 @@ loop:
 			log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "gas limit exceeded")
 			w.current.nextL1MsgIndex = queueIndex + 1
 			txs.Shift()
-			if false {
+			if w.config.StoreSkippedTxTraces {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
 			} else {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
@@ -1119,7 +1119,7 @@ loop:
 				circuitCapacityReached = false
 
 				// Store skipped transaction in local db
-				if false {
+				if w.config.StoreSkippedTxTraces {
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				} else {
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "row consumption overflow", w.current.header.Number.Uint64(), nil)
@@ -1134,7 +1134,7 @@ loop:
 			log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			w.current.nextL1MsgIndex = queueIndex + 1
 			// TODO: propagate more info about the error from CCC
-			if false {
+			if w.config.StoreSkippedTxTraces {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			} else {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)				
@@ -1152,7 +1152,7 @@ loop:
 			log.Trace("Unknown circuit capacity checker error for L2MessageTx", "tx", tx.Hash().String())
 			log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			// TODO: propagate more info about the error from CCC
-			if false {
+			if w.config.StoreSkippedTxTraces {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			} else {
 				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)			
@@ -1174,7 +1174,7 @@ loop:
 				queueIndex := tx.AsL1MessageTx().QueueIndex
 				log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "strange error", "err", err)
 				w.current.nextL1MsgIndex = queueIndex + 1
-				if false {
+				if w.config.StoreSkippedTxTraces {
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
 				} else {
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)			

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1038,7 +1038,11 @@ loop:
 			log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "gas limit exceeded")
 			w.current.nextL1MsgIndex = queueIndex + 1
 			txs.Shift()
-			rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
+			if false {
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
+			} else {
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
+			}
 			l1TxGasLimitExceededCounter.Inc(1)
 
 		case errors.Is(err, core.ErrGasLimitReached):
@@ -1115,7 +1119,11 @@ loop:
 				circuitCapacityReached = false
 
 				// Store skipped transaction in local db
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
+				if false {
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
+				} else {
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
+				}
 			}
 
 		case (errors.Is(err, circuitcapacitychecker.ErrUnknown) && tx.IsL1MessageTx()):
@@ -1126,7 +1134,11 @@ loop:
 			log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			w.current.nextL1MsgIndex = queueIndex + 1
 			// TODO: propagate more info about the error from CCC
-			rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
+			if false {
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
+			} else {
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)				
+			}
 			l1TxCccUnknownErrCounter.Inc(1)
 
 			// Normally we would do `txs.Shift()` here.
@@ -1140,7 +1152,11 @@ loop:
 			log.Trace("Unknown circuit capacity checker error for L2MessageTx", "tx", tx.Hash().String())
 			log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			// TODO: propagate more info about the error from CCC
-			rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
+			if false {
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
+			} else {
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)			
+			}
 			l2TxCccUnknownErrCounter.Inc(1)
 
 			// Normally we would do `txs.Pop()` here.
@@ -1158,7 +1174,11 @@ loop:
 				queueIndex := tx.AsL1MessageTx().QueueIndex
 				log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "strange error", "err", err)
 				w.current.nextL1MsgIndex = queueIndex + 1
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
+				if false {
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
+				} else {
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)			
+				}
 				l1TxStrangeErrCounter.Inc(1)
 			}
 			txs.Shift()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1025,7 +1025,7 @@ loop:
 		// Start executing the transaction
 		w.current.state.Prepare(tx.Hash(), w.current.tcount)
 
-		logs, _, err := w.commitTransaction(tx, coinbase)
+		logs, traces, err := w.commitTransaction(tx, coinbase)
 		switch {
 		case errors.Is(err, core.ErrGasLimitReached) && tx.IsL1MessageTx():
 			// If this block already contains some L1 messages,
@@ -1039,9 +1039,9 @@ loop:
 			w.current.nextL1MsgIndex = queueIndex + 1
 			txs.Shift()
 			if false {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
 			} else {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "gas limit exceeded", w.current.header.Number.Uint64(), nil)
 			}
 			l1TxGasLimitExceededCounter.Inc(1)
 
@@ -1120,9 +1120,9 @@ loop:
 
 				// Store skipped transaction in local db
 				if false {
-					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				} else {
-					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "row consumption overflow", w.current.header.Number.Uint64(), nil)
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				}
 			}
 
@@ -1135,9 +1135,9 @@ loop:
 			w.current.nextL1MsgIndex = queueIndex + 1
 			// TODO: propagate more info about the error from CCC
 			if false {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			} else {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)				
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)				
 			}
 			l1TxCccUnknownErrCounter.Inc(1)
 
@@ -1153,9 +1153,9 @@ loop:
 			log.Info("Skipping L2 message", "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "unknown row consumption error")
 			// TODO: propagate more info about the error from CCC
 			if false {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)
 			} else {
-				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)			
+				rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "unknown circuit capacity checker error", w.current.header.Number.Uint64(), nil)			
 			}
 			l2TxCccUnknownErrCounter.Inc(1)
 
@@ -1175,9 +1175,9 @@ loop:
 				log.Info("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block", w.current.header.Number, "reason", "strange error", "err", err)
 				w.current.nextL1MsgIndex = queueIndex + 1
 				if false {
-					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)
 				} else {
-					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)			
+					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, fmt.Sprintf("strange error: %v", err), w.current.header.Number.Uint64(), nil)			
 				}
 				l1TxStrangeErrCounter.Inc(1)
 			}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 62        // Patch version component of the current release
+	VersionPatch = 63        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Currently it's hard to debug a skipped tx if it's rejected by ccc, because its traces is never store. This PR adds a flag and store the skipped txs' traces when the flag is enabled.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205413693252457