### PR TITLE
fix: temporarily disable string encoding for new opcodes

### DIFF
--- a/core/vm/opcodes.go
+++ b/core/vm/opcodes.go
@@ -288,7 +288,11 @@ var opCodeToString = map[OpCode]string{
 	GASLIMIT:    "GASLIMIT",
 	CHAINID:     "CHAINID",
 	SELFBALANCE: "SELFBALANCE",
-	BASEFEE:     "BASEFEE",
+
+	// we temporarily comment this out, since ccc expects
+	// the "opcode 0x%x not defined" string in the traces,
+	// should uncomment once ccc supports the string version.
+	// BASEFEE:     "BASEFEE",
 
 	// 0x50 range - 'storage' and execution.
 	POP: "POP",
@@ -305,10 +309,15 @@ var opCodeToString = map[OpCode]string{
 	MSIZE:    "MSIZE",
 	GAS:      "GAS",
 	JUMPDEST: "JUMPDEST",
-	TLOAD:    "TLOAD",
-	TSTORE:   "TSTORE",
-	MCOPY:    "MCOPY",
-	PUSH0:    "PUSH0",
+
+	// we temporarily comment these out, since ccc expects
+	// the "opcode 0x%x not defined" string in the traces,
+	// should uncomment once ccc supports the string version.
+	// TLOAD:    "TLOAD",
+	// TSTORE:   "TSTORE",
+	// MCOPY:    "MCOPY",
+
+	PUSH0: "PUSH0",
 
 	// 0x60 range - push.
 	PUSH1:  "PUSH1",

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 9         // Patch version component of the current release
+	VersionPatch = 10        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Adding new opcodes to `opCodeToString` makes the ccc fail when parsing the traces, leading to inconsistent behavior.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
