### PR TITLE
feat: reduce the number of samples in lifetimeTimer

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 25        // Patch version component of the current release
+	VersionPatch = 26        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/pipeline/pipeline.go
+++ b/rollup/pipeline/pipeline.go
@@ -33,7 +33,11 @@ var (
 	ErrApplyStageDone           = errors.New("apply stage is done")
 	ErrUnexpectedL1MessageIndex = errors.New("unexpected L1 message index")
 
-	lifetimeTimer   = metrics.NewRegisteredTimer("pipeline/lifetime", nil)
+	lifetimeTimer = func() metrics.Timer {
+		t := metrics.NewCustomTimer(metrics.NewHistogram(metrics.NewExpDecaySample(128, 0.015)), metrics.NewMeter())
+		metrics.DefaultRegistry.Register("pipeline/lifetime", t)
+		return t
+	}()
 	applyTimer      = metrics.NewRegisteredTimer("pipeline/apply", nil)
 	applyIdleTimer  = metrics.NewRegisteredTimer("pipeline/apply_idle", nil)
 	applyStallTimer = metrics.NewRegisteredTimer("pipeline/apply_stall", nil)


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Pipelines are spawned per block and lifetimeTimer keeps track of the total lifetime of each pipeline instance.

The default number of samples (1028) that lifetimeTimer keeps track of is too high for such an infrequent event, which makes p50,p90 etc values to take a long time to react to changes in the values that we track here.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
