### PR TITLE
feat: add block time metric

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -53,6 +53,7 @@ var (
 	headBlockGauge     = metrics.NewRegisteredGauge("chain/head/block", nil)
 	headHeaderGauge    = metrics.NewRegisteredGauge("chain/head/header", nil)
 	headFastBlockGauge = metrics.NewRegisteredGauge("chain/head/receipt", nil)
+	headTimeGapGauge   = metrics.NewRegisteredGauge("chain/head/timegap", nil)
 
 	l2BaseFeeGauge = metrics.NewRegisteredGauge("chain/fees/l2basefee", nil)
 
@@ -1254,6 +1255,12 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 	} else {
 		l2BaseFeeGauge.Update(0)
 	}
+
+	parent := bc.GetHeaderByHash(block.ParentHash())
+	// block.Time is guaranteed to be larger than parent.Time,
+	// and the time gap should fit into int64.
+	gap := int64(block.Time() - parent.Time)
+	headTimeGapGauge.Update(gap)
 
 	// Calculate the total difficulty of the block
 	ptd := bc.GetTd(block.ParentHash(), block.NumberU64()-1)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 2         // Minor version component of the current release
-	VersionPatch = 5         // Patch version component of the current release
+	VersionPatch = 6         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Track block time, defined as the gap between the timestamps of two consecutive blocks.

Note: This is not exactly the same as the time it takes to produce a block but it's correlated. The relevant code is here:

https://github.com/scroll-tech/go-ethereum/blob/62926d46495bdc9ab2138c2fd24a2b206508f936/consensus/clique/clique.go#L557-L560

E.g. if block `#100` is at 100s, then we set block `#101`'s timestamp as 103s, but in reality we seal and broadcast this block at 106s. Then, block `#102`'s timestamp will be set as 106 or higher. So this metric will capture the delay.

I decided to track this metric in `writeBlockWithState` because this way it's tracked both in signer nodes (from `WriteBlockWithState`, called by `worker`) and follower nodes (from `InsertChain`).

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
