### PR TITLE
L1sload new design

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1193,7 +1193,7 @@ func (c *l1sload) Run(state StateDB, input []byte) ([]byte, error) {
 	address := common.BytesToAddress(input[0:20])
 	keys := make([]common.Hash, numStorageSlots)
 	for i := range keys {
-		keys[i] = common.BytesToHash(input[20 + 32*i : 52 + 32*i])
+		keys[i] = common.BytesToHash(input[20+32*i : 52+32*i])
 	}
 
 	res, err := c.l1Client.StoragesAt(context.Background(), address, keys, block)

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1193,7 +1193,7 @@ func (c *l1sload) Run(state StateDB, input []byte) ([]byte, error) {
 	address := common.BytesToAddress(input[0:20])
 	keys := make([]common.Hash, numStorageSlots)
 	for i := range keys {
-		keys[i] = common.BytesToHash(input[32*i-12 : 32*i+20])
+		keys[i] = common.BytesToHash(input[20 + 32*i : 52 + 32*i])
 	}
 
 	res, err := c.l1Client.StoragesAt(context.Background(), address, keys, block)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -29,7 +29,7 @@ import (
 
 // L1Client provides functionality provided by L1
 type L1Client interface {
-	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
+	StoragesAt(ctx context.Context, account common.Address, keys []common.Hash, blockNumber *big.Int) ([]byte, error)
 }
 
 // Config are the configuration options for the Interpreter

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -524,12 +524,12 @@ func (ec *Client) StoragesAt(ctx context.Context, account common.Address, keys [
 	if err := ec.c.BatchCallContext(ctx, reqs); err != nil {
 		return nil, err
 	}
-	output := make([]byte, 32 * len(keys))
+	output := make([]byte, 32*len(keys))
 	for i := range reqs {
 		if reqs[i].Error != nil {
 			return nil, reqs[i].Error
 		}
-		copy(output[i * 32:], results[i])
+		copy(output[i*32:], results[i])
 	}
 	return output, nil
 }

--- a/ethclient/ethclient_test.go
+++ b/ethclient/ethclient_test.go
@@ -617,6 +617,17 @@ func testAtFunctions(t *testing.T, client *rpc.Client) {
 	if !bytes.Equal(storage, penStorage) {
 		t.Fatalf("unexpected storage: %v %v", storage, penStorage)
 	}
+	// StoragesAt
+	storages, err := ec.StoragesAt(context.Background(), testAddr, []common.Hash{{}, {}}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(storages[0:32], penStorage) {
+		t.Fatalf("unexpected storage: %v %v", storages[0:32], penStorage)
+	}
+	if !bytes.Equal(storages[32:64], penStorage) {
+		t.Fatalf("unexpected storage: %v %v", storages[32:64], penStorage)
+	}
 	// CodeAt
 	code, err := ec.CodeAt(context.Background(), testAddr, nil)
 	if err != nil {

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -155,6 +155,9 @@ const (
 	Bls12381MapG1Gas          uint64 = 5500   // Gas price for BLS12-381 mapping field element to G1 operation
 	Bls12381MapG2Gas          uint64 = 110000 // Gas price for BLS12-381 mapping field element to G2 operation
 
+	L1SloadBaseGas    uint64 = 2000 // Base price for L1Sload
+	L1SloadPerLoadGas uint64 = 2000 // Per-load price for loading one storage slot
+
 	// The Refund Quotient is the cap on how much of the used gas can be refunded. Before EIP-3529,
 	// up to half the consumed gas could be refunded. Redefined as 1/5th in EIP-3529
 	RefundQuotient        uint64 = 2

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -168,6 +168,8 @@ const (
 	BlobTxBlobGaspriceUpdateFraction = 3338477 // Controls the maximum rate of change for blob gas price
 
 	BlobTxTargetBlobGasPerBlock = 3 * BlobTxBlobGasPerBlob // Target consumable blob gas for data blobs per block (for 1559-like pricing)
+
+	L1SloadMaxNumStorageSlots = 5 // Max number of storage slots requested in L1Sload precompile
 )
 
 // Gas discount table for BLS12-381 G1 and G2 multi exponentiation operations

--- a/rollup/rollup_sync_service/l1client_test.go
+++ b/rollup/rollup_sync_service/l1client_test.go
@@ -76,3 +76,7 @@ func (m *mockEthClient) BlockByHash(ctx context.Context, hash common.Hash) (*typ
 func (m *mockEthClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
 	return nil, nil
 }
+
+func (m *mockEthClient) StoragesAt(ctx context.Context, account common.Address, keys []common.Hash, blockNumber *big.Int) ([]byte, error) {
+	return nil, nil
+}

--- a/rollup/sync_service/types.go
+++ b/rollup/sync_service/types.go
@@ -20,4 +20,5 @@ type EthClient interface {
 	TransactionByHash(ctx context.Context, txHash common.Hash) (tx *types.Transaction, isPending bool, err error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 	StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error)
+	StoragesAt(ctx context.Context, account common.Address, keys []common.Hash, blockNumber *big.Int) ([]byte, error)
 }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Change behavior of l1sload precompile to new design

1. removed block number
2. allow multiple storage keys in a single call


To request multiple storage keys in a single call make batch RPC request


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
