### PR TITLE
fix: eth_estimateGas error in zero balance address

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -953,7 +953,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, b.backend.RPCEVMTimeout(), b.backend.RPCGasCap(), false)
+	result, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, b.backend.RPCEVMTimeout(), b.backend.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}
@@ -1023,7 +1023,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, p.backend.RPCEVMTimeout(), p.backend.RPCGasCap(), false)
+	result, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, p.backend.RPCEVMTimeout(), p.backend.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -953,7 +953,7 @@ func (b *Block) Call(ctx context.Context, args struct {
 			return nil, err
 		}
 	}
-	result, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, b.backend.RPCEVMTimeout(), b.backend.RPCGasCap())
+	result, err := ethapi.DoCall(ctx, b.backend, args.Data, *b.numberOrHash, nil, b.backend.RPCEVMTimeout(), b.backend.RPCGasCap(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -1023,7 +1023,7 @@ func (p *Pending) Call(ctx context.Context, args struct {
 	Data ethapi.TransactionArgs
 }) (*CallResult, error) {
 	pendingBlockNr := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	result, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, p.backend.RPCEVMTimeout(), p.backend.RPCGasCap())
+	result, err := ethapi.DoCall(ctx, p.backend, args.Data, pendingBlockNr, nil, p.backend.RPCEVMTimeout(), p.backend.RPCGasCap(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -741,10 +741,10 @@ func (s *PublicBlockChainAPI) GetHeaderByHash(ctx context.Context, hash common.H
 }
 
 // GetBlockByNumber returns the requested canonical block.
-//   - When blockNr is -1 the chain head is returned.
-//   - When blockNr is -2 the pending chain head is returned.
-//   - When fullTx is true all transactions in the block are returned, otherwise
-//     only the transaction hash is returned.
+// * When blockNr is -1 the chain head is returned.
+// * When blockNr is -2 the pending chain head is returned.
+// * When fullTx is true all transactions in the block are returned, otherwise
+//   only the transaction hash is returned.
 func (s *PublicBlockChainAPI) GetBlockByNumber(ctx context.Context, number rpc.BlockNumber, fullTx bool) (map[string]interface{}, error) {
 	block, err := s.b.BlockByNumber(ctx, number)
 	if block != nil && err == nil {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -849,12 +849,11 @@ func (s *PublicBlockChainAPI) GetStorageAt(ctx context.Context, address common.A
 // if statDiff is set, all diff will be applied first and then execute the call
 // message.
 type OverrideAccount struct {
-	Nonce      *hexutil.Uint64              `json:"nonce"`
-	Code       *hexutil.Bytes               `json:"code"`
-	Balance    **hexutil.Big                `json:"balance"`
-	BalanceAdd **hexutil.Big                `json:"balanceAdd"`
-	State      *map[common.Hash]common.Hash `json:"state"`
-	StateDiff  *map[common.Hash]common.Hash `json:"stateDiff"`
+	Nonce     *hexutil.Uint64              `json:"nonce"`
+	Code      *hexutil.Bytes               `json:"code"`
+	Balance   **hexutil.Big                `json:"balance"`
+	State     *map[common.Hash]common.Hash `json:"state"`
+	StateDiff *map[common.Hash]common.Hash `json:"stateDiff"`
 }
 
 // StateOverride is the collection of overridden accounts.
@@ -875,15 +874,8 @@ func (diff *StateOverride) Apply(state *state.StateDB) error {
 			state.SetCode(addr, *account.Code)
 		}
 		// Override account balance.
-		if account.Balance != nil && account.BalanceAdd != nil {
-			return fmt.Errorf("account %s has both 'balance' and 'balanceAdd'", addr.Hex())
-		}
 		if account.Balance != nil {
 			state.SetBalance(addr, (*big.Int)(*account.Balance))
-		}
-		if account.BalanceAdd != nil {
-			balance := big.NewInt(0).Add(state.GetBalance(addr), (*big.Int)(*account.BalanceAdd))
-			state.SetBalance(addr, balance)
 		}
 		if account.State != nil && account.StateDiff != nil {
 			return fmt.Errorf("account %s has both 'state' and 'stateDiff'", addr.Hex())
@@ -951,7 +943,7 @@ func EstimateL1MsgFee(ctx context.Context, b Backend, args TransactionArgs, bloc
 	return fees.EstimateL1DataFeeForMessage(msg, header.BaseFee, config.ChainID, signer, evm.StateDB)
 }
 
-func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, timeout time.Duration, globalGasCap uint64, isEstimateGas bool) (*core.ExecutionResult, error) {
+func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, timeout time.Duration, globalGasCap uint64) (*core.ExecutionResult, error) {
 	defer func(start time.Time) { log.Debug("Executing EVM call finished", "runtime", time.Since(start)) }(time.Now())
 
 	state, header, err := b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
@@ -992,17 +984,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 	// Execute the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
 
-	signer := types.MakeSigner(b.ChainConfig(), header.Number)
-	l1DataFee, err := fees.EstimateL1DataFeeForMessage(msg, header.BaseFee, b.ChainConfig().ChainID, signer, state)
-	if err != nil {
-		return nil, err
-	}
-
-	if isEstimateGas {
-		l1DataFee = common.Big0
-	}
-
-	result, err := core.ApplyMessage(evm, msg, gp, l1DataFee)
+	result, err := core.ApplyMessage(evm, msg, gp, common.Big0)
 	if err := vmError(); err != nil {
 		return nil, err
 	}
@@ -1054,27 +1036,7 @@ func (e *revertError) ErrorData() interface{} {
 // Note, this function doesn't make and changes in the state/blockchain and is
 // useful to execute and retrieve values.
 func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Bytes, error) {
-	// If gasPrice is 0 and no state override is set, make sure
-	// that the account has sufficient balance to cover `l1DataFee`.
-	isGasPriceZero := args.GasPrice == nil || args.GasPrice.ToInt().Cmp(big.NewInt(0)) == 0
-
-	if overrides == nil {
-		overrides = &StateOverride{}
-	}
-	_, isOverrideSet := (*overrides)[args.from()]
-
-	if isGasPriceZero && !isOverrideSet {
-		l1DataFee, err := EstimateL1MsgFee(ctx, s.b, args, blockNrOrHash, overrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap(), s.b.ChainConfig())
-		if err != nil {
-			return nil, err
-		}
-
-		(*overrides)[args.from()] = OverrideAccount{
-			BalanceAdd: newRPCBalance(l1DataFee),
-		}
-	}
-
-	result, err := DoCall(ctx, s.b, args, blockNrOrHash, overrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap(), false)
+	result, err := DoCall(ctx, s.b, args, blockNrOrHash, overrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}
@@ -1172,7 +1134,7 @@ func DoEstimateGas(ctx context.Context, b Backend, args TransactionArgs, blockNr
 	executable := func(gas uint64) (bool, *core.ExecutionResult, error) {
 		args.Gas = (*hexutil.Uint64)(&gas)
 
-		result, err := DoCall(ctx, b, args, blockNrOrHash, nil, 0, gasCap, true)
+		result, err := DoCall(ctx, b, args, blockNrOrHash, nil, 0, gasCap)
 		if err != nil {
 			if errors.Is(err, core.ErrIntrinsicGas) {
 				return true, nil, nil // Special case, raise gas limit

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -894,11 +894,6 @@ func (diff *StateOverride) Apply(state *state.StateDB) error {
 	return nil
 }
 
-func newRPCBalance(balance *big.Int) **hexutil.Big {
-	rpcBalance := (*hexutil.Big)(balance)
-	return &rpcBalance
-}
-
 func EstimateL1MsgFee(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride, timeout time.Duration, globalGasCap uint64, config *params.ChainConfig) (*big.Int, error) {
 	if !config.Scroll.FeeVaultEnabled() {
 		return big.NewInt(0), nil

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 2         // Patch version component of the current release
+	VersionPatch = 3         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Correct response (Ethereum, account with 0 balance):

```
curl https://mainnet.infura.io/v3/9baa7a0388c9440a85534617d4d862a9 -X POST -H "Content-Type: application/json" --data '{"method":"eth_estimateGas","params":[{"from":"0x8888889C9818892B700e27F316cc3E41e17fBeb9","to":"0x8888889C9818892B700e27F316cc3E41e17fBeb9"}],"id":1,"jsonrpc":"2.0"}'

{"jsonrpc":"2.0","id":1,"result":"0x5208"}
```


Incorrect response (Scroll, account with 0 balance):

```
curl https://rpc.scroll.io/ -X POST -H "Content-Type: application/json" --data '{"method":"eth_estimateGas","params":[{"from":"0x8888889C9818892B700e27F316cc3E41e17fBeb9","to":"0x8888889C9818892B700e27F316cc3E41e17fBeb9"}],"id":1,"jsonrpc":"2.0"}'

{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"err: insufficient funds for gas * price + value: address 0x8888889C9818892b700E27f316CC3E41e17fbeb9 have 0 want 75453596795115 (supplied gas 5005617)"}}
```

Root cause:
1. Error msg return path:
a. https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/core/state_transition.go#L243
b. https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/core/state_transition.go#L312
c. https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/core/state_transition.go#L341
d. https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/core/state_transition.go#L205
e. https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/internal/ethapi/api.go#L1003
f. https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/internal/ethapi/api.go#L1176
2. Caused by adding l1 data fee here: https://github.com/scroll-tech/go-ethereum/blob/scroll-v5.0.1/core/state_transition.go#L238

No need to check L1 data fee in `DoCall`, because it only checks if the tx can be successfully executed within a specified gas limit.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205740405905906