### PR TITLE
fix(sync-service): only add queue index when message index is not zero

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 1         // Minor version component of the current release
-	VersionPatch = 26        // Patch version component of the current release
+	VersionPatch = 27        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -220,7 +220,9 @@ func (s *SyncService) fetchMessages() {
 		}
 
 		for _, msg := range msgs {
-			queueIndex++
+			if msg.QueueIndex > 0 {
+				queueIndex++
+			}
 			// check if received queue index matches expected queue index
 			if msg.QueueIndex != queueIndex {
 				log.Error("Unexpected queue index in SyncService", "expected", queueIndex, "got", msg.QueueIndex, "msg", msg)


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

A corner case fix, one will encounter this when syncing from scratch. The root cause is that the db fetching result does not differentiate between "not found" and "0".

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
