### PR TITLE
docs(miner): rename `circuitCapacityReached` to `circuitCapacityOrBlockTimeReached`

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1019,8 +1019,7 @@ func (w *worker) commitTransactions(txs types.OrderedTransactionSet, coinbase co
 		l2CommitTxsTimer.Update(time.Since(t0))
 	}(time.Now())
 
-	// CircuitCapacity or BlockTime Reached
-	var ccOrBtReached bool
+	var ccOrBtReached bool // CircuitCapacity or BlockTime Reached
 
 	// Short circuit if current is nil
 	if w.current == nil {
@@ -1466,7 +1465,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	}
 	l2CommitNewWorkTidyPendingTxTimer.UpdateSince(tidyPendingStart)
 
-	var skipCommit, ccOrBtReached bool
+	var skipCommit, ccOrBtReached bool // ccOrBtReached means either circuit capacity or block time has been reached
 	commitL1MsgStart := time.Now()
 	if w.chainConfig.Scroll.ShouldIncludeL1Messages() && len(l1Messages) > 0 {
 		log.Trace("Processing L1 messages for inclusion", "count", len(l1Messages))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1019,11 +1019,11 @@ func (w *worker) commitTransactions(txs types.OrderedTransactionSet, coinbase co
 		l2CommitTxsTimer.Update(time.Since(t0))
 	}(time.Now())
 
-	var ccOrBtReached bool // CircuitCapacity or BlockTime Reached
+	var circuitCapacityOrBlockTimeReached bool
 
 	// Short circuit if current is nil
 	if w.current == nil {
-		return true, ccOrBtReached
+		return true, circuitCapacityOrBlockTimeReached
 	}
 
 	gasLimit := w.current.header.GasLimit
@@ -1058,12 +1058,12 @@ loop:
 					inc:   true,
 				}
 			}
-			return atomic.LoadInt32(interrupt) == commitInterruptNewHead, ccOrBtReached
+			return atomic.LoadInt32(interrupt) == commitInterruptNewHead, circuitCapacityOrBlockTimeReached
 		}
 		// seal block early if we're over time
 		// note: current.header.Time = max(parent.Time + cliquePeriod, now())
 		if w.current.tcount > 0 && w.chainConfig.Clique != nil && uint64(time.Now().Unix()) > w.current.header.Time {
-			ccOrBtReached = true // skip subsequent invocations of commitTransactions
+			circuitCapacityOrBlockTimeReached = true // skip subsequent invocations of commitTransactions
 			break
 		}
 		// If we don't have enough gas for any further transactions then we're done
@@ -1187,7 +1187,7 @@ loop:
 				}
 				atomic.AddInt32(&w.newTxs, int32(1))
 
