### PR TITLE
ci: add github action to replace import_path and release

### DIFF
--- a/.github/workflows/release-sdk.yaml
+++ b/.github/workflows/release-sdk.yaml
@@ -1,0 +1,45 @@
+name: Release SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      REV:
+        description: "revision. can be commit hash or tag"
+        required: true
+        type: string
+
+jobs:
+  release-sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Checkout revision
+        run: |
+          git checkout ${{ github.event.inputs.REV }}
+      - name: Replace import path
+        run: |
+          set -euo pipefail
+
+          # Define the old and new import paths
+          OLD_IMPORT_PATH="github.com/ethereum/go-ethereum"
+          NEW_IMPORT_PATH="github.com/scroll-tech/go-ethereum"
+
+          # List of file types to search through
+          FILE_TYPES=("*.go" "go.mod" "*.txt")
+
+          # Loop through each file type and replace the import path
+          for FILE_TYPE in "${FILE_TYPES[@]}"; do
+            find . -type f -name "$FILE_TYPE" -exec sed -i "s|$OLD_IMPORT_PATH|$NEW_IMPORT_PATH|g" {} +
+          done
+      - name: Commit the changes and push
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a
+        with:
+          skip_fetch: true
+          file_pattern: "*"
+          commit_message: "chore: replace import path [bot]"
+          create_branch: true
+          branch: ${{ github.event.inputs.REV }}-replace-import-path
+          tagging_message: sdk-${{ github.event.inputs.REV }}


### PR DESCRIPTION
Demo:
+ https://github.com/HAOYUatHZ/go-ethereum/actions/workflows/release-sdk.yaml
+ https://github.com/HAOYUatHZ/go-ethereum/branches
+ https://github.com/HAOYUatHZ/go-ethereum/tags
