### PR TITLE
fix(traces): deletion proof apply wrong storage value from structLogger

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 4         // Minor version component of the current release
-	VersionPatch = 4         // Patch version component of the current release
+	VersionPatch = 5         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/tracing/tracing.go
+++ b/rollup/tracing/tracing.go
@@ -428,10 +428,11 @@ func (env *TraceEnv) getTxResult(state *state.StateDB, index int, block *types.B
 		zktrieTracer := state.NewProofTracer(trie)
 		env.sMu.Unlock()
 
-		for key, values := range keys {
+		for key, _ := range keys {
 			addrStr := addr.String()
 			keyStr := key.String()
-			isDelete := bytes.Equal(values.Bytes(), common.Hash{}.Bytes())
+			value := state.GetState(addr, key)
+			isDelete := bytes.Equal(value.Bytes(), common.Hash{}.Bytes())
 
 			txm := txStorageTrace.StorageProofs[addrStr]
 			env.sMu.Lock()

--- a/rollup/tracing/tracing.go
+++ b/rollup/tracing/tracing.go
@@ -428,7 +428,7 @@ func (env *TraceEnv) getTxResult(state *state.StateDB, index int, block *types.B
 		zktrieTracer := state.NewProofTracer(trie)
 		env.sMu.Unlock()
 
-		for key, _ := range keys {
+		for key := range keys {
 			addrStr := addr.String()
 			keyStr := key.String()
 			value := state.GetState(addr, key)


### PR DESCRIPTION
While tracing a tx, the deletion proof module would pick all updated storage slots from the `UpdatedStorages` of structLogger. The map being returned is expected to contain all the slots and its `FINAL` value. If the final value is 0, module consider it is an deletion and add a addtion trace for building the deletion proof.

However, the `UpdatedStorages` only record the value from `SLOAD`/`SSTORE` op and in the case of revert, the recorded value is unmatch with the final value. This PR make the final value directly from statedb instead of the record, so it fix the issue.

This fixing can be safely being picked into older version for patching.

Has test the new l2trace generated for block `6689419` and there is no panic any more
