### PR TITLE
feat: re-enable EIP-1559 in Banach hard fork

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -590,7 +590,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 		return nil, errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
 	head := b.blockchain.CurrentHeader()
-	if !b.blockchain.Config().IsLondon(head.Number) {
+	if !b.blockchain.Config().IsBanach(head.Number) {
 		// If there's no basefee, then it must be a non-1559 execution
 		if call.GasPrice == nil {
 			call.GasPrice = new(big.Int)

--- a/accounts/abi/bind/base.go
+++ b/accounts/abi/bind/base.go
@@ -289,7 +289,7 @@ func (c *BoundContract) createDynamicTx(opts *TransactOpts, contract *common.Add
 
 func (c *BoundContract) createLegacyTx(opts *TransactOpts, contract *common.Address, input []byte) (*types.Transaction, error) {
 	if opts.GasFeeCap != nil || opts.GasTipCap != nil {
-		return nil, errors.New("maxFeePerGas or maxPriorityFeePerGas specified but london is not active yet")
+		return nil, errors.New("maxFeePerGas or maxPriorityFeePerGas specified but banach is not active yet")
 	}
 	// Normalize value
 	value := opts.Value

--- a/cmd/evm/internal/t8ntool/transition.go
+++ b/cmd/evm/internal/t8ntool/transition.go
@@ -247,8 +247,8 @@ func Transition(ctx *cli.Context) error {
 		return NewError(ErrorJson, fmt.Errorf("failed signing transactions: %v", err))
 	}
 	// Sanity check, to not `panic` in state_transition
-	if chainConfig.IsLondon(big.NewInt(int64(prestate.Env.Number))) {
-		if prestate.Env.BaseFee == nil && chainConfig.Scroll.BaseFeeEnabled() {
+	if chainConfig.IsBanach(big.NewInt(int64(prestate.Env.Number))) {
+		if prestate.Env.BaseFee == nil {
 			return NewError(ErrorConfig, errors.New("EIP-1559 config but missing 'currentBaseFee' in env section"))
 		}
 	}
@@ -321,8 +321,9 @@ func (t *txWithKey) UnmarshalJSON(input []byte) error {
 // signUnsignedTransactions converts the input txs to canonical transactions.
 //
 // The transactions can have two forms, either
-//   1. unsigned or
-//   2. signed
+//  1. unsigned or
+//  2. signed
+//
 // For (1), r, s, v, need so be zero, and the `secretKey` needs to be set.
 // If so, we sign it here and now, with the given `secretKey`
 // If the condition above is not met, then it's considered a signed transaction.

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -335,7 +335,7 @@ func (c *Clique) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 	if header.GasUsed > header.GasLimit {
 		return fmt.Errorf("invalid gasUsed: have %d, gasLimit %d", header.GasUsed, header.GasLimit)
 	}
-	if !chain.Config().IsLondon(header.Number) {
+	if !chain.Config().IsBanach(header.Number) {
 		// Verify BaseFee not present before EIP-1559 fork.
 		if header.BaseFee != nil {
 			return fmt.Errorf("invalid baseFee before fork: have %d, want <nil>", header.BaseFee)

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -291,7 +291,7 @@ func (ethash *Ethash) verifyHeader(chain consensus.ChainHeaderReader, header, pa
 		return fmt.Errorf("invalid gasUsed: have %d, gasLimit %d", header.GasUsed, header.GasLimit)
 	}
 	// Verify the block's gas usage and (if applicable) verify the base fee.
-	if !chain.Config().IsLondon(header.Number) {
+	if !chain.Config().IsBanach(header.Number) {
 		// Verify BaseFee not present before EIP-1559 fork.
 		if header.BaseFee != nil {
 			return fmt.Errorf("invalid baseFee before fork: have %d, expected 'nil'", header.BaseFee)

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -32,34 +32,21 @@ import (
 func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Header) error {
 	// Verify that the gas limit remains within allowed bounds
 	parentGasLimit := parent.GasLimit
-	if !config.IsLondon(parent.Number) {
+	if !config.IsBanach(parent.Number) {
 		parentGasLimit = parent.GasLimit * params.ElasticityMultiplier
 	}
 	if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
 		return err
 	}
 	// Verify the header is not malformed
-	if header.BaseFee == nil && config.Scroll.BaseFeeEnabled() {
+	if header.BaseFee == nil {
 		return fmt.Errorf("header is missing baseFee")
 	}
-	// Now BaseFee can be nil, because !config.Scroll.BaseFeeEnabled()
-	if header.BaseFee == nil {
-		return nil
-	}
 	// Verify the baseFee is correct based on the parent header.
-
-	var expectedBaseFee *big.Int
-
-	// compatible check with the logic in commitNewWork
-	if config.Clique == nil || config.Scroll.BaseFeeEnabled() {
-		expectedBaseFee = CalcBaseFee(config, parent)
-	} else {
-		expectedBaseFee = big.NewInt(0)
-	}
-
+	expectedBaseFee := CalcBaseFee(config, parent)
 	if header.BaseFee.Cmp(expectedBaseFee) != 0 {
 		return fmt.Errorf("invalid baseFee: have %s, want %s, parentBaseFee %s, parentGasUsed %d",
-			expectedBaseFee, header.BaseFee, parent.BaseFee, parent.GasUsed)
+			header.BaseFee, expectedBaseFee, parent.BaseFee, parent.GasUsed)
 	}
 	return nil
 }
@@ -67,7 +54,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 // CalcBaseFee calculates the basefee of the header.
 func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 	// If the current block is the first EIP-1559 block, return the InitialBaseFee.
-	if !config.IsLondon(parent.Number) {
+	if !config.IsBanach(parent.Number) {
 		return new(big.Int).SetUint64(params.InitialBaseFee)
 	}
 
@@ -76,9 +63,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header) *big.Int {
 		parentGasTargetBig       = new(big.Int).SetUint64(parentGasTarget)
 		baseFeeChangeDenominator = new(big.Int).SetUint64(params.BaseFeeChangeDenominator)
 	)
-	if !config.Scroll.BaseFeeEnabled() {
-		return nil
-	}
+
 	// If the parent gasUsed is the same as the target, the baseFee remains unchanged.
 	if parent.GasUsed == parentGasTarget {
 		return new(big.Int).Set(parent.BaseFee)

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -31,11 +31,7 @@ import (
 // - basefee check
 func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Header) error {
 	// Verify that the gas limit remains within allowed bounds
-	parentGasLimit := parent.GasLimit
-	if !config.IsBanach(parent.Number) {
-		parentGasLimit = parent.GasLimit * params.ElasticityMultiplier
-	}
-	if err := VerifyGaslimit(parentGasLimit, header.GasLimit); err != nil {
+	if err := VerifyGaslimit(parent.GasLimit, header.GasLimit); err != nil {
 		return err
 	}
 	// Verify the header is not malformed

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -37,7 +37,7 @@ func VerifyEip1559Header(config *params.ChainConfig, parent, header *types.Heade
 		return fmt.Errorf("header is missing baseFee")
 	}
 	// note: we do not verify base fee, the sequencer has the
-	// right to set any base fee, any it is not subject to
+	// right to set any base fee, and it is not subject to
 	// L2 consensus or zk verification.
 	// TODO: add some reasonable bounds on base fee
 	return nil

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -20,7 +20,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/params"
 )
@@ -107,31 +106,21 @@ func TestBlockGasLimits(t *testing.T) {
 	}
 }
 
-// TODO: update these tests
 // TestCalcBaseFee assumes all blocks are 1559-blocks
-func TestCalcBaseFee(t *testing.T) {
-	parentL1BaseFee := big.NewInt(1000000000) // 1 gwei
-	expectedL2BaseFee := int64(164000000)
-
+func TestCalcBaseFee2(t *testing.T) {
 	tests := []struct {
-		parentBaseFee   int64
-		parentGasLimit  uint64
-		parentGasUsed   uint64
-		expectedBaseFee int64
+		parentL1BaseFee   int64
+		expectedL2BaseFee int64
 	}{
-		{params.InitialBaseFee, 20000000, 10000000, expectedL2BaseFee}, // usage == target
-		{params.InitialBaseFee, 20000000, 9000000, expectedL2BaseFee},  // usage below target
-		{params.InitialBaseFee, 20000000, 11000000, expectedL2BaseFee}, // usage above target
+		{0, 150000000},
+		{1000000000, 164000000},
+		{2000000000, 178000000},
+		{100000000000, 1550000000},
+		{111111111111, 1705555555},
+		{1000000000000, 10000000000}, // cap at max L2 base fee
 	}
 	for i, test := range tests {
-		parent := &types.Header{
-			Number:   common.Big32,
-			GasLimit: test.parentGasLimit,
-			GasUsed:  test.parentGasUsed,
-			BaseFee:  big.NewInt(test.parentBaseFee),
-		}
-
-		if have, want := CalcBaseFee(config(), parent, parentL1BaseFee), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
+		if have, want := CalcBaseFee(config(), nil, big.NewInt(test.parentL1BaseFee)), big.NewInt(test.expectedL2BaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
 	}

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -107,7 +107,7 @@ func TestBlockGasLimits(t *testing.T) {
 }
 
 // TestCalcBaseFee assumes all blocks are 1559-blocks
-func TestCalcBaseFee2(t *testing.T) {
+func TestCalcBaseFee(t *testing.T) {
 	tests := []struct {
 		parentL1BaseFee   int64
 		expectedL2BaseFee int64

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -52,7 +52,8 @@ func copyConfig(original *params.ChainConfig) *params.ChainConfig {
 
 func config() *params.ChainConfig {
 	config := copyConfig(params.TestChainConfig)
-	config.LondonBlock = big.NewInt(5)
+	config.LondonBlock = big.NewInt(3)
+	config.BanachBlock = big.NewInt(5)
 	return config
 }
 
@@ -67,13 +68,13 @@ func TestBlockGasLimits(t *testing.T) {
 		gasLimit  uint64
 		ok        bool
 	}{
-		// Transitions from non-london to london
+		// Transitions from non-banach to banach
 		{10000000, 4, 20000000, true},  // No change
 		{10000000, 4, 20019530, true},  // Upper limit
 		{10000000, 4, 20019531, false}, // Upper +1
 		{10000000, 4, 19980470, true},  // Lower limit
 		{10000000, 4, 19980469, false}, // Lower limit -1
-		// London to London
+		// Banach to Banach
 		{20000000, 5, 20000000, true},
 		{20000000, 5, 20019530, true},  // Upper limit
 		{20000000, 5, 20019531, false}, // Upper limit +1

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -107,6 +107,7 @@ func TestBlockGasLimits(t *testing.T) {
 	}
 }
 
+// TODO: update these tests
 // TestCalcBaseFee assumes all blocks are 1559-blocks
 func TestCalcBaseFee(t *testing.T) {
 	parentL1BaseFee := big.NewInt(1000000000) // 1 gwei

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -69,11 +69,11 @@ func TestBlockGasLimits(t *testing.T) {
 		ok        bool
 	}{
 		// Transitions from non-banach to banach
-		{10000000, 4, 20000000, true},  // No change
-		{10000000, 4, 20019530, true},  // Upper limit
-		{10000000, 4, 20019531, false}, // Upper +1
-		{10000000, 4, 19980470, true},  // Lower limit
-		{10000000, 4, 19980469, false}, // Lower limit -1
+		{10000000, 4, 10000000, true},  // No change
+		{10000000, 4, 10009764, true},  // Upper limit
+		{10000000, 4, 10009765, false}, // Upper +1
+		{10000000, 4, 9990236, true},   // Lower limit
+		{10000000, 4, 9990235, false},  // Lower limit -1
 		// Banach to Banach
 		{20000000, 5, 20000000, true},
 		{20000000, 5, 20019530, true},  // Upper limit

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -109,15 +109,18 @@ func TestBlockGasLimits(t *testing.T) {
 
 // TestCalcBaseFee assumes all blocks are 1559-blocks
 func TestCalcBaseFee(t *testing.T) {
+	parentL1BaseFee := big.NewInt(1000000000) // 1 gwei
+	expectedL2BaseFee := int64(164000000)
+
 	tests := []struct {
 		parentBaseFee   int64
 		parentGasLimit  uint64
 		parentGasUsed   uint64
 		expectedBaseFee int64
 	}{
-		{params.InitialBaseFee, 20000000, 10000000, params.InitialBaseFee}, // usage == target
-		{params.InitialBaseFee, 20000000, 9000000, 987500000},              // usage below target
-		{params.InitialBaseFee, 20000000, 11000000, 1012500000},            // usage above target
+		{params.InitialBaseFee, 20000000, 10000000, expectedL2BaseFee}, // usage == target
+		{params.InitialBaseFee, 20000000, 9000000, expectedL2BaseFee},  // usage below target
+		{params.InitialBaseFee, 20000000, 11000000, expectedL2BaseFee}, // usage above target
 	}
 	for i, test := range tests {
 		parent := &types.Header{
@@ -126,7 +129,8 @@ func TestCalcBaseFee(t *testing.T) {
 			GasUsed:  test.parentGasUsed,
 			BaseFee:  big.NewInt(test.parentBaseFee),
 		}
-		if have, want := CalcBaseFee(config(), parent), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
+
+		if have, want := CalcBaseFee(config(), parent, parentL1BaseFee), big.NewInt(test.expectedBaseFee); have.Cmp(want) != 0 {
 			t.Errorf("test %d: have %d  want %d, ", i, have, want)
 		}
 	}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1249,7 +1249,11 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	}
 
 	// Note latest seen L2 base fee
-	l2BaseFeeGauge.Update(block.BaseFee().Int64())
+	if block.BaseFee() != nil {
+		l2BaseFeeGauge.Update(block.BaseFee().Int64())
+	} else {
+		l2BaseFeeGauge.Update(0)
+	}
 
 	// Calculate the total difficulty of the block
 	ptd := bc.GetTd(block.ParentHash(), block.NumberU64()-1)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -54,6 +54,8 @@ var (
 	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
 	headFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)
 
+	l2BaseFeeGauge = metrics.NewRegisteredGauge("chain/fees/l2basefee", nil)
+
 	accountReadTimer   = metrics.NewRegisteredTimer("chain/account/reads", nil)
 	accountHashTimer   = metrics.NewRegisteredTimer("chain/account/hashes", nil)
 	accountUpdateTimer = metrics.NewRegisteredTimer("chain/account/updates", nil)
@@ -1245,6 +1247,9 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	if bc.insertStopped() {
 		return NonStatTy, errInsertionInterrupted
 	}
+
+	// Note latest seen L2 base fee
+	l2BaseFeeGauge.Update(block.BaseFee().Int64())
 
 	// Calculate the total difficulty of the block
 	ptd := bc.GetTd(block.ParentHash(), block.NumberU64()-1)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1704,6 +1704,7 @@ func TestInsertReceiptChainRollback(t *testing.T) {
 		t.Fatalf("failed to create temp freezer db: %v", err)
 	}
 	gspec := Genesis{Config: params.AllEthashProtocolChanges}
+	gspec.BaseFee = big.NewInt(params.InitialBaseFee)
 	gspec.MustCommit(ancientDb)
 	ancientChain, _ := NewBlockChain(ancientDb, nil, gspec.Config, ethash.NewFaker(), vm.Config{}, nil, nil)
 	defer ancientChain.Stop()

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3171,7 +3171,10 @@ func TestFeeVault(t *testing.T) {
 
 	// Ensure that the fee vault received all tx fees
 	actual = state.GetBalance(*params.TestChainConfig.Scroll.FeeVaultAddress)
-	expected = new(big.Int).SetUint64(block.GasUsed() * block.Transactions()[0].GasTipCap().Uint64())
+
+	effectiveGasPrice := new(big.Int).Add(block.BaseFee(), block.Transactions()[0].GasTipCap())
+	gasUsed := new(big.Int).SetUint64(block.GasUsed())
+	expected = new(big.Int).Mul(gasUsed, effectiveGasPrice)
 
 	if actual.Cmp(expected) != 0 {
 		t.Fatalf("fee vault balance incorrect: expected %d, got %d", expected, actual)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -607,7 +607,7 @@ func TestFastVsFullChains(t *testing.T) {
 		gendb   = rawdb.NewMemoryDatabase()
 		key, _  = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 		address = crypto.PubkeyToAddress(key.PublicKey)
-		funds   = big.NewInt(1000000000000000)
+		funds   = big.NewInt(3000000000000000)
 		gspec   = &Genesis{
 			Config:  params.TestChainConfig,
 			Alloc:   GenesisAlloc{address: {Balance: funds}},

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -275,9 +275,9 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 		Number:   new(big.Int).Add(parent.Number(), common.Big1),
 		Time:     time,
 	}
-	if chain.Config().IsLondon(header.Number) {
+	if chain.Config().IsBanach(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(chain.Config(), parent.Header())
-		if !chain.Config().IsLondon(parent.Number()) {
+		if !chain.Config().IsBanach(parent.Number()) {
 			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
 			header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
 		}

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -277,10 +277,6 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 	}
 	if chain.Config().IsBanach(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(chain.Config(), parent.Header())
-		if !chain.Config().IsBanach(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit = CalcGasLimit(parentGasLimit, parentGasLimit)
-		}
 	}
 	return header
 }

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/core/vm"
 	"github.com/scroll-tech/go-ethereum/ethdb"
 	"github.com/scroll-tech/go-ethereum/params"
+	"github.com/scroll-tech/go-ethereum/rollup/fees"
 )
 
 // BlockGen creates blocks for testing.
@@ -276,7 +277,8 @@ func makeHeader(chain consensus.ChainReader, parent *types.Block, state *state.S
 		Time:     time,
 	}
 	if chain.Config().IsBanach(header.Number) {
-		header.BaseFee = misc.CalcBaseFee(chain.Config(), parent.Header())
+		parentL1BaseFee := fees.GetL1BaseFee(state)
+		header.BaseFee = misc.CalcBaseFee(chain.Config(), parent.Header(), parentL1BaseFee)
 	}
 	return header
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -312,13 +312,11 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 	if g.Difficulty == nil {
 		head.Difficulty = params.GenesisDifficulty
 	}
-	if g.Config != nil && g.Config.IsLondon(common.Big0) {
+	if g.Config != nil && g.Config.IsBanach(common.Big0) {
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
-		} else if g.Config.Scroll.BaseFeeEnabled() {
-			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		} else {
-			head.BaseFee = nil
+			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
 		}
 	}
 	statedb.Commit(false)

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -28,6 +28,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/common/hexutil"
 	"github.com/scroll-tech/go-ethereum/common/math"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	"github.com/scroll-tech/go-ethereum/core/rawdb"
 	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
@@ -316,7 +317,7 @@ func (g *Genesis) ToBlock(db ethdb.Database) *types.Block {
 		if g.BaseFee != nil {
 			head.BaseFee = g.BaseFee
 		} else {
-			head.BaseFee = new(big.Int).SetUint64(params.InitialBaseFee)
+			head.BaseFee = misc.CalcBaseFee(g.Config, nil, big.NewInt(0))
 		}
 	}
 	statedb.Commit(false)

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -348,21 +348,22 @@ func TestStateProcessorErrors(t *testing.T) {
 			smallInitCode  = [320]byte{}
 		)
 		defer blockchain.Stop()
+		parentL1BaseFee := big.NewInt(1000000000) // 1 gwei
 		for i, tt := range []struct {
 			txs  []*types.Transaction
 			want string
 		}{
 			{ // ErrMaxInitCodeSizeExceeded
 				txs: []*types.Transaction{
-					mkDynamicCreationTx(0, 500000, common.Big0, misc.CalcBaseFee(config, genesis.Header()), tooBigInitCode[:]),
+					mkDynamicCreationTx(0, 500000, common.Big0, misc.CalcBaseFee(config, genesis.Header(), parentL1BaseFee), tooBigInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x832b54a6c3359474a9f504b1003b2cc1b6fcaa18e4ef369eb45b5d40dad6378f]: max initcode size exceeded: code size 49153 limit 49152",
+				want: "could not apply tx 0 [0xa3d2dadf08846f3328b84b0a38240ace42f79c99ea4b9c097c8dcb345f61a84e]: max initcode size exceeded: code size 49153 limit 49152",
 			},
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{
-					mkDynamicCreationTx(0, 54299, common.Big0, misc.CalcBaseFee(config, genesis.Header()), smallInitCode[:]),
+					mkDynamicCreationTx(0, 54299, common.Big0, misc.CalcBaseFee(config, genesis.Header(), parentL1BaseFee), smallInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x39b7436cb432d3662a25626474282c5c4c1a213326fd87e4e18a91477bae98b2]: intrinsic gas too low: have 54299, want 54300",
+				want: "could not apply tx 0 [0x0880861c73bc504c01041b6d506737a119ca7c68c1fe666dc1682636b807c9db]: intrinsic gas too low: have 54299, want 54300",
 			},
 		} {
 			block := GenerateBadBlock(genesis, ethash.NewFaker(), tt.txs, gspec.Config)
@@ -396,8 +397,10 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		Time:      parent.Time() + 10,
 		UncleHash: types.EmptyUncleHash,
 	}
+
 	if config.IsBanach(header.Number) {
-		header.BaseFee = misc.CalcBaseFee(config, parent.Header())
+		parentL1BaseFee := big.NewInt(1000000000) // 1 gwei
+		header.BaseFee = misc.CalcBaseFee(config, parent.Header(), parentL1BaseFee)
 	}
 	var receipts []*types.Receipt
 	// The post-state result doesn't need to be correct (this is a bad block), but we do need something there

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -56,6 +56,7 @@ func TestStateProcessorErrors(t *testing.T) {
 			BerlinBlock:         big.NewInt(0),
 			LondonBlock:         big.NewInt(0),
 			ShanghaiBlock:       big.NewInt(0),
+			BanachBlock:         big.NewInt(0),
 			Ethash:              new(params.EthashConfig),
 		}
 		signer  = types.LatestSigner(config)
@@ -332,6 +333,7 @@ func TestStateProcessorErrors(t *testing.T) {
 					ArrowGlacierBlock:   big.NewInt(0),
 					ArchimedesBlock:     big.NewInt(0),
 					ShanghaiBlock:       big.NewInt(0),
+					BanachBlock:         big.NewInt(0),
 				},
 				Alloc: GenesisAlloc{
 					common.HexToAddress("0x71562b71999873DB5b286dF957af199Ec94617F7"): GenesisAccount{
@@ -354,13 +356,13 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					mkDynamicCreationTx(0, 500000, common.Big0, misc.CalcBaseFee(config, genesis.Header()), tooBigInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x7b33776d375660694a23ef992c090265682f3687607e0099b14503fdb65d73e3]: max initcode size exceeded: code size 49153 limit 49152",
+				want: "could not apply tx 0 [0x832b54a6c3359474a9f504b1003b2cc1b6fcaa18e4ef369eb45b5d40dad6378f]: max initcode size exceeded: code size 49153 limit 49152",
 			},
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{
 					mkDynamicCreationTx(0, 54299, common.Big0, misc.CalcBaseFee(config, genesis.Header()), smallInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x98e54c5ecfa7986a66480d65ba32f2c6a2a6aedc3a67abb91b1e118b0717ed2d]: intrinsic gas too low: have 54299, want 54300",
+				want: "could not apply tx 0 [0x39b7436cb432d3662a25626474282c5c4c1a213326fd87e4e18a91477bae98b2]: intrinsic gas too low: have 54299, want 54300",
 			},
 		} {
 			block := GenerateBadBlock(genesis, ethash.NewFaker(), tt.txs, gspec.Config)
@@ -394,7 +396,7 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		Time:      parent.Time() + 10,
 		UncleHash: types.EmptyUncleHash,
 	}
-	if config.IsLondon(header.Number) {
+	if config.IsBanach(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(config, parent.Header())
 	}
 	var receipts []*types.Receipt

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -406,7 +406,8 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	effectiveTip := st.gasPrice
 
-	if rules.IsBanach {
+	// only burn the base fee if the fee vault is not enabled
+	if rules.IsBanach && !st.evm.ChainConfig().Scroll.FeeVaultEnabled() {
 		effectiveTip = cmath.BigMin(st.gasTipCap, new(big.Int).Sub(st.gasFeeCap, st.evm.Context.BaseFee))
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -287,8 +287,9 @@ func (st *StateTransition) preCheck() error {
 				st.msg.From().Hex(), codeHash)
 		}
 	}
-	// Make sure that transaction gasFeeCap is greater than the baseFee (post Banach)
-	if st.evm.ChainConfig().IsBanach(st.evm.Context.BlockNumber) {
+	// Make sure that transaction gasFeeCap is greater than the baseFee (post London)
+	// Note: Logically, this should be `IsBanach`, but we keep `IsLondon` to ensure backward compatibility.
+	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
 		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0 {
 			if l := st.gasFeeCap.BitLen(); l > 256 {

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -287,7 +287,7 @@ func (st *StateTransition) preCheck() error {
 				st.msg.From().Hex(), codeHash)
 		}
 	}
-	// Make sure that transaction gasFeeCap is greater than the baseFee (post London)
+	// Make sure that transaction gasFeeCap is greater than the baseFee (post london)
 	// Note: Logically, this should be `IsBanach`, but we keep `IsLondon` to ensure backward compatibility.
 	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -283,8 +283,8 @@ func (st *StateTransition) preCheck() error {
 				st.msg.From().Hex(), codeHash)
 		}
 	}
-	// Make sure that transaction gasFeeCap is greater than the baseFee (post london)
-	if st.evm.ChainConfig().IsLondon(st.evm.Context.BlockNumber) {
+	// Make sure that transaction gasFeeCap is greater than the baseFee (post Banach)
+	if st.evm.ChainConfig().IsBanach(st.evm.Context.BlockNumber) {
 		// Skip the checks if gas fields are zero and baseFee was explicitly disabled (eth_call)
 		if !st.evm.Config.NoBaseFee || st.gasFeeCap.BitLen() > 0 || st.gasTipCap.BitLen() > 0 {
 			if l := st.gasFeeCap.BitLen(); l > 256 {
@@ -405,12 +405,9 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		st.refundGas(params.RefundQuotientEIP3529)
 	}
 	effectiveTip := st.gasPrice
-	if rules.IsLondon {
-		if st.evm.Context.BaseFee != nil {
-			effectiveTip = cmath.BigMin(st.gasTipCap, new(big.Int).Sub(st.gasFeeCap, st.evm.Context.BaseFee))
-		} else {
-			effectiveTip = cmath.BigMin(st.gasTipCap, st.gasFeeCap)
-		}
+
+	if rules.IsBanach {
+		effectiveTip = cmath.BigMin(st.gasTipCap, new(big.Int).Sub(st.gasFeeCap, st.evm.Context.BaseFee))
 	}
 
 	// The L2 Fee is the same as the fee that is charged in the normal geth

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1232,7 +1232,8 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	if reset != nil {
 		pool.demoteUnexecutables()
 		if reset.newHead != nil && pool.chainconfig.IsBanach(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
-			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead)
+			l1BaseFee := fees.GetL1BaseFee(pool.currentState)
+			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead, l1BaseFee)
 			pool.priced.SetBaseFee(pendingBaseFee)
 		}
 		// Update all accounts to the latest known pending nonce

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1231,7 +1231,7 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	// because of another transaction (e.g. higher gas price).
 	if reset != nil {
 		pool.demoteUnexecutables()
-		if reset.newHead != nil && pool.chainconfig.IsLondon(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
+		if reset.newHead != nil && pool.chainconfig.IsBanach(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
 			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead)
 			pool.priced.SetBaseFee(pendingBaseFee)
 		}
@@ -1356,8 +1356,8 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) {
 	next := new(big.Int).Add(newHead.Number, big.NewInt(1))
 	pool.istanbul = pool.chainconfig.IsIstanbul(next)
 
-	pool.eip2718 = pool.chainconfig.Scroll.EnableEIP2718 && pool.chainconfig.IsBerlin(next)
-	pool.eip1559 = pool.chainconfig.Scroll.EnableEIP1559 && pool.chainconfig.IsLondon(next)
+	pool.eip2718 = pool.chainconfig.IsBanach(next)
+	pool.eip1559 = pool.chainconfig.IsBanach(next)
 	pool.shanghai = pool.chainconfig.IsShanghai(next)
 }
 

--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -148,20 +148,23 @@ type StorageWrapper struct {
 }
 
 type TransactionData struct {
-	Type     uint8           `json:"type"`
-	Nonce    uint64          `json:"nonce"`
-	TxHash   string          `json:"txHash"`
-	Gas      uint64          `json:"gas"`
-	GasPrice *hexutil.Big    `json:"gasPrice"`
-	From     common.Address  `json:"from"`
-	To       *common.Address `json:"to"`
-	ChainId  *hexutil.Big    `json:"chainId"`
-	Value    *hexutil.Big    `json:"value"`
-	Data     string          `json:"data"`
-	IsCreate bool            `json:"isCreate"`
-	V        *hexutil.Big    `json:"v"`
-	R        *hexutil.Big    `json:"r"`
-	S        *hexutil.Big    `json:"s"`
+	Type       uint8           `json:"type"`
+	Nonce      uint64          `json:"nonce"`
+	TxHash     string          `json:"txHash"`
+	Gas        uint64          `json:"gas"`
+	GasPrice   *hexutil.Big    `json:"gasPrice"`
+	GasTipCap  *hexutil.Big    `json:"gasTipCap"`
+	GasFeeCap  *hexutil.Big    `json:"gasFeeCap"`
+	From       common.Address  `json:"from"`
+	To         *common.Address `json:"to"`
+	ChainId    *hexutil.Big    `json:"chainId"`
+	Value      *hexutil.Big    `json:"value"`
+	Data       string          `json:"data"`
+	IsCreate   bool            `json:"isCreate"`
+	AccessList AccessList      `json:"accessList"`
+	V          *hexutil.Big    `json:"v"`
+	R          *hexutil.Big    `json:"r"`
+	S          *hexutil.Big    `json:"s"`
 }
 
 // NewTransactionData returns a transaction that will serialize to the trace
@@ -177,20 +180,23 @@ func NewTransactionData(tx *Transaction, blockNumber uint64, config *params.Chai
 	}
 
 	result := &TransactionData{
-		Type:     tx.Type(),
-		TxHash:   tx.Hash().String(),
-		Nonce:    nonce,
-		ChainId:  (*hexutil.Big)(tx.ChainId()),
-		From:     from,
-		Gas:      tx.Gas(),
-		GasPrice: (*hexutil.Big)(tx.GasPrice()),
-		To:       tx.To(),
-		Value:    (*hexutil.Big)(tx.Value()),
-		Data:     hexutil.Encode(tx.Data()),
-		IsCreate: tx.To() == nil,
-		V:        (*hexutil.Big)(v),
-		R:        (*hexutil.Big)(r),
-		S:        (*hexutil.Big)(s),
+		Type:       tx.Type(),
+		TxHash:     tx.Hash().String(),
+		Nonce:      nonce,
+		ChainId:    (*hexutil.Big)(tx.ChainId()),
+		From:       from,
+		Gas:        tx.Gas(),
+		GasPrice:   (*hexutil.Big)(tx.GasPrice()),
+		GasTipCap:  (*hexutil.Big)(tx.GasTipCap()),
+		GasFeeCap:  (*hexutil.Big)(tx.GasFeeCap()),
+		To:         tx.To(),
+		Value:      (*hexutil.Big)(tx.Value()),
+		Data:       hexutil.Encode(tx.Data()),
+		IsCreate:   tx.To() == nil,
+		AccessList: tx.AccessList(),
+		V:          (*hexutil.Big)(v),
+		R:          (*hexutil.Big)(r),
+		S:          (*hexutil.Big)(s),
 	}
 	return result
 }

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,6 +40,8 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
+	case config.IsBanach(blockNumber):
+		signer = NewLondonSignerWithEIP4844(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSignerWithEIP4844(config.ChainID)
 	case config.IsBerlin(blockNumber):

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -74,6 +74,8 @@ func NewEVMInterpreter(evm *EVM, cfg Config) *EVMInterpreter {
 	if cfg.JumpTable[STOP] == nil {
 		var jt JumpTable
 		switch {
+		case evm.chainRules.IsBanach:
+			jt = banachInstructionSet
 		case evm.chainRules.IsShanghai:
 			jt = shanghaiInstructionSet
 		case evm.chainRules.IsLondon:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -59,10 +59,18 @@ var (
 	berlinInstructionSet           = newBerlinInstructionSet()
 	londonInstructionSet           = newLondonInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
+	banachInstructionSet           = newBanachInstructionSet()
 )
 
 // JumpTable contains the EVM opcodes supported at a given fork.
 type JumpTable [256]*operation
+
+// newBanachInstructionSet returns the frontier, homestead, byzantium,
+// contantinople, istanbul, petersburg, berlin, london, shanghai, and banach instructions.
+func newBanachInstructionSet() JumpTable {
+	instructionSet := newShanghaiInstructionSet()
+	return instructionSet
+}
 
 // newShanghaiInstructionSet returns the frontier, homestead, byzantium,
 // contantinople, istanbul, petersburg, berlin, london and shanghai instructions.

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -69,6 +69,7 @@ type JumpTable [256]*operation
 // contantinople, istanbul, petersburg, berlin, london, shanghai, and banach instructions.
 func newBanachInstructionSet() JumpTable {
 	instructionSet := newShanghaiInstructionSet()
+	enable3198(&instructionSet) // Base fee opcode https://eips.ethereum.org/EIPS/eip-3198
 	return instructionSet
 }
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -380,3 +380,7 @@ func (b *EthAPIBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(block, txIndex, reexec)
 }
+
+func (b *EthAPIBackend) StateAt(root common.Hash) (*state.StateDB, error) {
+	return b.eth.BlockChain().StateAt(root)
+}

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -143,7 +143,10 @@ func (api *consensusAPI) AssembleBlock(params assembleBlockParams) (*executableD
 		Time:       params.Timestamp,
 	}
 	if config := api.eth.BlockChain().Config(); config.IsBanach(header.Number) {
-		stateDb, _ := api.eth.BlockChain().StateAt(parent.Root())
+		stateDb, err := api.eth.BlockChain().StateAt(parent.Root())
+		if err != nil {
+			return nil, err
+		}
 		parentL1BaseFee := fees.GetL1BaseFee(stateDb)
 		header.BaseFee = misc.CalcBaseFee(config, parent.Header(), parentL1BaseFee)
 	}
@@ -285,7 +288,10 @@ func (api *consensusAPI) NewBlock(params executableData) (*newBlockResponse, err
 	if parent == nil {
 		return &newBlockResponse{false}, fmt.Errorf("could not find parent %x", params.ParentHash)
 	}
-	stateDb, _ := api.eth.BlockChain().StateAt(parent.Root())
+	stateDb, err := api.eth.BlockChain().StateAt(parent.Root())
+	if err != nil {
+		return nil, err
+	}
 	parentL1BaseFee := fees.GetL1BaseFee(stateDb)
 	block, err := insertBlockParamsToBlock(api.eth.BlockChain().Config(), parent.Header(), params, parentL1BaseFee)
 	if err != nil {

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -141,7 +141,7 @@ func (api *consensusAPI) AssembleBlock(params assembleBlockParams) (*executableD
 		Extra:      []byte{},
 		Time:       params.Timestamp,
 	}
-	if config := api.eth.BlockChain().Config(); config.IsLondon(header.Number) {
+	if config := api.eth.BlockChain().Config(); config.IsBanach(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(config, parent.Header())
 	}
 	err = api.eth.Engine().Prepare(bc, header)
@@ -267,7 +267,7 @@ func insertBlockParamsToBlock(config *chainParams.ChainConfig, parent *types.Hea
 		GasUsed:     params.GasUsed,
 		Time:        params.Timestamp,
 	}
-	if config.IsLondon(number) {
+	if config.IsBanach(number) {
 		header.BaseFee = misc.CalcBaseFee(config, parent)
 	}
 	block := types.NewBlockWithHeader(header).WithBody(txs, nil /* uncles */)

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -88,7 +88,7 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 	if bf.results.baseFee = bf.header.BaseFee; bf.results.baseFee == nil {
 		bf.results.baseFee = new(big.Int)
 	}
-	if chainconfig.IsLondon(big.NewInt(int64(bf.blockNumber + 1))) {
+	if chainconfig.IsBanach(big.NewInt(int64(bf.blockNumber + 1))) {
 		bf.results.nextBaseFee = misc.CalcBaseFee(chainconfig, bf.header)
 	} else {
 		bf.results.nextBaseFee = new(big.Int)
@@ -191,10 +191,11 @@ func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.Block
 // actually processed range is returned to avoid ambiguity when parts of the requested range
 // are not available or when the head has changed during processing this request.
 // Three arrays are returned based on the processed blocks:
-// - reward: the requested percentiles of effective priority fees per gas of transactions in each
-//   block, sorted in ascending order and weighted by gas used.
-// - baseFee: base fee per gas in the given block
-// - gasUsedRatio: gasUsed/gasLimit in the given block
+//   - reward: the requested percentiles of effective priority fees per gas of transactions in each
+//     block, sorted in ascending order and weighted by gas used.
+//   - baseFee: base fee per gas in the given block
+//   - gasUsedRatio: gasUsed/gasLimit in the given block
+//
 // Note: baseFee includes the next block after the newest of the returned range, because this
 // value can be derived from the newest block.
 func (oracle *Oracle) FeeHistory(ctx context.Context, blocks int, unresolvedLastBlock rpc.BlockNumber, rewardPercentiles []float64) (*big.Int, [][]*big.Int, []*big.Int, []float64, error) {

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core"
+	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/event"
 	"github.com/scroll-tech/go-ethereum/log"
@@ -58,6 +59,7 @@ type OracleBackend interface {
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 	ChainConfig() *params.ChainConfig
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
+	StateAt(root common.Hash) (*state.StateDB, error)
 }
 
 // Oracle recommends gas prices based on the content of recent

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/consensus/ethash"
 	"github.com/scroll-tech/go-ethereum/core"
 	"github.com/scroll-tech/go-ethereum/core/rawdb"
+	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/core/vm"
 	"github.com/scroll-tech/go-ethereum/crypto"
@@ -108,6 +109,9 @@ func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool) *testBacke
 	)
 	config.LondonBlock = londonBlock
 	config.ArrowGlacierBlock = londonBlock
+	config.ArchimedesBlock = londonBlock
+	config.ShanghaiBlock = londonBlock
+	config.BanachBlock = londonBlock
 	engine := ethash.NewFaker()
 	db := rawdb.NewMemoryDatabase()
 	genesis, err := gspec.Commit(db)
@@ -158,6 +162,10 @@ func (b *testBackend) CurrentHeader() *types.Header {
 
 func (b *testBackend) GetBlockByNumber(number uint64) *types.Block {
 	return b.chain.GetBlockByNumber(number)
+}
+
+func (b *testBackend) StateAt(root common.Hash) (*state.StateDB, error) {
+	return nil, nil
 }
 
 func TestSuggestTipCap(t *testing.T) {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1694,7 +1694,6 @@ func (s *PublicTransactionPoolAPI) GetTransactionReceipt(ctx context.Context, ha
 			baseFee = big.NewInt(0)
 		}
 
-		// TODO
 		gasPrice := new(big.Int).Add(baseFee, tx.EffectiveGasTipValue(header.BaseFee))
 		fields["effectiveGasPrice"] = hexutil.Uint64(gasPrice.Uint64())
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -159,11 +159,20 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]*RPCTransac
 	}
 	pending, queue := s.b.TxPoolContent()
 	curHeader := s.b.CurrentHeader()
+
+	// get latest L1 base fee
+	state, err := s.b.StateAt(curHeader.Root)
+	if err != nil || state == nil {
+		log.Error("State not found", "number", curHeader.Number, "hash", curHeader.Hash().Hex(), "state", state, "err", err)
+		return nil
+	}
+	l1BaseFee := fees.GetL1BaseFee(state)
+
 	// Flatten the pending transactions
 	for account, txs := range pending {
 		dump := make(map[string]*RPCTransaction)
 		for _, tx := range txs {
-			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig())
+			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig(), l1BaseFee)
 		}
 		content["pending"][account.Hex()] = dump
 	}
@@ -171,7 +180,7 @@ func (s *PublicTxPoolAPI) Content() map[string]map[string]map[string]*RPCTransac
 	for account, txs := range queue {
 		dump := make(map[string]*RPCTransaction)
 		for _, tx := range txs {
-			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig())
+			dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig(), l1BaseFee)
 		}
 		content["queued"][account.Hex()] = dump
 	}
@@ -184,17 +193,25 @@ func (s *PublicTxPoolAPI) ContentFrom(addr common.Address) map[string]map[string
 	pending, queue := s.b.TxPoolContentFrom(addr)
 	curHeader := s.b.CurrentHeader()
 
+	// get latest L1 base fee
+	state, err := s.b.StateAt(curHeader.Root)
+	if err != nil || state == nil {
+		log.Error("State not found", "number", curHeader.Number, "hash", curHeader.Hash().Hex(), "state", state, "err", err)
+		return nil
+	}
+	l1BaseFee := fees.GetL1BaseFee(state)
+
 	// Build the pending transactions
 	dump := make(map[string]*RPCTransaction, len(pending))
 	for _, tx := range pending {
-		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig())
+		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig(), l1BaseFee)
 	}
 	content["pending"] = dump
 
 	// Build the queued transactions
 	dump = make(map[string]*RPCTransaction, len(queue))
 	for _, tx := range queue {
-		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig())
+		dump[fmt.Sprintf("%d", tx.Nonce())] = newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig(), l1BaseFee)
 	}
 	content["queued"] = dump
 
@@ -1351,11 +1368,11 @@ func NewRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 }
 
 // newRPCPendingTransaction returns a pending transaction that will serialize to the RPC representation
-func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, config *params.ChainConfig) *RPCTransaction {
+func newRPCPendingTransaction(tx *types.Transaction, current *types.Header, config *params.ChainConfig, l1BaseFee *big.Int) *RPCTransaction {
 	var baseFee *big.Int
 	blockNumber := uint64(0)
 	if current != nil {
-		baseFee = misc.CalcBaseFee(config, current)
+		baseFee = misc.CalcBaseFee(config, current, l1BaseFee)
 		blockNumber = current.Number.Uint64()
 	}
 	return NewRPCTransaction(tx, common.Hash{}, blockNumber, 0, baseFee, config)
@@ -1594,7 +1611,17 @@ func (s *PublicTransactionPoolAPI) GetTransactionByHash(ctx context.Context, has
 	}
 	// No finalized transaction, try to retrieve it from the pool
 	if tx := s.b.GetPoolTransaction(hash); tx != nil {
-		return newRPCPendingTransaction(tx, s.b.CurrentHeader(), s.b.ChainConfig()), nil
+		curHeader := s.b.CurrentHeader()
+
+		// get latest L1 base fee
+		state, err := s.b.StateAt(curHeader.Root)
+		if err != nil || state == nil {
+			log.Error("State not found", "number", curHeader.Number, "hash", curHeader.Hash().Hex(), "state", state, "err", err)
+			return nil, fmt.Errorf("cannot get L1 base fee, state not found")
+		}
+		l1BaseFee := fees.GetL1BaseFee(state)
+
+		return newRPCPendingTransaction(tx, s.b.CurrentHeader(), s.b.ChainConfig(), l1BaseFee), nil
 	}
 
 	// Transaction unknown, return as such
@@ -1867,10 +1894,19 @@ func (s *PublicTransactionPoolAPI) PendingTransactions() ([]*RPCTransaction, err
 	}
 	curHeader := s.b.CurrentHeader()
 	transactions := make([]*RPCTransaction, 0, len(pending))
+
+	// get latest L1 base fee
+	state, err := s.b.StateAt(curHeader.Root)
+	if err != nil || state == nil {
+		log.Error("State not found", "number", curHeader.Number, "hash", curHeader.Hash().Hex(), "state", state, "err", err)
+		return nil, fmt.Errorf("cannot get L1 base fee, state not found")
+	}
+	l1BaseFee := fees.GetL1BaseFee(state)
+
 	for _, tx := range pending {
 		from, _ := types.Sender(s.signer, tx)
 		if _, exists := accounts[from]; exists {
-			transactions = append(transactions, newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig()))
+			transactions = append(transactions, newRPCPendingTransaction(tx, curHeader, s.b.ChainConfig(), l1BaseFee))
 		}
 	}
 	return transactions, nil

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -65,6 +65,7 @@ type Backend interface {
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
 	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
+	StateAt(root common.Hash) (*state.StateDB, error)
 	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
 	GetTd(ctx context.Context, hash common.Hash) *big.Int
 	GetEVM(ctx context.Context, msg core.Message, state *state.StateDB, header *types.Header, vmConfig *vm.Config) (*vm.EVM, func() error, error)

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -84,7 +84,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	// need to consult the chain for defaults. It's definitely a London tx.
 	if args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil {
 		// In this clause, user left some fields unspecified.
-		if b.ChainConfig().IsLondon(head.Number) && args.GasPrice == nil {
+		if b.ChainConfig().IsBanach(head.Number) && args.GasPrice == nil {
 			if args.MaxPriorityFeePerGas == nil {
 				tip, err := b.SuggestGasTipCap(ctx)
 				if err != nil {
@@ -117,7 +117,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 				if err != nil {
 					return err
 				}
-				if b.ChainConfig().IsLondon(head.Number) {
+				if b.ChainConfig().IsBanach(head.Number) {
 					// The legacy tx gas price suggestion should not add 2x base fee
 					// because all fees are consumed, so it would result in a spiral
 					// upwards.

--- a/internal/ethapi/transaction_args.go
+++ b/internal/ethapi/transaction_args.go
@@ -78,10 +78,10 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 	if args.GasPrice != nil && (args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil) {
 		return errors.New("both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified")
 	}
-	// After london, default to 1559 unless gasPrice is set
+	// After banach, default to 1559 unless gasPrice is set
 	head := b.CurrentHeader()
 	// If user specifies both maxPriorityfee and maxFee, then we do not
-	// need to consult the chain for defaults. It's definitely a London tx.
+	// need to consult the chain for defaults. It's definitely a Banach tx.
 	if args.MaxPriorityFeePerGas == nil || args.MaxFeePerGas == nil {
 		// In this clause, user left some fields unspecified.
 		if b.ChainConfig().IsBanach(head.Number) && args.GasPrice == nil {
@@ -110,7 +110,7 @@ func (args *TransactionArgs) setDefaults(ctx context.Context, b Backend) error {
 			}
 		} else {
 			if args.MaxFeePerGas != nil || args.MaxPriorityFeePerGas != nil {
-				return errors.New("maxFeePerGas or maxPriorityFeePerGas specified but london is not active yet")
+				return errors.New("maxFeePerGas or maxPriorityFeePerGas specified but banach is not active yet")
 			}
 			if args.GasPrice == nil {
 				price, err := b.SuggestGasTipCap(ctx)

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -19,6 +19,7 @@ package les
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -335,4 +336,7 @@ func (b *LesApiBackend) StateAtBlock(ctx context.Context, block *types.Block, re
 
 func (b *LesApiBackend) StateAtTransaction(ctx context.Context, block *types.Block, txIndex int, reexec uint64) (core.Message, vm.BlockContext, *state.StateDB, error) {
 	return b.eth.stateAtTransaction(ctx, block, txIndex, reexec)
+}
+func (b *LesApiBackend) StateAt(root common.Hash) (*state.StateDB, error) {
+	return nil, fmt.Errorf("StateAt is not supported in LES protocol")
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1323,16 +1323,11 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		Time:       uint64(timestamp),
 	}
 	// Set baseFee and GasLimit if we are on an EIP-1559 chain
-	if w.chainConfig.IsLondon(header.Number) {
-		if w.chainConfig.Scroll.BaseFeeEnabled() {
-			header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
-		} else {
-			// When disabling EIP-2718 or EIP-1559, we do not set baseFeePerGas in RPC response.
-			// Setting BaseFee as nil here can help outside SDK calculates l2geth's RLP encoding,
-			// otherwise the l2geth's BaseFee is not known from the outside.
-			header.BaseFee = nil
-		}
-		if !w.chainConfig.IsLondon(parent.Number()) {
+	if w.chainConfig.IsBanach(header.Number) {
+		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
+
+		// TODO
+		if !w.chainConfig.IsBanach(parent.Number()) {
 			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
 			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
 		}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1322,15 +1322,9 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		Extra:      w.extra,
 		Time:       uint64(timestamp),
 	}
-	// Set baseFee and GasLimit if we are on an EIP-1559 chain
+	// Set baseFee if we are on an EIP-1559 chain
 	if w.chainConfig.IsBanach(header.Number) {
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header())
-
-		// TODO
-		if !w.chainConfig.IsBanach(parent.Number()) {
-			parentGasLimit := parent.GasLimit() * params.ElasticityMultiplier
-			header.GasLimit = core.CalcGasLimit(parentGasLimit, w.config.GasCeil)
-		}
 	}
 	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
 	if w.isRunning() {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1323,14 +1323,6 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		Extra:      w.extra,
 		Time:       uint64(timestamp),
 	}
-	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
-	if w.isRunning() {
-		if w.coinbase == (common.Address{}) {
-			log.Error("Refusing to mine without etherbase")
-			return
-		}
-		header.Coinbase = w.coinbase
-	}
 	// Set baseFee if we are on an EIP-1559 chain
 	if w.chainConfig.IsBanach(header.Number) {
 		state, err := w.chain.StateAt(parent.Root())
@@ -1340,6 +1332,14 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 		}
 		parentL1BaseFee := fees.GetL1BaseFee(state)
 		header.BaseFee = misc.CalcBaseFee(w.chainConfig, parent.Header(), parentL1BaseFee)
+	}
+	// Only set the coinbase if our consensus engine is running (avoid spurious block rewards)
+	if w.isRunning() {
+		if w.coinbase == (common.Address{}) {
+			log.Error("Refusing to mine without etherbase")
+			return
+		}
+		header.Coinbase = w.coinbase
 	}
 	if err := w.engine.Prepare(w.chain, header); err != nil {
 		log.Error("Failed to prepare header for mining", "err", err)

--- a/params/config.go
+++ b/params/config.go
@@ -289,8 +289,6 @@ var (
 			MaxTxPerBlock:             &ScrollMaxTxPerBlock,
 			MaxTxPayloadBytesPerBlock: &ScrollMaxTxPayloadBytesPerBlock,
 			FeeVaultAddress:           &rcfg.ScrollFeeVaultAddress,
-			EnableEIP2718:             false,
-			EnableEIP1559:             false,
 			L1Config: &L1Config{
 				L1ChainId:             5,
 				L1MessageQueueAddress: common.HexToAddress("0x79DB48002Aa861C8cb189cabc21c6B1468BC83BB"),
@@ -328,8 +326,6 @@ var (
 			MaxTxPerBlock:             &ScrollMaxTxPerBlock,
 			MaxTxPayloadBytesPerBlock: &ScrollMaxTxPayloadBytesPerBlock,
 			FeeVaultAddress:           &rcfg.ScrollFeeVaultAddress,
-			EnableEIP2718:             false,
-			EnableEIP1559:             false,
 			L1Config: &L1Config{
 				L1ChainId:             11155111,
 				L1MessageQueueAddress: common.HexToAddress("0xF0B2293F5D834eAe920c6974D50957A1732de763"),
@@ -367,8 +363,6 @@ var (
 			MaxTxPerBlock:             &ScrollMaxTxPerBlock,
 			MaxTxPayloadBytesPerBlock: &ScrollMaxTxPayloadBytesPerBlock,
 			FeeVaultAddress:           &rcfg.ScrollFeeVaultAddress,
-			EnableEIP2718:             false,
-			EnableEIP1559:             false,
 			L1Config: &L1Config{
 				L1ChainId:             1,
 				L1MessageQueueAddress: common.HexToAddress("0x0d7E906BD9cAFa154b048cFa766Cc1E54E39AF9B"),
@@ -383,12 +377,10 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil,
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
 		ScrollConfig{
 			UseZktrie:                 false,
 			FeeVaultAddress:           nil,
-			EnableEIP2718:             true,
-			EnableEIP1559:             true,
 			MaxTxPerBlock:             nil,
 			MaxTxPayloadBytesPerBlock: nil,
 			L1Config:                  &L1Config{5, common.HexToAddress("0x0000000000000000000000000000000000000000"), 0, common.HexToAddress("0x0000000000000000000000000000000000000000")},
@@ -399,35 +391,29 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000},
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, &CliqueConfig{Period: 0, Epoch: 30000},
 		ScrollConfig{
 			UseZktrie:                 false,
 			FeeVaultAddress:           nil,
-			EnableEIP2718:             true,
-			EnableEIP1559:             true,
 			MaxTxPerBlock:             nil,
 			MaxTxPayloadBytesPerBlock: nil,
 			L1Config:                  &L1Config{5, common.HexToAddress("0x0000000000000000000000000000000000000000"), 0, common.HexToAddress("0x0000000000000000000000000000000000000000")},
 		}}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil,
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
 		ScrollConfig{
 			UseZktrie:                 false,
 			FeeVaultAddress:           &common.Address{123},
-			EnableEIP2718:             true,
-			EnableEIP1559:             true,
 			MaxTxPerBlock:             nil,
 			MaxTxPayloadBytesPerBlock: nil,
 			L1Config:                  &L1Config{5, common.HexToAddress("0x0000000000000000000000000000000000000000"), 0, common.HexToAddress("0x0000000000000000000000000000000000000000")},
 		}}
 	TestRules = TestChainConfig.Rules(new(big.Int))
 
-	TestNoL1DataFeeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil,
+	TestNoL1DataFeeChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil,
 		ScrollConfig{
 			UseZktrie:                 false,
 			FeeVaultAddress:           nil,
-			EnableEIP2718:             true,
-			EnableEIP1559:             true,
 			MaxTxPerBlock:             nil,
 			MaxTxPayloadBytesPerBlock: nil,
 			L1Config:                  &L1Config{5, common.HexToAddress("0x0000000000000000000000000000000000000000"), 0, common.HexToAddress("0x0000000000000000000000000000000000000000")},
@@ -539,12 +525,6 @@ type ScrollConfig struct {
 	// Transaction fee vault address [optional]
 	FeeVaultAddress *common.Address `json:"feeVaultAddress,omitempty"`
 
-	// Enable EIP-2718 in tx pool [optional]
-	EnableEIP2718 bool `json:"enableEIP2718,omitempty"`
-
-	// Enable EIP-1559 in tx pool, EnableEIP2718 should be true too [optional]
-	EnableEIP1559 bool `json:"enableEIP1559,omitempty"`
-
 	// L1 config
 	L1Config *L1Config `json:"l1Config,omitempty"`
 }
@@ -564,10 +544,6 @@ func (c *L1Config) String() string {
 
 	return fmt.Sprintf("{l1ChainId: %v, l1MessageQueueAddress: %v, numL1MessagesPerBlock: %v, ScrollChainAddress: %v}",
 		c.L1ChainId, c.L1MessageQueueAddress.Hex(), c.NumL1MessagesPerBlock, c.ScrollChainAddress.Hex())
-}
-
-func (s ScrollConfig) BaseFeeEnabled() bool {
-	return s.EnableEIP2718 && s.EnableEIP1559
 }
 
 func (s ScrollConfig) FeeVaultEnabled() bool {
@@ -593,8 +569,8 @@ func (s ScrollConfig) String() string {
 		maxTxPayloadBytesPerBlock = fmt.Sprintf("%v", *s.MaxTxPayloadBytesPerBlock)
 	}
 
-	return fmt.Sprintf("{useZktrie: %v, maxTxPerBlock: %v, MaxTxPayloadBytesPerBlock: %v, feeVaultAddress: %v, enableEIP2718: %v, enableEIP1559: %v, l1Config: %v}",
-		s.UseZktrie, maxTxPerBlock, maxTxPayloadBytesPerBlock, s.FeeVaultAddress, s.EnableEIP2718, s.EnableEIP1559, s.L1Config.String())
+	return fmt.Sprintf("{useZktrie: %v, maxTxPerBlock: %v, MaxTxPayloadBytesPerBlock: %v, feeVaultAddress: %v, l1Config: %v}",
+		s.UseZktrie, maxTxPerBlock, maxTxPayloadBytesPerBlock, s.FeeVaultAddress, s.L1Config.String())
 }
 
 // IsValidTxCount returns whether the given block's transaction count is below the limit.

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 20        // Patch version component of the current release
+	VersionPatch = 21        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 19        // Patch version component of the current release
+	VersionPatch = 20        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 21        // Patch version component of the current release
+	VersionPatch = 22        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -187,3 +187,7 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB) (*big.Int, error) 
 	l1DataFee := calculateEncodedL1DataFee(raw, overhead, l1BaseFee, scalar)
 	return l1DataFee, nil
 }
+
+func GetL1BaseFee(state StateDB) *big.Int {
+	return state.GetState(rcfg.L1GasPriceOracleAddress, rcfg.L1BaseFeeSlot).Big()
+}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -188,7 +188,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	snaps, statedb := MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre, snapshotter)
 
 	var baseFee *big.Int
-	if config.IsLondon(new(big.Int)) {
+	if config.IsBanach(new(big.Int)) {
 		baseFee = t.json.Env.BaseFee
 		if baseFee == nil {
 			// Retesteth uses `0x10` for genesis baseFee. Therefore, it defaults to


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Re-enable [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) and and [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) transactions.

Main changes:
- [X] Accept 2718 and 1559 txs in `txpool`.
- [X] Set `baseFee` in `worker`.
- [X] Update execution and verification logic.
- [X] Enable `BASEFEE` opcode.
- [x] Update max and target gas limit.
- [x] Do not burn ETH but send to fee vault.
- [x] Update traces to support new tx fields.

Test plan:
- [x] Test compatibility (sync with Scroll and Scroll Sepolia)
- [x] Test APIs (`eth_sendRawTransaction`, `eth_getBlockByNumber`, `eth_feeHistory`).
- [x] Test transition: Run local testnet with Banach block `N > 0`.

Local testnet test notes: https://gist.github.com/Thegaram/131e368f1faad4c8e23d556d92d1e463


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