-				ccOrBtReached = true
+				circuitCapacityOrBlockTimeReached = true
 				break loop
 			} else {
 				// 2. Circuit capacity limit reached in a block, and it's the first tx: skip the tx
@@ -1213,7 +1213,7 @@ loop:
 				// Reset ccc so that we can process other transactions for this block
 				w.circuitCapacityChecker.Reset()
 				log.Trace("Worker reset ccc", "id", w.circuitCapacityChecker.ID)
-				ccOrBtReached = false
+				circuitCapacityOrBlockTimeReached = false
 
 				// Store skipped transaction in local db
 				if w.config.StoreSkippedTxTraces {
@@ -1241,7 +1241,7 @@ loop:
 			// Normally we would do `txs.Shift()` here.
 			// However, after `ErrUnknown`, ccc might remain in an
 			// inconsistent state, so we cannot pack more transactions.
-			ccOrBtReached = true
+			circuitCapacityOrBlockTimeReached = true
 			w.checkCurrentTxNumWithCCC(w.current.tcount)
 			break loop
 
@@ -1261,7 +1261,7 @@ loop:
 			// However, after `ErrUnknown`, ccc might remain in an
 			// inconsistent state, so we cannot pack more transactions.
 			w.eth.TxPool().RemoveTx(tx.Hash(), true)
-			ccOrBtReached = true
+			circuitCapacityOrBlockTimeReached = true
 			w.checkCurrentTxNumWithCCC(w.current.tcount)
 			break loop
 
@@ -1309,7 +1309,7 @@ loop:
 	if interrupt != nil {
 		w.resubmitAdjustCh <- &intervalAdjust{inc: false}
 	}
-	return false, ccOrBtReached
+	return false, circuitCapacityOrBlockTimeReached
 }
 
 func (w *worker) checkCurrentTxNumWithCCC(expected int) {
@@ -1465,7 +1465,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	}
 	l2CommitNewWorkTidyPendingTxTimer.UpdateSince(tidyPendingStart)
 
-	var skipCommit, ccOrBtReached bool // ccOrBtReached means either circuit capacity or block time has been reached
+	var skipCommit, circuitCapacityOrBlockTimeReached bool
 	commitL1MsgStart := time.Now()
 	if w.chainConfig.Scroll.ShouldIncludeL1Messages() && len(l1Messages) > 0 {
 		log.Trace("Processing L1 messages for inclusion", "count", len(l1Messages))
@@ -1474,7 +1474,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 			log.Error("Failed to create L1 message set", "l1Messages", l1Messages, "err", err)
 			return
 		}
-		skipCommit, ccOrBtReached = w.commitTransactions(txs, w.coinbase, interrupt)
+		skipCommit, circuitCapacityOrBlockTimeReached = w.commitTransactions(txs, w.coinbase, interrupt)
 		if skipCommit {
 			l2CommitNewWorkCommitL1MsgTimer.UpdateSince(commitL1MsgStart)
 			return
@@ -1486,12 +1486,12 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	if w.prioritizedTx != nil && w.current.header.Number.Uint64() > w.prioritizedTx.blockNumber {
 		w.prioritizedTx = nil
 	}
-	if !ccOrBtReached && w.prioritizedTx != nil && w.current.header.Number.Uint64() == w.prioritizedTx.blockNumber {
+	if !circuitCapacityOrBlockTimeReached && w.prioritizedTx != nil && w.current.header.Number.Uint64() == w.prioritizedTx.blockNumber {
 		tx := w.prioritizedTx.tx
 		from, _ := types.Sender(w.current.signer, tx) // error already checked before
 		txList := map[common.Address]types.Transactions{from: []*types.Transaction{tx}}
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, txList, header.BaseFee)
-		skipCommit, ccOrBtReached = w.commitTransactions(txs, w.coinbase, interrupt)
+		skipCommit, circuitCapacityOrBlockTimeReached = w.commitTransactions(txs, w.coinbase, interrupt)
 		if skipCommit {
 			l2CommitNewWorkPrioritizedTxCommitTimer.UpdateSince(prioritizedTxStart)
 			return
@@ -1500,24 +1500,24 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	l2CommitNewWorkPrioritizedTxCommitTimer.UpdateSince(prioritizedTxStart)
 
 	remoteLocalStart := time.Now()
-	if len(localTxs) > 0 && !ccOrBtReached {
+	if len(localTxs) > 0 && !circuitCapacityOrBlockTimeReached {
 		localTxPriceAndNonceStart := time.Now()
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, localTxs, header.BaseFee)
 		l2CommitNewWorkLocalPriceAndNonceTimer.UpdateSince(localTxPriceAndNonceStart)
 
-		skipCommit, ccOrBtReached = w.commitTransactions(txs, w.coinbase, interrupt)
+		skipCommit, circuitCapacityOrBlockTimeReached = w.commitTransactions(txs, w.coinbase, interrupt)
 		if skipCommit {
 			l2CommitNewWorkRemoteLocalCommitTimer.UpdateSince(remoteLocalStart)
 			return
 		}
 	}
 
-	if len(remoteTxs) > 0 && !ccOrBtReached {
+	if len(remoteTxs) > 0 && !circuitCapacityOrBlockTimeReached {
 		remoteTxPriceAndNonceStart := time.Now()
 		txs := types.NewTransactionsByPriceAndNonce(w.current.signer, remoteTxs, header.BaseFee)
 		l2CommitNewWorkRemotePriceAndNonceTimer.UpdateSince(remoteTxPriceAndNonceStart)
 
-		// don't need to get `ccOrBtReached` here because we don't have further `commitTransactions`
+		// don't need to get `circuitCapacityOrBlockTimeReached` here because we don't have further `commitTransactions`
 		// after this one, and if we assign it won't take effect (`ineffassign`)
 		skipCommit, _ = w.commitTransactions(txs, w.coinbase, interrupt)
 		if skipCommit {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Align the variable name with the actual meaning, which is to track whether the circuit capacity or block time limit has been reached, not just the circuit capacity.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
