### PR TITLE
fix: make sure building of pending blocks don't have any lasting sideaffects

### DIFF
--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -556,6 +556,14 @@ func (w *worker) startNewPipeline(timestamp int64) {
 }
 
 func (w *worker) handlePipelineResult(res *pipeline.Result) error {
+	if !w.isRunning() {
+		if res != nil && res.FinalBlock != nil {
+			w.updateSnapshot(res.FinalBlock)
+		}
+		w.currentPipeline = nil
+		return nil
+	}
+
 	if res != nil && res.OverflowingTx != nil {
 		if res.FinalBlock == nil {
 			// first txn overflowed the circuit, skip
@@ -600,14 +608,6 @@ func (w *worker) handlePipelineResult(res *pipeline.Result) error {
 			errors.Is(res.CCCErr, circuitcapacitychecker.ErrUnknown):
 			l2TxCccUnknownErrCounter.Inc(1)
 		}
-	}
-
-	if !w.isRunning() {
-		if res != nil && res.FinalBlock != nil {
-			w.updateSnapshot(res.FinalBlock)
-		}
-		w.currentPipeline = nil
-		return nil
 	}
 
 	var commitError error
@@ -747,6 +747,10 @@ func (w *worker) postSideBlock(event core.ChainSideEvent) {
 }
 
 func (w *worker) onTxFailingInPipeline(txIndex int, tx *types.Transaction, err error) bool {
+	if !w.isRunning() {
+		return false
+	}
+
 	writeTrace := func() {
 		var trace *types.BlockTrace
 		var errWithTrace *pipeline.ErrorWithTrace

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 24        // Patch version component of the current release
+	VersionPatch = 25        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

both `onTxFailingInPipeline` and `handlePipelineResult` modify the database in a persistent way. We should avoid writing anything to database due to a pending block we build in follower nodes. 


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
