### PR TITLE
docs(zktrie): remove an outdated comment

### DIFF
--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -127,8 +127,6 @@ func (t *ZkTrie) Commit(LeafCallback) (common.Hash, int, error) {
 	if err := t.ZkTrie.Commit(); err != nil {
 		return common.Hash{}, 0, err
 	}
-	// in current implmentation, every update of trie already writes into database
-	// so Commmit does nothing
 	return t.Hash(), 0, nil
 }
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

removing an outdated comment for clarity, zktrie now uses lazy committment, so commit actually will write db. no need to bump the version.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] docs: Documentation-only changes

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
