### PR TITLE
fix(rollup-verifier): hardcode genesis codec version as codecv0 and sync codecv1 implementation

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 2         // Minor version component of the current release
-	VersionPatch = 0         // Patch version component of the current release
+	VersionPatch = 1         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -415,7 +415,7 @@ func validateBatch(event *L1FinalizeBatchEvent, parentBatchMeta *rawdb.Finalized
 	}
 
 	var localBatchHash common.Hash
-	if !chainCfg.IsBernoulli(startBlock.Header.Number) {
+	if startBlock.Header.Number.Uint64() == 0 || !chainCfg.IsBernoulli(startBlock.Header.Number) { // codecv0: genesis batch or batches before Bernoulli
 		daBatch, err := codecv0.NewDABatch(batch)
 		if err != nil {
 			return 0, nil, fmt.Errorf("failed to create codecv0 DA batch, batch index: %v, err: %w", event.BatchIndex.Uint64(), err)

--- a/rollup/types/encoding/codecv1/codecv1.go
+++ b/rollup/types/encoding/codecv1/codecv1.go
@@ -244,17 +244,10 @@ func NewDABatch(batch *encoding.Batch) (*DABatch, error) {
 	}
 
 	// blob payload
-	blob, z, err := constructBlobPayload(batch.Chunks)
+	blob, blobVersionedHash, z, err := constructBlobPayload(batch.Chunks)
 	if err != nil {
 		return nil, err
 	}
-
-	// blob versioned hash
-	c, err := kzg4844.BlobToCommitment(*blob)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create blob commitment")
-	}
-	blobVersionedHash := kzg4844.CalcBlobHashV1(sha256.New(), &c)
 
 	daBatch := DABatch{
 		Version:                CodecV1Version,
@@ -298,7 +291,7 @@ func computeBatchDataHash(chunks []*encoding.Chunk, totalL1MessagePoppedBefore u
 }
 
 // constructBlobPayload constructs the 4844 blob payload.
-func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Point, error) {
+func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, common.Hash, *kzg4844.Point, error) {
 	// metadata consists of num_chunks (2 bytes) and chunki_size (4 bytes per chunk)
 	metadataLength := 2 + MaxNumChunks*4
 
@@ -306,8 +299,8 @@ func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Poi
 	blobBytes := make([]byte, metadataLength)
 
 	// challenge digest preimage
-	// 1 hash for metadata and 1 for each chunk
-	challengePreimage := make([]byte, (1+MaxNumChunks)*32)
+	// 1 hash for metadata, 1 hash for each chunk, 1 hash for blob versioned hash
+	challengePreimage := make([]byte, (1+MaxNumChunks+1)*32)
 
 	// the chunk data hash used for calculating the challenge preimage
 	var chunkDataHash common.Hash
@@ -326,7 +319,7 @@ func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Poi
 					// encode L2 txs into blob payload
 					rlpTxData, err := encoding.ConvertTxDataToRLPEncoding(tx)
 					if err != nil {
-						return nil, nil, err
+						return nil, common.Hash{}, nil, err
 					}
 					blobBytes = append(blobBytes, rlpTxData...)
 				}
@@ -358,8 +351,18 @@ func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Poi
 	// convert raw data to BLSFieldElements
 	blob, err := makeBlobCanonical(blobBytes)
 	if err != nil {
-		return nil, nil, err
+		return nil, common.Hash{}, nil, err
 	}
+
+	// compute blob versioned hash
+	c, err := kzg4844.BlobToCommitment(*blob)
+	if err != nil {
+		return nil, common.Hash{}, nil, fmt.Errorf("failed to create blob commitment")
+	}
+	blobVersionedHash := kzg4844.CalcBlobHashV1(sha256.New(), &c)
+
+	// challenge: append blob versioned hash
+	copy(challengePreimage[(1+MaxNumChunks)*32:], blobVersionedHash[:])
 
 	// compute z = challenge_digest % BLS_MODULUS
 	challengeDigest := crypto.Keccak256Hash(challengePreimage)
@@ -371,7 +374,7 @@ func constructBlobPayload(chunks []*encoding.Chunk) (*kzg4844.Blob, *kzg4844.Poi
 	start := 32 - len(pointBytes)
 	copy(z[start:], pointBytes)
 
-	return blob, &z, nil
+	return blob, blobVersionedHash, &z, nil
 }
 
 // makeBlobCanonical converts the raw blob data into the canonical blob representation of 4096 BLSFieldElements.


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

1. hardcode genesis codec version to `codecv0`.
2. update codecv1 to latest version, synced from `scroll` repo.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
