### PR TITLE
fix(ethclient): support new cancun fields in header

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -89,6 +89,18 @@ type Header struct {
 	// WithdrawalsHash was added by EIP-4895 and is ignored in legacy headers.
 	// Included for Ethereum compatibility in Scroll SDK
 	WithdrawalsHash *common.Hash `json:"withdrawalsRoot" rlp:"optional"`
+
+	// BlobGasUsed was added by EIP-4844 and is ignored in legacy headers.
+	// Included for Ethereum compatibility in Scroll SDK
+	BlobGasUsed *uint64 `json:"blobGasUsed" rlp:"optional"`
+
+	// ExcessBlobGas was added by EIP-4844 and is ignored in legacy headers.
+	// Included for Ethereum compatibility in Scroll SDK
+	ExcessBlobGas *uint64 `json:"excessBlobGas" rlp:"optional"`
+
+	// ParentBeaconRoot was added by EIP-4788 and is ignored in legacy headers.
+	// Included for Ethereum compatibility in Scroll SDK
+	ParentBeaconRoot *common.Hash `json:"parentBeaconBlockRoot" rlp:"optional"`
 }
 
 // field type overrides for gencodec

--- a/core/types/gen_header_json.go
+++ b/core/types/gen_header_json.go
@@ -16,24 +16,27 @@ var _ = (*headerMarshaling)(nil)
 // MarshalJSON marshals as JSON.
 func (h Header) MarshalJSON() ([]byte, error) {
 	type Header struct {
-		ParentHash      common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash       common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase        common.Address `json:"miner"`
-		Root            common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash          common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash     common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom           Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty      *hexutil.Big   `json:"difficulty"       gencodec:"required"`
-		Number          *hexutil.Big   `json:"number"           gencodec:"required"`
-		GasLimit        hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed         hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time            hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra           hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest       common.Hash    `json:"mixHash"`
-		Nonce           BlockNonce     `json:"nonce"`
-		BaseFee         *hexutil.Big   `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash *common.Hash   `json:"withdrawalsRoot" rlp:"optional"`
-		Hash            common.Hash    `json:"hash"`
+		ParentHash       common.Hash     `json:"parentHash"       gencodec:"required"`
+		UncleHash        common.Hash     `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase         common.Address  `json:"miner"`
+		Root             common.Hash     `json:"stateRoot"        gencodec:"required"`
+		TxHash           common.Hash     `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash      common.Hash     `json:"receiptsRoot"     gencodec:"required"`
+		Bloom            Bloom           `json:"logsBloom"        gencodec:"required"`
+		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit         hexutil.Uint64  `json:"gasLimit"         gencodec:"required"`
+		GasUsed          hexutil.Uint64  `json:"gasUsed"          gencodec:"required"`
+		Time             hexutil.Uint64  `json:"timestamp"        gencodec:"required"`
+		Extra            hexutil.Bytes   `json:"extraData"        gencodec:"required"`
+		MixDigest        common.Hash     `json:"mixHash"`
+		Nonce            BlockNonce      `json:"nonce"`
+		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		Hash             common.Hash     `json:"hash"`
+		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var enc Header
 	enc.ParentHash = h.ParentHash
@@ -54,29 +57,35 @@ func (h Header) MarshalJSON() ([]byte, error) {
 	enc.BaseFee = (*hexutil.Big)(h.BaseFee)
 	enc.WithdrawalsHash = h.WithdrawalsHash
 	enc.Hash = h.Hash()
+	enc.BlobGasUsed = (*hexutil.Uint64)(h.BlobGasUsed)
+	enc.ExcessBlobGas = (*hexutil.Uint64)(h.ExcessBlobGas)
+	enc.ParentBeaconRoot = h.ParentBeaconRoot
 	return json.Marshal(&enc)
 }
 
 // UnmarshalJSON unmarshals from JSON.
 func (h *Header) UnmarshalJSON(input []byte) error {
 	type Header struct {
-		ParentHash      *common.Hash    `json:"parentHash"       gencodec:"required"`
-		UncleHash       *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
-		Coinbase        *common.Address `json:"miner"`
-		Root            *common.Hash    `json:"stateRoot"        gencodec:"required"`
-		TxHash          *common.Hash    `json:"transactionsRoot" gencodec:"required"`
-		ReceiptHash     *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
-		Bloom           *Bloom          `json:"logsBloom"        gencodec:"required"`
-		Difficulty      *hexutil.Big    `json:"difficulty"       gencodec:"required"`
-		Number          *hexutil.Big    `json:"number"           gencodec:"required"`
-		GasLimit        *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
-		GasUsed         *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
-		Time            *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
-		Extra           *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
-		MixDigest       *common.Hash    `json:"mixHash"`
-		Nonce           *BlockNonce     `json:"nonce"`
-		BaseFee         *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
-		WithdrawalsHash *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		ParentHash       *common.Hash    `json:"parentHash"       gencodec:"required"`
+		UncleHash        *common.Hash    `json:"sha3Uncles"       gencodec:"required"`
+		Coinbase         *common.Address `json:"miner"`
+		Root             *common.Hash    `json:"stateRoot"        gencodec:"required"`
+		TxHash           *common.Hash    `json:"transactionsRoot" gencodec:"required"`
+		ReceiptHash      *common.Hash    `json:"receiptsRoot"     gencodec:"required"`
+		Bloom            *Bloom          `json:"logsBloom"        gencodec:"required"`
+		Difficulty       *hexutil.Big    `json:"difficulty"       gencodec:"required"`
+		Number           *hexutil.Big    `json:"number"           gencodec:"required"`
+		GasLimit         *hexutil.Uint64 `json:"gasLimit"         gencodec:"required"`
+		GasUsed          *hexutil.Uint64 `json:"gasUsed"          gencodec:"required"`
+		Time             *hexutil.Uint64 `json:"timestamp"        gencodec:"required"`
+		Extra            *hexutil.Bytes  `json:"extraData"        gencodec:"required"`
+		MixDigest        *common.Hash    `json:"mixHash"`
+		Nonce            *BlockNonce     `json:"nonce"`
+		BaseFee          *hexutil.Big    `json:"baseFeePerGas" rlp:"optional"`
+		WithdrawalsHash  *common.Hash    `json:"withdrawalsRoot" rlp:"optional"`
+		BlobGasUsed      *hexutil.Uint64 `json:"blobGasUsed" rlp:"optional"`
+		ExcessBlobGas    *hexutil.Uint64 `json:"excessBlobGas" rlp:"optional"`
+		ParentBeaconRoot *common.Hash    `json:"parentBeaconBlockRoot" rlp:"optional"`
 	}
 	var dec Header
 	if err := json.Unmarshal(input, &dec); err != nil {
@@ -144,6 +153,15 @@ func (h *Header) UnmarshalJSON(input []byte) error {
 	}
 	if dec.WithdrawalsHash != nil {
 		h.WithdrawalsHash = dec.WithdrawalsHash
+	}
+	if dec.BlobGasUsed != nil {
+		h.BlobGasUsed = (*uint64)(dec.BlobGasUsed)
+	}
+	if dec.ExcessBlobGas != nil {
+		h.ExcessBlobGas = (*uint64)(dec.ExcessBlobGas)
+	}
+	if dec.ParentBeaconRoot != nil {
+		h.ParentBeaconRoot = dec.ParentBeaconRoot
 	}
 	return nil
 }

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 13        // Patch version component of the current release
+	VersionPatch = 14        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Support new fields in Scroll Go SDK. similar to: https://github.com/scroll-tech/go-ethereum/pull/354/files


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
