### PR TITLE
fix(txpool): revert duplicated l1 data fee check

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -667,7 +667,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		// Transactor should have enough funds to cover the costs
 		// cost == V + GP * GL + L1 data fee
 		if b := pool.currentState.GetBalance(from); b.Cmp(new(big.Int).Add(tx.Cost(), l1DataFee)) < 0 {
-			return ErrInsufficientFunds
+			return errors.New("invalid transaction: insufficient funds for l1fee + gas * price + value")
 		}
 	} else {
 		// Transactor should have enough funds to cover the costs

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -661,7 +661,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// 1. Check balance >= transaction cost (V + GP * GL) to maintain compatibility with the previous logic.
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
-	if b := pool.currentState.GetBalance(from); b.Cmp(tx.Cost()) < 0 {
+	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
 	}
 	// 2. If FeeVault is enabled, perform an additional check for L1 data fees.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -658,7 +658,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
-	// 1. Check balance >= transaction cost (V + GP * GL) to maintain compatibility with the previous logic.
+	// 1. Check balance >= transaction cost (V + GP * GL) to maintain compatibility with the logic without considering L1 data fee.
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
 	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -658,14 +658,9 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if pool.currentState.GetNonce(from) > tx.Nonce() {
 		return ErrNonceTooLow
 	}
-	// Get L1 data fee in current state
-	l1DataFee, err := fees.CalculateL1DataFee(tx, pool.currentState)
-	if err != nil {
-		return fmt.Errorf("failed to calculate L1 data fee, err: %w", err)
-	}
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
-	if pool.currentState.GetBalance(from).Cmp(new(big.Int).Add(tx.Cost(), l1DataFee)) < 0 {
+	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
 		return ErrInsufficientFunds
 	}
 	// Ensure the transaction has more gas than the basic tx fee.

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -18,6 +18,7 @@ package light
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sync"
@@ -386,7 +387,7 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 		// Transactor should have enough funds to cover the costs
 		// cost == V + GP * GL + L1 data fee
 		if b := currentState.GetBalance(from); b.Cmp(new(big.Int).Add(tx.Cost(), l1DataFee)) < 0 {
-			return core.ErrInsufficientFunds
+			return errors.New("invalid transaction: insufficient funds for l1fee + gas * price + value")
 		}
 	} else {
 		// Transactor should have enough funds to cover the costs

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -378,7 +378,7 @@ func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error
 	if tx.Value().Sign() < 0 {
 		return core.ErrNegativeValue
 	}
-	// 1. Check balance >= transaction cost (V + GP * GL) to maintain compatibility with the previous logic.
+	// 1. Check balance >= transaction cost (V + GP * GL) to maintain compatibility with the logic without considering L1 data fee.
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
 	if b := currentState.GetBalance(from); b.Cmp(tx.Cost()) < 0 {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 10        // Patch version component of the current release
+	VersionPatch = 11        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -190,11 +190,6 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB) (*big.Int, error) 
 	return l1DataFee, nil
 }
 
-func calculateL2Fee(tx *types.Transaction) *big.Int {
-	l2GasLimit := new(big.Int).SetUint64(tx.Gas())
-	return new(big.Int).Mul(tx.GasPrice(), l2GasLimit)
-}
-
 func VerifyFee(signer types.Signer, tx *types.Transaction, state StateDB) error {
 	from, err := types.Sender(signer, tx)
 	if err != nil {
@@ -202,10 +197,7 @@ func VerifyFee(signer types.Signer, tx *types.Transaction, state StateDB) error 
 	}
 
 	balance := state.GetBalance(from)
-	cost := tx.Value()
-
-	l2Fee := calculateL2Fee(tx)
-	cost = cost.Add(cost, l2Fee)
+	cost := tx.Cost()
 	if balance.Cmp(cost) < 0 {
 		return errors.New("invalid transaction: insufficient funds for gas * price + value")
 	}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

1. Revert duplicated l1 data fee check in: https://github.com/scroll-tech/go-ethereum/pull/609
2. Move gas fee check after other basic checks, because gas fee check needs state access.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
