### PR TITLE
fix: add missing CA certificates to Dockerfile.mockccc

### DIFF
--- a/Dockerfile.mockccc
+++ b/Dockerfile.mockccc
@@ -15,6 +15,9 @@ RUN cd /go-ethereum && env GO111MODULE=on go run build/ci.go install ./cmd/geth
 # Pull Geth into a second stage deploy alpine container
 FROM ubuntu:20.04
 
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends ca-certificates
+
 ENV CGO_LDFLAGS="-ldl"
 
 COPY --from=builder /go-ethereum/build/bin/geth /usr/local/bin/


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
Install ca-certificates as otherwise cert verification fails when connecting to L1 RPC when building the image with `make mockccc_docker`.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
