### PR TITLE
fix(CI): remove libzktrie.so

### DIFF
--- a/.github/workflows/l2geth_ci.yml
+++ b/.github/workflows/l2geth_ci.yml
@@ -27,7 +27,6 @@ jobs:
       run: |
         make nccc_geth
   build-geth: # build geth with circuit capacity checker
-    if: github.event_name == 'push' # will only be triggered when pushing to main & staging & develop & alpha
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/.github/workflows/l2geth_ci.yml
+++ b/.github/workflows/l2geth_ci.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         make nccc_geth
   build-geth: # build geth with circuit capacity checker
+    if: github.event_name == 'push' # will only be triggered when pushing to main & staging & develop & alpha
     runs-on: ubuntu-latest
     steps:
     - name: Install Go

--- a/.github/workflows/l2geth_ci.yml
+++ b/.github/workflows/l2geth_ci.yml
@@ -46,7 +46,6 @@ jobs:
       run: |
         make libzkp
         sudo cp ./rollup/circuitcapacitychecker/libzkp/libzkp.so /usr/local/lib/
-        sudo cp ./rollup/circuitcapacitychecker/libzkp/libzktrie.so /usr/local/lib/
         make geth
   check:
     if: github.event.pull_request.draft == false


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

After v0.11.4, `libzktrie.so` is no longer a compiling output of `make libzkp`. geth building CI will get the following error when copying this file:
```
cp: cannot stat './rollup/circuitcapacitychecker/libzkp/libzktrie.so': No such file or directory
```

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
