### PR TITLE
fix(libzkp): upgrade to `v0.8.2`

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 0         // Patch version component of the current release
+	VersionPatch = 1         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.lock
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.lock
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.8.1"
-source = "git+https://github.com/scroll-tech/scroll-prover?branch=test-ccc#db1e0545ff127251c3d94d691f5939a704bea887"
+source = "git+https://github.com/scroll-tech/scroll-prover?branch=test-ccc#00b5e8feeeaab78eef5b585d8737bb22ff3b66e0"
 dependencies = [
  "aggregator",
  "anyhow",
@@ -3177,7 +3177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d470e29e933dac4101180fd6574971892315c414cf2961a192729089687cc9b"
 dependencies = [
  "derive_more",
- "primitive-types 0.11.1",
+ "primitive-types 0.12.1",
  "rlp",
  "ruint-macro",
  "rustc_version",

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.lock
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.lock
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.8.1"
-source = "git+https://github.com/scroll-tech/scroll-prover?branch=test-ccc#00b5e8feeeaab78eef5b585d8737bb22ff3b66e0"
+source = "git+https://github.com/scroll-tech/scroll-prover?tag=v0.8.2#02b68773531eec81355ee713c0155bf76aa968b6"
 dependencies = [
  "aggregator",
  "anyhow",

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.lock
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.lock
@@ -2788,7 +2788,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.8.1"
-source = "git+https://github.com/scroll-tech/scroll-prover?tag=v0.8.1#5b94df914877aa7f20f7c37fabf80d73f1c8cf2c"
+source = "git+https://github.com/scroll-tech/scroll-prover?branch=test-ccc#db1e0545ff127251c3d94d691f5939a704bea887"
 dependencies = [
  "aggregator",
  "anyhow",

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.toml
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.toml
@@ -20,7 +20,7 @@ maingate = { git = "https://github.com/scroll-tech/halo2wrong", branch = "halo2-
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves.git", branch = "0.3.1-derive-serde" }
 
 [dependencies]
-prover = { git = "https://github.com/scroll-tech/scroll-prover", tag = "v0.8.1" }
+prover = { git = "https://github.com/scroll-tech/scroll-prover", branch = "test-ccc" }
 
 anyhow = "1.0"
 log = "0.4"

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.toml
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.toml
@@ -20,7 +20,7 @@ maingate = { git = "https://github.com/scroll-tech/halo2wrong", branch = "halo2-
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves.git", branch = "0.3.1-derive-serde" }
 
 [dependencies]
-prover = { git = "https://github.com/scroll-tech/scroll-prover", branch = "test-ccc" }
+prover = { git = "https://github.com/scroll-tech/scroll-prover", tag = "v0.8.2" }
 
 anyhow = "1.0"
 log = "0.4"


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

fix to `row_number <= NORMALIZED_ROW_LIMIT`.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
