### PR TITLE
fix (libzkp): free Rust CString by `from_raw` (potential memory leak)

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 0         // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/impl.go
+++ b/rollup/circuitcapacitychecker/impl.go
@@ -79,7 +79,7 @@ func (ccc *CircuitCapacityChecker) ApplyTransaction(traces *types.BlockTrace) (*
 	log.Debug("start to check circuit capacity for tx", "id", ccc.ID, "TxHash", traces.Transactions[0].TxHash)
 	rawResult := C.apply_tx(C.uint64_t(ccc.ID), tracesStr)
 	defer func() {
-		C.free(unsafe.Pointer(rawResult))
+		C.free_c_chars(rawResult)
 	}()
 	log.Debug("check circuit capacity for tx done", "id", ccc.ID, "TxHash", traces.Transactions[0].TxHash)
 
@@ -125,7 +125,7 @@ func (ccc *CircuitCapacityChecker) ApplyBlock(traces *types.BlockTrace) (*types.
 	log.Debug("start to check circuit capacity for block", "id", ccc.ID, "blockNumber", traces.Header.Number, "blockHash", traces.Header.Hash())
 	rawResult := C.apply_block(C.uint64_t(ccc.ID), tracesStr)
 	defer func() {
-		C.free(unsafe.Pointer(rawResult))
+		C.free_c_chars(rawResult)
 	}()
 	log.Debug("check circuit capacity for block done", "id", ccc.ID, "blockNumber", traces.Header.Number, "blockHash", traces.Header.Hash())
 
@@ -157,7 +157,7 @@ func (ccc *CircuitCapacityChecker) CheckTxNum(expected int) (bool, uint64, error
 	log.Debug("ccc get_tx_num start", "id", ccc.ID)
 	rawResult := C.get_tx_num(C.uint64_t(ccc.ID))
 	defer func() {
-		C.free(unsafe.Pointer(rawResult))
+		C.free_c_chars(rawResult)
 	}()
 	log.Debug("ccc get_tx_num end", "id", ccc.ID)
 
@@ -180,7 +180,7 @@ func (ccc *CircuitCapacityChecker) SetLightMode(lightMode bool) error {
 	log.Debug("ccc set_light_mode start", "id", ccc.ID)
 	rawResult := C.set_light_mode(C.uint64_t(ccc.ID), C.bool(lightMode))
 	defer func() {
-		C.free(unsafe.Pointer(rawResult))
+		C.free_c_chars(rawResult)
 	}()
 	log.Debug("ccc set_light_mode end", "id", ccc.ID)
 

--- a/rollup/circuitcapacitychecker/libzkp/libzkp.h
+++ b/rollup/circuitcapacitychecker/libzkp/libzkp.h
@@ -8,3 +8,4 @@ char* apply_tx(uint64_t id, char *tx_traces);
 char* apply_block(uint64_t id, char *block_trace);
 char* get_tx_num(uint64_t id);
 char* set_light_mode(uint64_t id, bool light_mode);
+void free_c_chars(char* ptr);

--- a/rollup/circuitcapacitychecker/libzkp/src/lib.rs
+++ b/rollup/circuitcapacitychecker/libzkp/src/lib.rs
@@ -259,10 +259,21 @@ pub mod checker {
     }
 }
 
-pub(crate) mod utils {
+pub mod utils {
     use std::ffi::{CStr, CString};
     use std::os::raw::c_char;
     use std::str::Utf8Error;
+
+    /// # Safety
+    #[no_mangle]
+    pub unsafe extern "C" fn free_c_chars(ptr: *mut c_char) {
+        if ptr.is_null() {
+            log::warn!("Try to free an empty pointer!");
+            return;
+        }
+
+        let _ = CString::from_raw(ptr);
+    }
 
     #[allow(dead_code)]
     pub(crate) fn c_char_to_str(c: *const c_char) -> Result<&'static str, Utf8Error> {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Fix potential memory leak of [CString::into_raw](https://doc.rust-lang.org/stable/std/ffi/struct.CString.html#method.into_raw). Similar as https://github.com/scroll-tech/scroll/pull/998

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
