### PR TITLE
Rollup/circuitcapacitychecker fix bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 [submodule "internal/utesting/blocktraces"]
 	path = internal/utesting/blocktraces
 	url = git@github.com:scroll-tech/test-traces.git
+[submodule "lib/solmate"]
+	path = lib/solmate
+	url = https://github.com/transmissions11/solmate

--- a/rollup/circuitcapacitychecker/impl.go
+++ b/rollup/circuitcapacitychecker/impl.go
@@ -44,9 +44,9 @@ func NewCircuitCapacityChecker(lightMode bool) *CircuitCapacityChecker {
 }
 
 // Reset resets a CircuitCapacityChecker
-func (ccc *CircuitCapacityChecker) Reset() {
-	ccc.Lock()
-	defer ccc.Unlock()
+func Reset(ccc *CircuitCapacityChecker) {
+	creationMu.Lock()
+	defer creationMu.Unlock()
 
 	C.reset_circuit_capacity_checker(C.uint64_t(ccc.ID))
 }
@@ -189,7 +189,7 @@ func (ccc *CircuitCapacityChecker) SetLightMode(lightMode bool) error {
 		return fmt.Errorf("fail to json unmarshal set_light_mode result, id: %d, err: %w", ccc.ID, err)
 	}
 	if result.Error != "" {
-		return fmt.Errorf("fail to set_light_mode in CircuitCapacityChecker, id: %d, err: %w", ccc.ID, result.Error)
+		return fmt.Errorf("fail to set_light_mode in CircuitCapacityChecker, id: %d, err: %s", ccc.ID, result.Error)
 	}
 
 	return nil


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Due to `NewCircuitCapacityChecker`'s creation is locked by `creationMu` so the reset also need it.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
