### PR TITLE
fix load genesis

### DIFF
--- a/core/genesis.go
+++ b/core/genesis.go
@@ -316,7 +316,8 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, triedb *trie.Database, gen
 		// overwrite triedb IsUsingZktrie config to be safe
 		triedb.SetIsUsingZktrie(storedcfg.Scroll.ZktrieEnabled())
 	}
-	if header.Root != types.EmptyRootHash && !triedb.Initialized(header.Root) {
+	// if header.Root != types.EmptyRootHash && !triedb.Initialized(header.Hash()) {
+	if _, err := state.New(header.Root, state.NewDatabaseWithNodeDB(db, triedb), nil); err != nil {
 		if genesis == nil {
 			genesis = DefaultGenesisBlock()
 		}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -421,6 +421,12 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 		return params.SepoliaChainConfig
 	case ghash == params.GoerliGenesisHash:
 		return params.GoerliChainConfig
+	case ghash == params.ScrollAlphaGenesisHash:
+		return params.ScrollAlphaChainConfig
+	case ghash == params.ScrollSepoliaGenesisHash:
+		return params.ScrollSepoliaChainConfig
+	case ghash == params.ScrollMainnetGenesisHash:
+		return params.ScrollMainnetChainConfig
 	default:
 		return params.AllEthashProtocolChanges
 	}


### PR DESCRIPTION
change to use current `develop` behavior.
this is also what previous upstream uses.

haven't digged into the root cause, but this work and we won't commit the genesis each time we restart (which will cause overwriting `headBlock` and the node will re-build the chain in the memory using ancient blocks). 