### PR TITLE
fix: use correct encoding for L1 data fee of EIP2718 transactions

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -40,7 +40,6 @@ var (
 	ErrInvalidTxType        = errors.New("transaction type not valid in this context")
 	ErrTxTypeNotSupported   = errors.New("transaction type not supported")
 	ErrGasFeeCapTooLow      = errors.New("fee cap less than base fee")
-	errEmptyTypedTx         = errors.New("empty typed transaction bytes")
 	errShortTypedTx         = errors.New("typed transaction too short")
 	errInvalidYParity       = errors.New("'yParity' field must be 0 or 1")
 	errVYParityMismatch     = errors.New("'v' and 'yParity' fields do not match")

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -78,7 +78,7 @@ func TestDecodeEmptyTypedTx(t *testing.T) {
 	input := []byte{0x80}
 	var tx Transaction
 	err := rlp.DecodeBytes(input, &tx)
-	if err != errEmptyTypedTx {
+	if err != errShortTypedTx {
 		t.Fatal("wrong error:", err)
 	}
 }
@@ -94,11 +94,33 @@ func TestTransactionSigHash(t *testing.T) {
 }
 
 func TestTransactionEncode(t *testing.T) {
+	should := common.FromHex("f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3")
+
+	// EncodeToBytes
 	txb, err := rlp.EncodeToBytes(rightvrsTx)
 	if err != nil {
 		t.Fatalf("encode error: %v", err)
 	}
-	should := common.FromHex("f86103018207d094b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a8255441ca098ff921201554726367d2be8c804a7ff89ccf285ebc57dff8ae4c44b9c19ac4aa08887321be575c8095f789dd4c743dfe42c1820f9231f98a962b210e3ac2452a3")
+	if !bytes.Equal(txb, should) {
+		t.Errorf("encoded RLP mismatch, got %x", txb)
+	}
+
+	// tx.EncodeRLP
+	raw := new(bytes.Buffer)
+	err = rightvrsTx.EncodeRLP(raw)
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	txb = raw.Bytes()
+	if !bytes.Equal(txb, should) {
+		t.Errorf("encoded RLP mismatch, got %x", txb)
+	}
+
+	// tx.MarshalBinary
+	txb, err = rightvrsTx.MarshalBinary()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
 	if !bytes.Equal(txb, should) {
 		t.Errorf("encoded RLP mismatch, got %x", txb)
 	}
@@ -194,11 +216,23 @@ func TestEIP2930Signer(t *testing.T) {
 func TestEIP2718TransactionEncode(t *testing.T) {
 	// RLP representation
 	{
+		// rlp.EncodeToBytes
 		have, err := rlp.EncodeToBytes(signedEip2718Tx)
 		if err != nil {
 			t.Fatalf("encode error: %v", err)
 		}
 		want := common.FromHex("b86601f8630103018261a894b94f5374fce5edbc8e2a8697c15331677e6ebf0b0a825544c001a0c9519f4f2b30335884581971573fadf60c6204f59a911df35ee8a540456b2660a032f1e8e2c5dd761f9e4f88f41c8310aeaba26a8bfcdacfedfa12ec3862d37521")
+		if !bytes.Equal(have, want) {
+			t.Errorf("encoded RLP mismatch, got %x", have)
+		}
+
+		// tx.EncodeRLP
+		raw := new(bytes.Buffer)
+		err = signedEip2718Tx.EncodeRLP(raw)
+		if err != nil {
+			t.Fatalf("encode error: %v", err)
+		}
+		have = raw.Bytes()
 		if !bytes.Equal(have, want) {
 			t.Errorf("encoded RLP mismatch, got %x", have)
 		}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 33        // Patch version component of the current release
+	VersionPatch = 34        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -2,6 +2,7 @@ package fees
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 
 	"github.com/scroll-tech/go-ethereum/common"
@@ -40,7 +41,6 @@ type Message interface {
 // required to compute the L1 fee
 type StateDB interface {
 	GetState(common.Address, common.Hash) common.Hash
-	GetBalance(addr common.Address) *big.Int
 }
 
 type gpoState struct {
@@ -64,7 +64,7 @@ func EstimateL1DataFeeForMessage(msg Message, baseFee *big.Int, config *params.C
 		return nil, err
 	}
 
-	raw, err := rlpEncode(tx)
+	raw, err := tx.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}
@@ -131,16 +131,6 @@ func asUnsignedDynamicTx(msg Message, chainID *big.Int) *types.Transaction {
 		AccessList: msg.AccessList(),
 		ChainID:    chainID,
 	})
-}
-
-// rlpEncode RLP encodes the transaction into bytes
-func rlpEncode(tx *types.Transaction) ([]byte, error) {
-	raw := new(bytes.Buffer)
-	if err := tx.EncodeRLP(raw); err != nil {
-		return nil, err
-	}
-
-	return raw.Bytes(), nil
 }
 
 func readGPOStorageSlots(addr common.Address, state StateDB) gpoState {
@@ -216,7 +206,7 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB, config *params.Cha
 		return big.NewInt(0), nil
 	}
 
-	raw, err := rlpEncode(tx)
+	raw, err := tx.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +219,12 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB, config *params.Cha
 		l1DataFee = calculateEncodedL1DataFee(raw, gpoState.overhead, gpoState.l1BaseFee, gpoState.scalar)
 	} else {
 		l1DataFee = calculateEncodedL1DataFeeCurie(raw, gpoState.l1BaseFee, gpoState.l1BlobBaseFee, gpoState.commitScalar, gpoState.blobScalar)
+	}
+
+	// ensure l1DataFee fits into uint64 for circuit compatibility
+	// (note: in practice this value should never be this big)
+	if !l1DataFee.IsUint64() {
+		l1DataFee = new(big.Int).SetUint64(math.MaxUint64)
 	}
 
 	return l1DataFee, nil

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -224,7 +224,7 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB, config *params.Cha
 	// ensure l1DataFee fits into uint64 for circuit compatibility
 	// (note: in practice this value should never be this big)
 	if !l1DataFee.IsUint64() {
-		l1DataFee = new(big.Int).SetUint64(math.MaxUint64)
+		l1DataFee.SetUint64(math.MaxUint64)
 	}
 
 	return l1DataFee, nil


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

[EIP2718](https://eips.ethereum.org/EIPS/eip-2718) defines the byte encoding as `Type || Payload`, but `EncodeRLP ` returns an actual RLP array, i.e. it prepends the marshaled result with one or more bytes. We should use `MarshalBinary` instead. Note: The behavior of `EncodeRLP ` and `MarshalBinary` is identical for legacy transactions, so this is not a breaking change.

This PR also adds an upper bound on `L1DataFee` to ensure these values don't overflow in the tracing/circuit code. Technically, this is a breaking change, but in practice such high data fee values never occur on Scroll.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
