### PR TITLE
perf(miner): reduce rawdb calls for getting `StartL1QueueIndex` when inniting `environment`

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -813,14 +813,7 @@ func (w *worker) makeCurrent(parent *types.Block, header *types.Header) error {
 	env.tcount = 0
 	env.blockSize = 0
 	env.l1TxCount = 0
-
-	// find next L1 message queue index
-	nextQueueIndex := rawdb.ReadFirstQueueIndexNotInL2Block(w.eth.ChainDb(), parent.Hash())
-	if nextQueueIndex == nil {
-		// the parent must have been processed before we start a new mining job.
-		log.Crit("Failed to read last L1 message in L2 block", "parent.Hash()", parent.Hash().String())
-	}
-	env.nextL1MsgIndex = *nextQueueIndex
+	env.nextL1MsgIndex = traceEnv.StartL1QueueIndex
 
 	// Swap out the old work with the new one, terminating any leftover prefetcher
 	// processes in the mean time and starting a new one.


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

It seems that `traceEnv.StartL1QueueIndex` and `env.nextL1MsgIndex`  are using the same value, so there is no need to repeatedly request the rawdb.

The presence of the `QueueIndex` has already been checked in `CreateTraceEnv`, so here we guarantee that the `QueueIndex` already exists

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes