### PR TITLE
fix(rawdb, api): fix `rawdb.writeSkippedTransaction` & `api.GetSkippedTransaction`

### DIFF
--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -86,15 +86,17 @@ type SkippedTransactionV2 struct {
 
 // writeSkippedTransaction writes a skipped transaction to the database.
 func writeSkippedTransaction(db ethdb.KeyValueWriter, tx *types.Transaction, traces *types.BlockTrace, reason string, blockNumber uint64, blockHash *common.Hash) {
+	var err error
 	// workaround: RLP decoding fails if this is nil
 	if blockHash == nil {
 		blockHash = &common.Hash{}
 	}
-	b, err := json.Marshal(traces)
-	if err != nil {
-		log.Crit("Failed to json marshal skipped transaction", "hash", tx.Hash().String(), "err", err)
+	stx := SkippedTransactionV2{Tx: tx, Reason: reason, BlockNumber: blockNumber, BlockHash: blockHash}
+	if traces != nil {
+		if stx.TracesBytes, err = json.Marshal(traces); err != nil {
+			log.Crit("Failed to json marshal skipped transaction", "hash", tx.Hash().String(), "err", err)
+		}
 	}
-	stx := SkippedTransactionV2{Tx: tx, TracesBytes: b, Reason: reason, BlockNumber: blockNumber, BlockHash: blockHash}
 	bytes, err := rlp.EncodeToBytes(stx)
 	if err != nil {
 		log.Crit("Failed to RLP encode skipped transaction", "hash", tx.Hash().String(), "err", err)

--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -3,7 +3,6 @@ package rawdb
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"encoding/json"
 	"math/big"
 	"sync"
@@ -98,7 +97,6 @@ func writeSkippedTransaction(db ethdb.KeyValueWriter, tx *types.Transaction, tra
 			log.Crit("Failed to json marshal skipped transaction", "hash", tx.Hash().String(), "err", err)
 		}
 	}
-	log.Info("stx.TracesBytes", "stx.TracesBytes", hex.EncodeToString(stx.TracesBytes))
 	bytes, err := rlp.EncodeToBytes(stx)
 	if err != nil {
 		log.Crit("Failed to RLP encode skipped transaction", "hash", tx.Hash().String(), "err", err)
@@ -153,8 +151,6 @@ func ReadSkippedTransaction(db ethdb.Reader, txHash common.Hash) *SkippedTransac
 		stxV2.BlockNumber = stx.BlockNumber
 		stxV2.BlockHash = stx.BlockHash
 	}
-
-	log.Info("ReadSkippedTransaction", "stxV2.TracesBytes", hex.EncodeToString(stxV2.TracesBytes))
 
 	if stxV2.BlockHash != nil && *stxV2.BlockHash == (common.Hash{}) {
 		stxV2.BlockHash = nil

--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -3,6 +3,7 @@ package rawdb
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"math/big"
 	"sync"
@@ -97,6 +98,7 @@ func writeSkippedTransaction(db ethdb.KeyValueWriter, tx *types.Transaction, tra
 			log.Crit("Failed to json marshal skipped transaction", "hash", tx.Hash().String(), "err", err)
 		}
 	}
+	log.Info("stx.TracesBytes", "stx.TracesBytes", hex.EncodeToString(stx.TracesBytes))
 	bytes, err := rlp.EncodeToBytes(stx)
 	if err != nil {
 		log.Crit("Failed to RLP encode skipped transaction", "hash", tx.Hash().String(), "err", err)
@@ -151,6 +153,8 @@ func ReadSkippedTransaction(db ethdb.Reader, txHash common.Hash) *SkippedTransac
 		stxV2.BlockNumber = stx.BlockNumber
 		stxV2.BlockHash = stx.BlockHash
 	}
+
+	log.Info("ReadSkippedTransaction", "stxV2.TracesBytes", hex.EncodeToString(stxV2.TracesBytes))
 
 	if stxV2.BlockHash != nil && *stxV2.BlockHash == (common.Hash{}) {
 		stxV2.BlockHash = nil

--- a/eth/api.go
+++ b/eth/api.go
@@ -738,9 +738,11 @@ func (api *ScrollAPI) GetSkippedTransaction(ctx context.Context, hash common.Has
 	rpcTx.SkipBlockNumber = (*hexutil.Big)(new(big.Int).SetUint64(stx.BlockNumber))
 	rpcTx.SkipBlockHash = stx.BlockHash
 	if len(stx.TracesBytes) != 0 {
-		if err := json.Unmarshal(stx.TracesBytes, rpcTx.Traces); err != nil {
+		traces := &types.BlockTrace{}
+		if err := json.Unmarshal(stx.TracesBytes, traces); err != nil {
 			return nil, fmt.Errorf("fail to Unmarshal traces for skipped tx, hash: %s, err: %w", hash.String(), err)
 		}
+		rpcTx.Traces = traces
 	}
 	return &rpcTx, nil
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1120,10 +1120,8 @@ loop:
 
 				// Store skipped transaction in local db
 				if w.config.StoreSkippedTxTraces {
-					log.Info("1", "traces", traces)
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				} else {
-					log.Info("2", "traces", traces)
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				}
 			}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1120,8 +1120,10 @@ loop:
 
 				// Store skipped transaction in local db
 				if w.config.StoreSkippedTxTraces {
+					log.Info("1", "traces", traces)
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, traces, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				} else {
+					log.Info("2", "traces", traces)
 					rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, "row consumption overflow", w.current.header.Number.Uint64(), nil)
 				}
 			}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

**Error**
```
$ curl --location --request POST 'http://localhost:8545' --header 'Content-Type: application/json' --data-raw '{"jsonrpc": "2.0","method": "scroll_getSkippedTransaction","params":["0x734c3a3aeb0a1b993b9b3b8f55200c413251cdd2fd71ff8edd3b544da592e228"],"id": 1}'
{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"fail to Unmarshal traces for skipped tx, hash: 0x734c3a3aeb0a1b993b9b3b8f55200c413251cdd2fd71ff8edd3b544da592e228, err: json: Unmarshal(nil *types.BlockTrace)"}}
```

**Summary**:
+ no need to marshal if traces is nil
+ when doing Unmarshal, must use a nil-pointer for the receiver

**You can verify using this PoC**:
```
type RPCTransaction struct {
	Traces *types.BlockTrace `json:"traces,omitempty"`
}

func main() {
	tracesBytes, err := json.Marshal(nil)
	if err != nil {
		panic(err) 
	}

	var rpcTx RPCTransaction
	if len(tracesBytes) != 0 {
		if err := json.Unmarshal(tracesBytes, rpcTx.Traces); err != nil {
			fmt.Printf("fail to Unmarshal traces for skipped tx1, err: %v\n", err)
		}
		traces:= &types.BlockTrace{}
		if err := json.Unmarshal(tracesBytes, traces); err != nil {
			fmt.Printf("fail to Unmarshal traces for skipped tx 2, err: %v\n", err)
		}
	}

	var xxx *types.BlockTrace
	tracesBytes, err = json.Marshal(xxx)
	if err != nil {
		panic(err) 
	}

	if len(tracesBytes) != 0 {
		if err := json.Unmarshal(tracesBytes, rpcTx.Traces); err != nil {
			fmt.Printf("fail to Unmarshal traces for skipped tx 3, err: %v\n", err)
		}
	}
}
```

Have tested this PR locally.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
