### PR TITLE
fix(sdk): accept blocks where coinbase is null (e.g. pending block)

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -69,7 +69,7 @@ func (n *BlockNonce) UnmarshalText(input []byte) error {
 type Header struct {
 	ParentHash  common.Hash    `json:"parentHash"       gencodec:"required"`
 	UncleHash   common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-	Coinbase    common.Address `json:"miner"            gencodec:"required"`
+	Coinbase    common.Address `json:"miner"`
 	Root        common.Hash    `json:"stateRoot"        gencodec:"required"`
 	TxHash      common.Hash    `json:"transactionsRoot" gencodec:"required"`
 	ReceiptHash common.Hash    `json:"receiptsRoot"     gencodec:"required"`

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -90,9 +90,6 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'sha3Uncles' for Header")
 	}
 	h.UncleHash = *dec.UncleHash
-	if dec.Coinbase == nil {
-		return errors.New("missing required field 'miner' for Header")
-	}
 	h.Coinbase = *dec.Coinbase
 	if dec.Root == nil {
 		return errors.New("missing required field 'stateRoot' for Header")

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -18,7 +18,7 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
 		ParentHash      common.Hash    `json:"parentHash"       gencodec:"required"`
 		UncleHash       common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase        common.Address `json:"miner"            gencodec:"required"`
+		Coinbase        common.Address `json:"miner"`
 		Root            common.Hash    `json:"stateRoot"        gencodec:"required"`
 		TxHash          common.Hash    `json:"transactionsRoot" gencodec:"required"`
 		ReceiptHash     common.Hash    `json:"receiptsRoot"     gencodec:"required"`
@@ -62,7 +62,7 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
 		ParentHash      *common.Hash    `json:"parentHash"       gencodec:"required"`
 		UncleHash       *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase        *common.Address `json:"miner"            gencodec:"required"`
+		Coinbase        *common.Address `json:"miner"`
 		Root            *common.Hash    `json:"stateRoot"        gencodec:"required"`
 		TxHash          *common.Hash    `json:"transactionsRoot" gencodec:"required"`
 		ReceiptHash     *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
@@ -90,7 +90,9 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 		return errors.New("missing required field 'sha3Uncles' for Header")
 	}
 	h.UncleHash = *dec.UncleHash
-	h.Coinbase = *dec.Coinbase
+	if dec.Coinbase != nil {
+		h.Coinbase = *dec.Coinbase
+	}
 	if dec.Root == nil {
 		return errors.New("missing required field 'stateRoot' for Header")
 	}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

- Appear error when getting a pending block, due to coinbase field is null.
- keep consistent with the behavior of the latest version of [go-ethereum](https://github.com/ethereum/go-ethereum/blob/12ef276a7d7faf29e504c52f2efe329a55ab895c/core/types/gen_header_json.go#L102).


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
