### PR TITLE
fix: re-enable CCC light mode

### DIFF
--- a/core/block_validator.go
+++ b/core/block_validator.go
@@ -56,7 +56,7 @@ func NewBlockValidator(config *params.ChainConfig, blockchain *BlockChain, engin
 		bc:                     blockchain,
 		checkCircuitCapacity:   checkCircuitCapacity,
 		db:                     db,
-		circuitCapacityChecker: circuitcapacitychecker.NewCircuitCapacityChecker(false),
+		circuitCapacityChecker: circuitcapacitychecker.NewCircuitCapacityChecker(true),
 	}
 	log.Info("created new BlockValidator", "CircuitCapacityChecker ID", validator.circuitCapacityChecker.ID)
 	return validator

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 16        // Patch version component of the current release
+	VersionPatch = 17        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

During testing we found that nodes with CCC light mode disabled cannot keep up with the sequencer. This PR re-enables light mode.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
