### PR TITLE
fix(ccc): fix CCC build errors

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 3         // Patch version component of the current release
+	VersionPatch = 4         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/impl.go
+++ b/rollup/circuitcapacitychecker/impl.go
@@ -11,6 +11,7 @@ import "C" //nolint:typecheck
 
 import (
 	"encoding/json"
+	"fmt"
 	"sync"
 	"unsafe"
 
@@ -147,7 +148,7 @@ func (ccc *CircuitCapacityChecker) ApplyBlock(traces *types.BlockTrace) (*types.
 }
 
 // CheckTxNum compares whether the tx_count in ccc match the expected
-func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, unit64, error) {
+func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, uint64, error) {
 	ccc.Lock()
 	defer ccc.Unlock()
 
@@ -159,13 +160,11 @@ func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, unit64, error
 	log.Debug("ccc get_tx_num end", "id", ccc.ID)
 
 	result := &WrappedTxNum{}
-	if err = json.Unmarshal([]byte(C.GoString(rawResult)), result); err != nil {
-		log.Error("fail to json unmarshal get_tx_num result", "id", ccc.ID, "err", err)
-		return false, 0, ErrUnknown
+	if err := json.Unmarshal([]byte(C.GoString(rawResult)), result); err != nil {
+		return false, 0, fmt.Errorf("fail to json unmarshal get_tx_num result, id: %d, err: %w", ccc.ID, err)
 	}
 	if result.Error != "" {
-		log.Error("fail to get_tx_num in CircuitCapacityChecker", "id", ccc.ID, "err", result.Error)
-		return false, 0, ErrUnknown
+		return false, 0, fmt.Errorf("fail to get_tx_num in CircuitCapacityChecker, id: %d, err: %w", ccc.ID, result.Error)
 	}
 
 	return result.TxNum == unit64(expected), result.TxNum, nil

--- a/rollup/circuitcapacitychecker/impl.go
+++ b/rollup/circuitcapacitychecker/impl.go
@@ -167,5 +167,5 @@ func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, uint64, error
 		return false, 0, fmt.Errorf("fail to get_tx_num in CircuitCapacityChecker, id: %d, err: %w", ccc.ID, result.Error)
 	}
 
-	return result.TxNum == unit64(expected), result.TxNum, nil
+	return result.TxNum == uint64(expected), result.TxNum, nil
 }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Errors:
```
Error: rollup/circuitcapacitychecker/impl.go:150:68: undefined: unit64
Error: rollup/circuitcapacitychecker/impl.go:162:5: undefined: err
Error: rollup/circuitcapacitychecker/impl.go:162:66: undefined: err
Error: rollup/circuitcapacitychecker/impl.go:163:78: undefined: err
Error: rollup/circuitcapacitychecker/impl.go:171:25: undefined: unit64
```

Fixes:
```diff
- func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, unit64, error) {
+ func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, uint64, error) {
```

```diff
- if err = json.Unmarshal([]byte(C.GoString(rawResult)), result); err != nil {
+ if err := json.Unmarshal([]byte(C.GoString(rawResult)), result); err != nil {
```

Additional fix: Return detailed error instead of `ErrUnknown`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
