### PR TITLE
fix(trace): use correct roots in trace of block with one transaction

### DIFF
--- a/core/rawdb/accessors_skipped_txs.go
+++ b/core/rawdb/accessors_skipped_txs.go
@@ -58,7 +58,7 @@ type SkippedTransaction struct {
 	// BlockNumber is the number of the block in which this transaction was skipped.
 	BlockNumber uint64
 
-	// BlockNumber is the hash of the block in which this transaction was skipped or nil.
+	// BlockHash is the hash of the block in which this transaction was skipped or nil.
 	BlockHash *common.Hash
 }
 
@@ -80,7 +80,7 @@ type SkippedTransactionV2 struct {
 	// BlockNumber is the number of the block in which this transaction was skipped.
 	BlockNumber uint64
 
-	// BlockNumber is the hash of the block in which this transaction was skipped or nil.
+	// BlockHash is the hash of the block in which this transaction was skipped or nil.
 	BlockHash *common.Hash
 }
 

--- a/core/trace.go
+++ b/core/trace.go
@@ -322,7 +322,8 @@ func (env *TraceEnv) getTxResult(state *state.StateDB, index int, block *types.B
 	// still we have no state root for per tx, only set the head and tail
 	if index == 0 {
 		txStorageTrace.RootBefore = state.GetRootHash()
-	} else if index == len(block.Transactions())-1 {
+	}
+	if index == len(block.Transactions())-1 {
 		txStorageTrace.RootAfter = block.Root()
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 4         // Patch version component of the current release
+	VersionPatch = 5         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Correctly set `txStorageTrace.RootAfter` in case the block only contains a single transaction.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
