### PR TITLE
fix(api-backend): disable finalized tag when rollup verify is disabled

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -77,6 +77,9 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 		return b.eth.blockchain.CurrentBlock().Header(), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
+		if !b.eth.config.EnableRollupVerify {
+			return nil, errors.New("sync L1 finalized batch feature not enabled, cannot query L2 finalized block height")
+		}
 		finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(b.eth.ChainDb())
 		if finalizedBlockHeightPtr == nil {
 			return nil, errors.New("L2 finalized block height not found in database")
@@ -119,6 +122,9 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 		return b.eth.blockchain.CurrentBlock(), nil
 	}
 	if number == rpc.FinalizedBlockNumber {
+		if !b.eth.config.EnableRollupVerify {
+			return nil, errors.New("sync L1 finalized batch feature not enabled, cannot query L2 finalized block height")
+		}
 		finalizedBlockHeightPtr := rawdb.ReadFinalizedL2BlockNumber(b.eth.ChainDb())
 		if finalizedBlockHeightPtr == nil {
 			return nil, errors.New("L2 finalized block height not found in database")

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 5         // Patch version component of the current release
+	VersionPatch = 6         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
Disables the "finalized tag" when the "rollup verify" feature is disabled.

Otherwise, if one node previously enabled `--rollup.verify` but then disable it, when it queries a "finalized" block, it will still get a finalized block number but an incorrect one.

Related previous PR: https://github.com/scroll-tech/go-ethereum/pull/548