### PR TITLE
fix(receipt): L1 message type tx RLP decoding

### DIFF
--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -207,7 +207,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 			return errEmptyTypedReceipt
 		}
 		r.Type = b[0]
-		if r.Type == AccessListTxType || r.Type == DynamicFeeTxType {
+		if r.Type == AccessListTxType || r.Type == DynamicFeeTxType || r.Type == L1MessageTxType {
 			var dec receiptRLP
 			if err := rlp.DecodeBytes(b[1:], &dec); err != nil {
 				return err

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -243,7 +243,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errEmptyTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType:
+	case DynamicFeeTxType, AccessListTxType, L1MessageTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 11        // Patch version component of the current release
+	VersionPatch = 12        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Test script:
```
package main

import (
	"bytes"
	"context"
	"encoding/json"
	"fmt"

	"github.com/scroll-tech/go-ethereum/common"
	"github.com/scroll-tech/go-ethereum/core/types"
	"github.com/scroll-tech/go-ethereum/ethclient"
	"github.com/scroll-tech/go-ethereum/rlp"
)

func main() {
	client, err := ethclient.Dial("https://rpc.scroll.io")
	if err != nil {
		panic(err)
	}
	defer client.Close()

	// Fetch the transaction receipt
	receipt, err := client.TransactionReceipt(context.Background(), common.HexToHash("0xcdb8b4fcb9493a51a37f85e84f4e1e37cdfaa9037a6e6663153ac510f65b3b3c"))
	if err != nil {
		panic(err)
	}

	// Encode the receipt using RLP encoding
	var buffer bytes.Buffer
	err = receipt.EncodeRLP(&buffer)
	if err != nil {
		panic(err)
	}

	// Decode the receipt back from RLP encoding
	decodedReceipt := new(types.Receipt)
	stream := rlp.NewStream(&buffer, uint64(buffer.Len()))
	err = decodedReceipt.DecodeRLP(stream)
	if err != nil {
		panic(err)
	}

	// Convert the decoded receipt to a JSON string
	decodedReceiptJSON, err := json.MarshalIndent(decodedReceipt, "", "  ")
	if err != nil {
		panic(err)
	}

	// Print the JSON string of the decoded receipt
	fmt.Println(string(decodedReceiptJSON))
}
```

logs before fix:
```
panic: transaction type not supported

goroutine 1 [running]:
main.main()
        /Users/colin/Desktop/scroll_git/go-ethereum/rollup/test_l1_message_rlp_encoding_decoding/main.go:40 +0x214
exit status 2
```

logs after fix:
```
{
  "type": "0x7e",
  "root": "0x",
  "status": "0x1",
  "cumulativeGasUsed": "0x3a942",
  "logsBloom": "0x00000000008000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000040000000000000000000000000000000000000000000200000000000000000000000000000000000800000000100000400000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000400000000800040000000000000000008000000000000800000000000000000000010000000000000000002000000000000000000000000000000000000080000000008000000",
  "logs": [
    {
      "address": "0x6ea73e05adc79974b931123675ea8f78ffdacdf0",
      "topics": [
        "0x9e86c356e14e24e26e3ce769bf8b87de38e0faa0ed0ca946fa09659aa606bd2d",
        "0x0000000000000000000000002dd622305147e919ae28bf5728312b89452ce06c",
        "0x0000000000000000000000002dd622305147e919ae28bf5728312b89452ce06c"
      ],
      "data": "0x00000000000000000000000000000000000000000000000000a6816cc801febd00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000",
      "blockNumber": "0x0",
      "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "transactionIndex": "0x0",
      "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "logIndex": "0x0",
      "removed": false
    },
    {
      "address": "0x781e90f1c8fc4611c9b7497c3b47f99ef6969cbc",
      "topics": [
        "0x4641df4a962071e12719d8c8c8e5ac7fc4d97b927346a3d7a335b1f7517e133c",
        "0x56c76009c939e691d0ecab692e751231a37c9f348e074af6dbc3261f69e00dc1"
      ],
      "data": "0x",
      "blockNumber": "0x0",
      "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "transactionIndex": "0x0",
      "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
      "logIndex": "0x0",
      "removed": false
    }
  ],
  "transactionHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "contractAddress": "0x0000000000000000000000000000000000000000",
  "gasUsed": "0x0",
  "blockHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
  "transactionIndex": "0x0"
}
```
