### PR TITLE
fix: use non-overlapping DB prefix for L1 messages

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1813,6 +1813,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			SetDNSDiscoveryDefaults(cfg, params.MainnetGenesisHash)
 		}
 	}
+
+	// set db prefix for backward-compatibility
+	if cfg.NetworkId == 534351 {
+		log.Warn("Using legacy db prefix for L1 messages")
+		rawdb.SetL1MessageLegacyPrefix()
+	}
 }
 
 // SetDNSDiscoveryDefaults configures DNS discovery with the given URL if

--- a/core/rawdb/database.go
+++ b/core/rawdb/database.go
@@ -324,6 +324,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		bloomBits       stat
 		cliqueSnaps     stat
 		l1Messages      stat
+		l1MessagesOld   stat
 		lastL1Message   stat
 
 		// Ancient store statistics
@@ -386,6 +387,8 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 			cliqueSnaps.Add(size)
 		case bytes.HasPrefix(key, l1MessagePrefix) && len(key) == len(l1MessagePrefix)+8:
 			l1Messages.Add(size)
+		case bytes.HasPrefix(key, l1MessageLegacyPrefix) && len(key) == len(l1MessageLegacyPrefix)+8:
+			l1MessagesOld.Add(size)
 		case bytes.HasPrefix(key, firstQueueIndexNotInL2BlockPrefix) && len(key) == len(firstQueueIndexNotInL2BlockPrefix)+common.HashLength:
 			lastL1Message.Add(size)
 		case bytes.HasPrefix(key, []byte("cht-")) ||
@@ -451,6 +454,7 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 		{"Key-Value store", "Clique snapshots", cliqueSnaps.Size(), cliqueSnaps.Count()},
 		{"Key-Value store", "Singleton metadata", metadata.Size(), metadata.Count()},
 		{"Key-Value store", "L1 messages", l1Messages.Size(), l1Messages.Count()},
+		{"Key-Value store", "L1 messages (legacy prefix)", l1MessagesOld.Size(), l1MessagesOld.Count()},
 		{"Key-Value store", "Last L1 message", lastL1Message.Size(), lastL1Message.Count()},
 		{"Ancient store", "Headers", ancientHeadersSize.String(), ancients.String()},
 		{"Ancient store", "Bodies", ancientBodiesSize.String(), ancients.String()},

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -105,7 +105,8 @@ var (
 
 	// Scroll L1 message store
 	syncedL1BlockNumberKey            = []byte("LastSyncedL1BlockNumber")
-	l1MessagePrefix                   = []byte("l1") // l1MessagePrefix + queueIndex (uint64 big endian) -> L1MessageTx
+	l1MessageLegacyPrefix             = []byte("l1")
+	l1MessagePrefix                   = []byte("L1") // l1MessagePrefix + queueIndex (uint64 big endian) -> L1MessageTx
 	firstQueueIndexNotInL2BlockPrefix = []byte("q")  // firstQueueIndexNotInL2BlockPrefix + L2 block hash -> enqueue index
 	highestSyncedQueueIndexKey        = []byte("HighestSyncedQueueIndex")
 
@@ -117,6 +118,13 @@ var (
 	skippedTransactionPrefix     = []byte("skip") // skippedTransactionPrefix + tx hash -> skipped transaction
 	skippedTransactionHashPrefix = []byte("sh")   // skippedTransactionHashPrefix + index -> tx hash
 )
+
+// Use the updated "L1" prefix on all new networks
+// to avoid overlap with txLookupPrefix.
+// Use the legacy "l1" prefix on Scroll Sepolia.
+func SetL1MessageLegacyPrefix() {
+	l1MessagePrefix = l1MessageLegacyPrefix
+}
 
 const (
 	// freezerHeaderTable indicates the name of the freezer header table.

--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	VersionMajor = 4         // Major version component of the current release
-	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 19        // Patch version component of the current release
+	VersionMinor = 5         // Minor version component of the current release
+	VersionPatch = 0         // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 4         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 18        // Patch version component of the current release
+	VersionPatch = 19        // Patch version component of the current release
 	VersionMeta  = "sepolia" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

`txLookupPrefix` (`"l"`) and `l1MessagePrefix` (`"l1"`) overlap, which leads to lots of unnecessary db reads during iteration.

This PR changes `l1MessagePrefix` to `"L1"` on all networks, except Scroll Sepolia. On Scroll Sepolia we keep `"l1"` for compatibility.

Note: Any private l2geth networks will crash after upgrading to this version. We don't expect anyone to maintain such networks, and we don't offer any guarantees of stability for such users. However, we should mention this in the release notes. For this reason I'll mark it as a `breaking-change`, but it's not a breaking change on Scroll Sepolia.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [X] Yes
