### PR TITLE
metrics: NilTimer should still run the function to be timed (#27723)

### DIFF
--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -123,7 +123,7 @@ func (NilTimer) Stop() {}
 func (NilTimer) Sum() int64 { return 0 }
 
 // Time is a no-op.
-func (NilTimer) Time(func()) {}
+func (NilTimer) Time(f func()) { f() }
 
 // Update is a no-op.
 func (NilTimer) Update(time.Duration) {}


### PR DESCRIPTION
cherry-picked from https://github.com/ethereum/go-ethereum/pull/27723