### PR TITLE
fix(worker): check gas limit before running ccc

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -891,12 +891,17 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 
 	// do not do CCC checks on follower nodes
 	if w.isRunning() {
+		// do gas limit check up-front and do not run CCC if it fails
+		if w.current.gasPool.Gas() < tx.Gas() {
+			return nil, nil, core.ErrGasLimitReached
+		}
+
 		snap := w.current.state.Snapshot()
 
 		log.Trace(
 			"Worker apply ccc for tx",
 			"id", w.circuitCapacityChecker.ID,
-			"txhash", tx.Hash(),
+			"txHash", tx.Hash().Hex(),
 		)
 
 		// 1. we have to check circuit capacity before `core.ApplyTransaction`,
@@ -922,7 +927,7 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 		log.Trace(
 			"Worker apply ccc for tx result",
 			"id", w.circuitCapacityChecker.ID,
-			"txhash", tx.Hash(),
+			"txHash", tx.Hash().Hex(),
 			"accRows", accRows,
 		)
 	}
@@ -933,6 +938,20 @@ func (w *worker) commitTransaction(tx *types.Transaction, coinbase common.Addres
 	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &coinbase, w.current.gasPool, w.current.state, w.current.header, tx, &w.current.header.GasUsed, *w.chain.GetVMConfig())
 	if err != nil {
 		w.current.state.RevertToSnapshot(snap)
+
+		if accRows != nil {
+			// At this point, we have called CCC but the transaction failed in `ApplyTransaction`.
+			// If we skip this tx and continue to pack more, the next tx will likely fail with
+			// `circuitcapacitychecker.ErrUnknown`. However, at this point we cannot decide whether
+			// we should seal the block or skip the tx and continue, so we simply return the error.
+			log.Error(
+				"GetBlockTrace passed but ApplyTransaction failed, ccc is left in inconsistent state",
+				"blockNumber", w.current.header.Number,
+				"txHash", tx.Hash().Hex(),
+				"err", err,
+			)
+		}
+
 		return nil, traces, err
 	}
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 6         // Patch version component of the current release
+	VersionPatch = 7         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

**Problem**: If tracing passes, but `ApplyTransaction` fails and we skip the transaction, then CCC will be left in an inconsistent state. This can happen in the case of `ErrGasLimitReached`, since this limit is not checked during tracing.

**Impact**: If a  transaction fails and is skipped with such an error, the next transaction will also fail with `ccc.ErrUnknown` and will be skipped unnecessarily.

**Solution**: Check gas-limit up front before running CCC. Also add an error log to make it easier to identify similar issues in the future.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
