### PR TITLE
feature: keep track of and export total time observed by a timer

### DIFF
--- a/metrics/influxdb/influxdb.go
+++ b/metrics/influxdb/influxdb.go
@@ -223,6 +223,7 @@ func (r *reporter) send() error {
 					"m5":       ms.Rate5(),
 					"m15":      ms.Rate15(),
 					"meanrate": ms.RateMean(),
+					"total":    int64(ms.Total()),
 				},
 				Time: now,
 			})

--- a/metrics/influxdb/influxdbv2.go
+++ b/metrics/influxdb/influxdbv2.go
@@ -190,6 +190,7 @@ func (r *v2Reporter) send() {
 				"m5":       ms.Rate5(),
 				"m15":      ms.Rate15(),
 				"meanrate": ms.RateMean(),
+				"total":    int64(ms.Total()),
 			}
 
 			pt := influxdb2.NewPoint(measurement, r.tags, fields, now)

--- a/metrics/timer_test.go
+++ b/metrics/timer_test.go
@@ -112,3 +112,18 @@ func ExampleGetOrRegisterTimer() {
 	t.Update(47)
 	fmt.Println(t.Max()) // Output: 47
 }
+
+func TestTimerSum(t *testing.T) {
+	tm := GetOrRegisterTimer("test.timer.sum", nil)
+	times := 5000000
+	for i := 0; i < times; i++ {
+		tm.Update(time.Second)
+	}
+	ss := tm.Snapshot()
+	if total := tm.Total().Seconds(); total != float64(times) {
+		t.Errorf("tm.Total().Seconds(): 5000000.0 != %v\n", total)
+	}
+	if total := ss.Total().Seconds(); total != float64(times) {
+		t.Errorf("ss.Total().Seconds(): 5000000.0 != %v\n", total)
+	}
+}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 22        // Patch version component of the current release
+	VersionPatch = 23        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Pipeline uses Timer to keep track of how long each event took. But we also need to be able to have an aggregate value that represents how much of runtime a certain event occupied. There is `timer.Sum()`but that gets reset after some number of events, depending on how often we flush to influxdb, it might mess with our metrics.

This is not the most ideal way of doing this, but I will try to fix it upstream first before making big changes here.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
