### PR TITLE
fix(traces): deletion proof apply wrong storage value from structLogger

### DIFF
--- a/rollup/tracing/tracing.go
+++ b/rollup/tracing/tracing.go
@@ -420,10 +420,11 @@ func (env *TraceEnv) getTxResult(state *state.StateDB, index int, block *types.B
 		zktrieTracer := state.NewProofTracer(trie)
 		env.sMu.Unlock()
 
-		for key, values := range keys {
+		for key := range keys {
 			addrStr := addr.String()
 			keyStr := key.String()
-			isDelete := bytes.Equal(values.Bytes(), common.Hash{}.Bytes())
+			value := state.GetState(addr, key)
+			isDelete := bytes.Equal(value.Bytes(), common.Hash{}.Bytes())
 
 			txm := txStorageTrace.StorageProofs[addrStr]
 			env.sMu.Lock()


### PR DESCRIPTION
cherry pick [4e3bf2f](https://github.com/scroll-tech/go-ethereum/commit/4e3bf2f58ea0bea0bae37a2682d66372a3d38383)