### PR TITLE
ci: use go go-1.21 during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILDNUM=""
 ARG SCROLL_LIB_PATH=/scroll/lib
 
 # Build libzkp dependency
-FROM scrolltech/go-rust-builder:go-1.20-rust-nightly-2022-12-10 as chef
+FROM scrolltech/go-rust-builder:go-1.21-rust-nightly-2023-12-03 as chef
 WORKDIR app
 
 FROM chef as planner
@@ -23,7 +23,7 @@ RUN cargo build --release
 RUN find ./ | grep libzktrie.so | xargs -I{} cp {} /app/target/release/
 
 # Build Geth in a stock Go builder container
-FROM scrolltech/go-rust-builder:go-1.20-rust-nightly-2022-12-10 as builder
+FROM scrolltech/go-rust-builder:go-1.21-rust-nightly-2023-12-03 as builder
 
 ADD . /go-ethereum
 

--- a/Dockerfile.alltools
+++ b/Dockerfile.alltools
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.20-alpine as builder
+FROM golang:1.21-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 

--- a/Dockerfile.mockccc
+++ b/Dockerfile.mockccc
@@ -5,7 +5,7 @@ ARG BUILDNUM=""
 ARG SCROLL_LIB_PATH=/scroll/lib
 
 # Build Geth in a stock Go builder container
-FROM scrolltech/go-rust-builder:go-1.20-rust-nightly-2022-12-10 as builder
+FROM scrolltech/go-rust-builder:go-1.21-rust-nightly-2023-12-03 as builder
 
 ADD . /go-ethereum
 RUN cd /go-ethereum && env GO111MODULE=on go run build/ci.go install ./cmd/geth

--- a/Dockerfile.mockccc.alpine
+++ b/Dockerfile.mockccc.alpine
@@ -4,7 +4,7 @@ ARG VERSION=""
 ARG BUILDNUM=""
 
 # Build Geth in a stock Go builder container
-FROM golang:1.20-alpine as builder
+FROM golang:1.21-alpine as builder
 
 RUN apk add --no-cache gcc musl-dev linux-headers git
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Fix failing build after https://github.com/scroll-tech/go-ethereum/pull/816, since new ccc build assumes we use go 1.21.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
