### PR TITLE
feat(rpc): add scroll_* rollup APIs

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -715,6 +715,78 @@ func (api *ScrollAPI) GetNumSkippedTransactions(ctx context.Context) (uint64, er
 	return rawdb.ReadNumSkippedTransactions(api.eth.ChainDb()), nil
 }
 
+// FinalizedBlockHeight returns the L2 finalized block height.
+func (api *ScrollAPI) FinalizedBlockHeight(ctx context.Context) (uint64, error) {
+	finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(api.eth.ChainDb())
+	if finalizedBlockHeightPtr == nil {
+		return 0, errors.New("L2 finalized block height not found in database")
+	}
+	return *finalizedBlockHeightPtr, nil
+}
+
+// IsBlockFinalized returns true if the provided block is finalized.
+func (api *ScrollAPI) IsBlockFinalized(ctx context.Context, blockHeight uint64) (bool, error) {
+	finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(api.eth.ChainDb())
+	if finalizedBlockHeightPtr == nil {
+		return false, errors.New("L2 finalized block height not found in database")
+	}
+	return blockHeight <= *finalizedBlockHeightPtr, nil
+}
+
+// SyncStatus includes L2 block sync height, L1 rollup sync height,
+// L1 message sync height, and L2 finalized block height.
+type SyncStatus struct {
+	L2BlockSyncHeight      uint64 `json:"l2BlockSyncHeight,omitempty"`
+	L1RollupSyncHeight     uint64 `json:"l1RollupSyncHeight,omitempty"`
+	L1MessageSyncHeight    uint64 `json:"l1MessageSyncHeight,omitempty"`
+	L2FinalizedBlockHeight uint64 `json:"l2FinalizedBlockHeight,omitempty"`
+}
+
+// SyncStatus returns the overall rollup status including L2 block sync height, L1 rollup sync height,
+// L1 message sync height, and L2 finalized block height.
+func (api *ScrollAPI) SyncStatus(ctx context.Context) *SyncStatus {
+	status := &SyncStatus{}
+
+	l2BlockHeader := api.eth.blockchain.CurrentHeader()
+	if l2BlockHeader != nil {
+		status.L2BlockSyncHeight = l2BlockHeader.Number.Uint64()
+	}
+
+	l1RollupSyncHeightPtr := rawdb.ReadRollupEventSyncedL1BlockNumber(api.eth.ChainDb())
+	if l1RollupSyncHeightPtr != nil {
+		status.L1RollupSyncHeight = *l1RollupSyncHeightPtr
+	}
+
+	l1MessageSyncHeightPtr := rawdb.ReadSyncedL1BlockNumber(api.eth.ChainDb())
+	if l1MessageSyncHeightPtr != nil {
+		status.L1MessageSyncHeight = *l1MessageSyncHeightPtr
+	}
+
+	l2FinalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(api.eth.ChainDb())
+	if l2FinalizedBlockHeightPtr != nil {
+		status.L2FinalizedBlockHeight = *l2FinalizedBlockHeightPtr
+	}
+
+	return status
+}
+
+// EstimateL1DataFee returns an estimate of the L1 data fee required to
+// process the given transaction against the current pending block.
+func (api *ScrollAPI) EstimateL1DataFee(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash) (*hexutil.Uint64, error) {
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	if blockNrOrHash != nil {
+		bNrOrHash = *blockNrOrHash
+	}
+
+	l1DataFee, err := ethapi.EstimateL1MsgFee(ctx, api.eth.APIBackend, args, bNrOrHash, nil, 0, api.eth.APIBackend.RPCGasCap(), api.eth.APIBackend.ChainConfig())
+	if err != nil {
+		return nil, fmt.Errorf("failed to estimate L1 data fee: %w", err)
+	}
+
+	result := hexutil.Uint64(l1DataFee.Uint64())
+	return &result, nil
+}
+
 // RPCTransaction is the standard RPC transaction return type with some additional skip-related fields.
 type RPCTransaction struct {
 	ethapi.RPCTransaction

--- a/eth/api.go
+++ b/eth/api.go
@@ -716,7 +716,7 @@ func (api *ScrollAPI) GetNumSkippedTransactions(ctx context.Context) (uint64, er
 }
 
 // FinalizedBlockHeight returns the L2 finalized block height.
-func (api *ScrollAPI) FinalizedBlockHeight(ctx context.Context) (uint64, error) {
+func (api *ScrollAPI) FinalizedBlockHeight(_ context.Context) (uint64, error) {
 	finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(api.eth.ChainDb())
 	if finalizedBlockHeightPtr == nil {
 		return 0, errors.New("L2 finalized block height not found in database")
@@ -726,11 +726,11 @@ func (api *ScrollAPI) FinalizedBlockHeight(ctx context.Context) (uint64, error) 
 
 // IsBlockFinalized returns true if the provided block is finalized.
 func (api *ScrollAPI) IsBlockFinalized(ctx context.Context, blockHeight uint64) (bool, error) {
-	finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(api.eth.ChainDb())
-	if finalizedBlockHeightPtr == nil {
-		return false, errors.New("L2 finalized block height not found in database")
+	finalizedBlockHeight, err := api.FinalizedBlockHeight(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to get L2 finalized block height: %w", err)
 	}
-	return blockHeight <= *finalizedBlockHeightPtr, nil
+	return blockHeight <= finalizedBlockHeight, nil
 }
 
 // SyncStatus includes L2 block sync height, L1 rollup sync height,
@@ -744,7 +744,7 @@ type SyncStatus struct {
 
 // SyncStatus returns the overall rollup status including L2 block sync height, L1 rollup sync height,
 // L1 message sync height, and L2 finalized block height.
-func (api *ScrollAPI) SyncStatus(ctx context.Context) *SyncStatus {
+func (api *ScrollAPI) SyncStatus(_ context.Context) *SyncStatus {
 	status := &SyncStatus{}
 
 	l2BlockHeader := api.eth.blockchain.CurrentHeader()

--- a/eth/api.go
+++ b/eth/api.go
@@ -715,24 +715,6 @@ func (api *ScrollAPI) GetNumSkippedTransactions(ctx context.Context) (uint64, er
 	return rawdb.ReadNumSkippedTransactions(api.eth.ChainDb()), nil
 }
 
-// FinalizedBlockHeight returns the L2 finalized block height.
-func (api *ScrollAPI) FinalizedBlockHeight(_ context.Context) (uint64, error) {
-	finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(api.eth.ChainDb())
-	if finalizedBlockHeightPtr == nil {
-		return 0, errors.New("L2 finalized block height not found in database")
-	}
-	return *finalizedBlockHeightPtr, nil
-}
-
-// IsBlockFinalized returns true if the provided block is finalized.
-func (api *ScrollAPI) IsBlockFinalized(ctx context.Context, blockHeight uint64) (bool, error) {
-	finalizedBlockHeight, err := api.FinalizedBlockHeight(ctx)
-	if err != nil {
-		return false, fmt.Errorf("failed to get L2 finalized block height: %w", err)
-	}
-	return blockHeight <= finalizedBlockHeight, nil
-}
-
 // SyncStatus includes L2 block sync height, L1 rollup sync height,
 // L1 message sync height, and L2 finalized block height.
 type SyncStatus struct {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -76,7 +76,7 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
-	if number == rpc.L2FinalizedBlockNumber {
+	if number == rpc.FinalizedBlockNumber {
 		finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(b.eth.ChainDb())
 		if finalizedBlockHeightPtr == nil {
 			return nil, errors.New("L2 finalized block height not found in database")
@@ -118,7 +118,7 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
-	if number == rpc.L2FinalizedBlockNumber {
+	if number == rpc.FinalizedBlockNumber {
 		finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(b.eth.ChainDb())
 		if finalizedBlockHeightPtr == nil {
 			return nil, errors.New("L2 finalized block height not found in database")

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -76,6 +76,14 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
+	if number == rpc.L2FinalizedBlockNumber {
+		finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(b.eth.ChainDb())
+		if finalizedBlockHeightPtr == nil {
+			return nil, errors.New("L2 finalized block height not found in database")
+		}
+		number = rpc.BlockNumber(*finalizedBlockHeightPtr)
+		return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
+	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
 
@@ -109,6 +117,14 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	// Otherwise resolve and return the block
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
+	}
+	if number == rpc.L2FinalizedBlockNumber {
+		finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(b.eth.ChainDb())
+		if finalizedBlockHeightPtr == nil {
+			return nil, errors.New("L2 finalized block height not found in database")
+		}
+		number = rpc.BlockNumber(*finalizedBlockHeightPtr)
+		return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 	}
 	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 }

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -170,6 +170,13 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.Block
 	} else if pendingBlock == nil && lastBlock > headBlock {
 		return nil, nil, 0, 0, fmt.Errorf("%w: requested %d, head %d", errRequestBeyondHead, lastBlock, headBlock)
 	}
+	if lastBlock == rpc.FinalizedBlockNumber {
+		if latestFinalizedHeader, err := oracle.backend.HeaderByNumber(ctx, rpc.FinalizedBlockNumber); err == nil {
+			lastBlock = rpc.BlockNumber(latestFinalizedHeader.Number.Uint64())
+		} else {
+			return nil, nil, 0, 0, err
+		}
+	}
 	// ensure not trying to retrieve before genesis
 	if rpc.BlockNumber(blocks) > lastBlock+1 {
 		blocks = int(lastBlock + 1)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -898,11 +898,6 @@ web3._extend({
 			params: 2
 		}),
 		new web3._extend.Method({
-			name: 'isBlockFinalized',
-			call: 'scroll_isBlockFinalized',
-			params: 1
-		}),
-		new web3._extend.Method({
 			name: 'estimateL1DataFee',
 			call: 'scroll_estimateL1DataFee',
 			params: 2,
@@ -923,10 +918,6 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'numSkippedTransactions',
 			getter: 'scroll_getNumSkippedTransactions'
-		}),
-		new web3._extend.Method({
-			name: 'finalizedBlockHeight',
-			getter: 'scroll_finalizedBlockHeight',
 		}),
 		new web3._extend.Method({
 			name: 'syncStatus',

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -919,8 +919,8 @@ web3._extend({
 			name: 'numSkippedTransactions',
 			getter: 'scroll_getNumSkippedTransactions'
 		}),
-		new web3._extend.Method({
-			name: 'scroll_syncStatus',
+		new web3._extend.Property({
+			name: 'syncStatus',
 			getter: 'scroll_syncStatus',
 		}),
 	]

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -897,6 +897,18 @@ web3._extend({
 			call: 'scroll_getSkippedTransactionHashes',
 			params: 2
 		}),
+		new web3._extend.Method({
+			name: 'isBlockFinalized',
+			call: 'scroll_isBlockFinalized',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'estimateL1DataFee',
+			call: 'scroll_estimateL1DataFee',
+			params: 2,
+			inputFormatter: [web3._extend.formatters.inputCallFormatter, web3._extend.formatters.inputBlockNumberFormatter],
+			outputFormatter: web3._extend.utils.toDecimal
+		}),
 	],
 	properties:
 	[
@@ -911,6 +923,14 @@ web3._extend({
 		new web3._extend.Property({
 			name: 'numSkippedTransactions',
 			getter: 'scroll_getNumSkippedTransactions'
+		}),
+		new web3._extend.Method({
+			name: 'finalizedBlockHeight',
+			getter: 'scroll_finalizedBlockHeight',
+		}),
+		new web3._extend.Method({
+			name: 'syncStatus',
+			getter: 'scroll_syncStatus',
 		}),
 	]
 });

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -920,7 +920,7 @@ web3._extend({
 			getter: 'scroll_getNumSkippedTransactions'
 		}),
 		new web3._extend.Method({
-			name: 'syncStatus',
+			name: 'scroll_syncStatus',
 			getter: 'scroll_syncStatus',
 		}),
 	]

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 0         // Patch version component of the current release
+	VersionPatch = 1         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -58,15 +58,11 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
-	// L1
 	SafeBlockNumber      = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
 	PendingBlockNumber   = BlockNumber(-2)
 	LatestBlockNumber    = BlockNumber(-1)
 	EarliestBlockNumber  = BlockNumber(0)
-
-	// L2
-	L2FinalizedBlockNumber = BlockNumber(-1001)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -97,9 +93,6 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "safe":
 		*bn = SafeBlockNumber
 		return nil
-	case "l2finalized":
-		*bn = L2FinalizedBlockNumber
-		return nil
 	}
 
 	blckNum, err := hexutil.DecodeUint64(input)
@@ -128,8 +121,6 @@ func (bn BlockNumber) MarshalText() ([]byte, error) {
 		return []byte("finalized"), nil
 	case SafeBlockNumber:
 		return []byte("safe"), nil
-	case L2FinalizedBlockNumber:
-		return []byte("l2finalized"), nil
 	default:
 		return hexutil.Uint64(bn).MarshalText()
 	}
@@ -182,10 +173,6 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	case "safe":
 		bn := SafeBlockNumber
-		bnh.BlockNumber = &bn
-		return nil
-	case "l2finalized":
-		bn := L2FinalizedBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	default:

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -58,11 +58,15 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
+	// L1
 	SafeBlockNumber      = BlockNumber(-4)
 	FinalizedBlockNumber = BlockNumber(-3)
 	PendingBlockNumber   = BlockNumber(-2)
 	LatestBlockNumber    = BlockNumber(-1)
 	EarliestBlockNumber  = BlockNumber(0)
+
+	// L2
+	L2FinalizedBlockNumber = BlockNumber(-1001)
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
@@ -93,6 +97,9 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "safe":
 		*bn = SafeBlockNumber
 		return nil
+	case "l2finalized":
+		*bn = L2FinalizedBlockNumber
+		return nil
 	}
 
 	blckNum, err := hexutil.DecodeUint64(input)
@@ -121,6 +128,8 @@ func (bn BlockNumber) MarshalText() ([]byte, error) {
 		return []byte("finalized"), nil
 	case SafeBlockNumber:
 		return []byte("safe"), nil
+	case L2FinalizedBlockNumber:
+		return []byte("l2finalized"), nil
 	default:
 		return hexutil.Uint64(bn).MarshalText()
 	}
@@ -173,6 +182,10 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	case "safe":
 		bn := SafeBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "l2finalized":
+		bn := L2FinalizedBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	default:


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

The following APIs are added:
```
scroll_syncStatus (with `--rollup.verify` enabled)
scroll_estimateL1DataFee
```

"finalized" tag in APIs related to "get block" or "get header" (only nodes with `--rollup.verify`) e.g.,
```
eth_call
eth_createAccessList
eth_getBalance
eth_estimateGas
eth_getHeaderByNumber
eth_getBlockTransactionCountByNumber
eth_getCode
eth_getProof
eth_getStorageAt
eth_getTransactionByBlockNumberAndIndex
eth_getTransactionCount
eth_getUncleByBlockNumberAndIndex
eth_getUncleCountByBlockNumber
trace_block
debug_traceBlockByNumber
```

notion doc: https://www.notion.so/scrollzkp/scroll_-rollup-APIs-2299f3461fd044d7a1f8623fd87ec3aa

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205572594936433