### PR TITLE
Chore: upgrade libzkp v0.10.6

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 3         // Minor version component of the current release
-	VersionPatch = 41        // Patch version component of the current release
+	VersionPatch = 42        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.lock
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "ark-std 0.3.0",
  "c-kzg",
@@ -521,7 +521,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -1139,7 +1139,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "base64 0.13.1",
  "ethers-core",
@@ -1293,7 +1293,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "eth-types",
  "halo2_proofs",
@@ -1507,7 +1507,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "env_logger 0.10.0",
  "gobuild",
@@ -1714,7 +1714,7 @@ dependencies = [
 [[package]]
 name = "halo2_proofs"
 version = "1.1.0"
-source = "git+https://github.com/scroll-tech/halo2.git?branch=v1.1#7179a60e4b4b1dafff084deac7b4bea235eecf5f"
+source = "git+https://github.com/scroll-tech/halo2.git?branch=v1.1#e5ddf67e5ae16be38d6368ed355c7c41906272ab"
 dependencies = [
  "ark-std 0.3.0",
  "blake2b_simd",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "env_logger 0.10.0",
  "eth-types",
@@ -2292,7 +2292,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "eth-types",
  "halo2-mpt-circuits",
@@ -2754,7 +2754,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "aggregator",
  "anyhow",
@@ -3605,7 +3605,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 [[package]]
 name = "snark-verifier"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#114cea6cd025f7daf66b8f0038126a796653e207"
+source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#58c46b74c73156b9e09dc27617369d2acfb4461b"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "snark-verifier-sdk"
 version = "0.0.1"
-source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#114cea6cd025f7daf66b8f0038126a796653e207"
+source = "git+https://github.com/scroll-tech/snark-verifier?branch=develop#58c46b74c73156b9e09dc27617369d2acfb4461b"
 dependencies = [
  "bincode",
  "ethereum-types",
@@ -4441,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.5#30ed394f24c73a8d1537805f30a43877f1096f4d"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.10.6#ef867ecb366e2d1b55a3755b2313d822fe3f33e0"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/rollup/circuitcapacitychecker/libzkp/Cargo.toml
+++ b/rollup/circuitcapacitychecker/libzkp/Cargo.toml
@@ -23,7 +23,7 @@ poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "main
 bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/impl_scalar_field" }
 
 [dependencies]
-prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.10.5", default-features = false, features = ["parallel_syn", "scroll", "shanghai", "strict-ccc"] }
+prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.10.6", default-features = false, features = ["parallel_syn", "scroll", "shanghai", "strict-ccc"] }
 
 anyhow = "1.0"
 base64 = "0.13.0"


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

At the time between signer curie hardfork and ccc upgraded to v0.11, this PR will reject txs with BASEFEE/TLOAD/TSTORE/MCOPY with err msg like 

```
assertion `left == right` failed left: None right: Some(InvalidOpcode(INVALID(92)))
```

to prevent any inconsistency between sequencer and ccc.

Details: original commit: https://github.com/scroll-tech/zkevm-circuits/pull/1256/commits/aabc96b1088d07680110ca0e5ca2e9ea0277830d#diff-1e6d053f6514ddc64497b6a584b3543a639730560b44b5fdf47a2c6b58b2ecd7R1626
When ccc thinks an opcode is invalid, it will require l2geth also treat the opcode as invalid.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
