### PR TITLE
chore(libzkp): upgrade to v0.9.10, optimize ccc for follower&chunking

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 23        // Patch version component of the current release
+	VersionPatch = 24        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.lock
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "ark-std",
  "env_logger 0.10.0",
@@ -297,7 +297,7 @@ checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -971,7 +971,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "ethers-core",
  "ethers-signers",
@@ -1128,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1308,7 +1308,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -1340,7 +1340,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "env_logger 0.9.3",
  "gobuild 0.1.0-alpha.2 (git+https://github.com/scroll-tech/gobuild.git)",
@@ -1949,7 +1949,7 @@ dependencies = [
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "env_logger 0.9.3",
  "eth-types",
@@ -2157,7 +2157,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2173,7 +2173,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "eth-types",
  "halo2-mpt-circuits",
@@ -2595,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "aggregator",
  "anyhow",
@@ -4212,7 +4212,7 @@ checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.8#8f17df87ba70f5a8fcaa23f4fcb7fb112f5a815a"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.9.10#c625e056ab50582c8c9c662fd2ae1457ef707cc0"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.toml
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.toml
@@ -20,7 +20,7 @@ maingate = { git = "https://github.com/scroll-tech/halo2wrong", branch = "halo2-
 halo2curves = { git = "https://github.com/scroll-tech/halo2curves.git", branch = "0.3.1-derive-serde" }
 
 [dependencies]
-prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.9.8", default-features = false, features = ["parallel_syn", "scroll", "shanghai", "strict-ccc"] }
+prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.9.10", default-features = false, features = ["parallel_syn", "scroll", "shanghai", "strict-ccc"] }
 
 anyhow = "1.0"
 log = "0.4"


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR


The poseidon circuit row usage is difficult to estimate fast. So previously we used some conservative estimation. Now we caliberated this estimation method using mainnet real metics.  After upgrading this,  total gas per chunk can be improved so we need less chunk provers.

Original commit: https://github.com/scroll-tech/zkevm-circuits/pull/991/commits/c625e056ab50582c8c9c662fd2ae1457ef707cc0. 

change a coefficient from 12 to 6, with the avg/mean is below 1:

<a href="https://imgbb.com/"><img src="https://i.ibb.co/74ZgpzL/mpt-ratio.png" alt="mpt-ratio" border="0" /></a>

(btw v0.9.9 is "add verification after chunk proof generated", so not related to l2geth.)


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
