### PR TITLE
fix(rollup-sync-service): remove syscall.Kill

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -226,7 +226,7 @@ func New(stack *node.Node, config *ethconfig.Config, l1Client sync_service.EthCl
 
 	if config.EnableRollupVerify {
 		// initialize and start rollup event sync service
-		eth.rollupSyncService, err = rollup_sync_service.NewRollupSyncService(context.Background(), chainConfig, eth.chainDb, l1Client, eth.blockchain, stack.Config().L1DeploymentBlock)
+		eth.rollupSyncService, err = rollup_sync_service.NewRollupSyncService(context.Background(), chainConfig, eth.chainDb, l1Client, eth.blockchain, stack)
 		if err != nil {
 			return nil, fmt.Errorf("cannot initialize rollup event sync service: %w", err)
 		}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 16        // Patch version component of the current release
+	VersionPatch = 17        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 15        // Patch version component of the current release
+	VersionPatch = 16        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service_test.go
+++ b/rollup/rollup_sync_service/rollup_sync_service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/core/rawdb"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/ethdb/memorydb"
+	"github.com/scroll-tech/go-ethereum/node"
 	"github.com/scroll-tech/go-ethereum/params"
 )
 
@@ -32,7 +33,12 @@ func TestRollupSyncServiceStartAndStop(t *testing.T) {
 	db := rawdb.NewDatabase(memorydb.New())
 	l1Client := &mockEthClient{}
 	bc := &core.BlockChain{}
-	service, err := NewRollupSyncService(context.Background(), genesisConfig, db, l1Client, bc, 1)
+	stack, err := node.New(&node.DefaultConfig)
+	if err != nil {
+		t.Fatalf("Failed to new P2P node: %v", err)
+	}
+	defer stack.Close()
+	service, err := NewRollupSyncService(context.Background(), genesisConfig, db, l1Client, bc, stack)
 	if err != nil {
 		t.Fatalf("Failed to new rollup sync service: %v", err)
 	}
@@ -112,7 +118,12 @@ func TestGetChunkRanges(t *testing.T) {
 		commitBatchRLP: rlpData,
 	}
 	bc := &core.BlockChain{}
-	service, err := NewRollupSyncService(context.Background(), genesisConfig, db, l1Client, bc, 1)
+	stack, err := node.New(&node.DefaultConfig)
+	if err != nil {
+		t.Fatalf("Failed to new P2P node: %v", err)
+	}
+	defer stack.Close()
+	service, err := NewRollupSyncService(context.Background(), genesisConfig, db, l1Client, bc, stack)
 	if err != nil {
 		t.Fatalf("Failed to new rollup sync service: %v", err)
 	}
@@ -169,7 +180,7 @@ func TestValidateBatch(t *testing.T) {
 		StateRoot:    chunk3.Blocks[len(chunk3.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*Chunk{chunk1, chunk2, chunk3})
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*Chunk{chunk1, chunk2, chunk3}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -193,7 +204,7 @@ func TestValidateBatch(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*Chunk{chunk4})
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*Chunk{chunk4}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Currently, the code fails to compile on Windows:
```
rollup\rollup_sync_service\rollup_sync_service.go:398:11: undefined: syscall.Kill
```

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206533228599657