### PR TITLE
refactor(worker): order L1 messages by queue index

### DIFF
--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -27,6 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/crypto"
 	"github.com/scroll-tech/go-ethereum/rlp"
@@ -403,6 +405,61 @@ func TestTransactionTimeSort(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestL1MessageQueueIndexSort(t *testing.T) {
+	assert := assert.New(t)
+
+	msgs := []L1MessageTx{
+		{QueueIndex: 3, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 6, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},
+		{QueueIndex: 5, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},
+		{QueueIndex: 4, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{3}},
+	}
+
+	txset, err := NewL1MessagesByQueueIndex(msgs)
+	assert.NoError(err)
+
+	nextIndex := uint64(1)
+
+	for {
+		tx := txset.Peek()
+		if tx == nil {
+			break
+		}
+
+		assert.True(tx.IsL1MessageTx())
+		assert.Equal(nextIndex, tx.AsL1MessageTx().QueueIndex)
+
+		txset.Shift()
+		nextIndex++
+	}
+
+	assert.Equal(uint64(7), nextIndex)
+}
+
+func TestL1MessageQueueIndexSortInvalid(t *testing.T) {
+	assert := assert.New(t)
+
+	msgs := []L1MessageTx{
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 2, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+	}
+
+	_, err := NewL1MessagesByQueueIndex(msgs)
+	assert.Error(err)
+
+	msgs = []L1MessageTx{
+		{QueueIndex: 1, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 3, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+		{QueueIndex: 4, Gas: 21016, To: &common.Address{1}, Data: []byte{0x01}, Sender: common.Address{2}},
+	}
+
+	_, err = NewL1MessagesByQueueIndex(msgs)
+	assert.Error(err)
 }
 
 // TestTransactionCoding tests serializing/de-serializing to/from rlp and JSON.

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 8         // Patch version component of the current release
+	VersionPatch = 9         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 7         // Patch version component of the current release
+	VersionPatch = 8         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 9         // Patch version component of the current release
+	VersionPatch = 10        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

`TransactionsByPriceAndNonce` is a data structure used to order transactions by gas price and nonce. The idea is that we can process transactions from one account following their nonce order, and we can simply skip all transactions from an account if one in the middle is not executed.  If all gas prices and nonces are equal, then it will order transactions based on their timestamp.

We currently reuse `TransactionsByPriceAndNonce` for processing L1 messages. However, L1 messages are ordered by their `QueueIndex`. Gas prices and nonces for L1 messages are `0`, and the `worker` ensures that the timestamps follow the `QueueIndex` order so this all happens to work.

However, this is hacky and error prone for multiple reasons:
- It is non-trivial to see that the order of processing L1 messages is correct. This was actually raised as a false positive critical finding during an audit. We added a test `TestTransactionTimeSort` to verify this behaviour.
- We should ensure to never call `Pop()` on an L1 message set. In other words, we should only skip a single L1 message and never skip all L1 messages from the same sender account. Otherwise we might skip L1 messages unnecessarily.

This PR improves this by introducing a new interface `OrderedTransactionSet`. `worker.commitTransactions` will now receive this interface. It has two implementations: `TransactionsByPriceAndNonce` (used for L2 transactions) and `L1MessagesByQueueIndex` (used for L1 message transactions).

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
