### PR TITLE
feat: use light_mode = false for block ccc

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 11        // Patch version component of the current release
+	VersionPatch = 12        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/src/lib.rs
+++ b/rollup/circuitcapacitychecker/libzkp/src/lib.rs
@@ -160,7 +160,7 @@ pub mod checker {
         let traces = serde_json::from_slice::<BlockTrace>(&block_trace)?;
 
         let r = panic::catch_unwind(|| {
-            CHECKERS
+            let ccc_instance = CHECKERS
                 .get_mut()
                 .ok_or(anyhow!(
                     "fail to get circuit capacity checkers map in apply_block"
@@ -168,8 +168,9 @@ pub mod checker {
                 .get_mut(&id)
                 .ok_or(anyhow!(
                     "fail to get circuit capacity checker (id: {id:?}) in apply_block"
-                ))?
-                .estimate_circuit_capacity(&[traces])
+                ))?;
+            ccc_instance.light_mode = false;
+            ccc_instance.estimate_circuit_capacity(&[traces])
         });
         match r {
             Ok(result) => result,


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

use "non light" mode for follower ccc, to get accurate row usage estimation.  By using this, we estimate gas/chunk can be doubled on average.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
