### PR TITLE
fix(GPO): min suggested tip cap if there's congestion to avoid filtering through `DefaultIgnorePrice`

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -38,7 +38,7 @@ const sampleNumber = 3 // Number of transactions sampled in a block
 
 var (
 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
-	DefaultIgnorePrice = big.NewInt(2 * params.Wei)
+	DefaultIgnorePrice = big.NewInt(1 * params.Wei)
 	DefaultBasePrice   = big.NewInt(0)
 )
 
@@ -196,9 +196,10 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	if pendingTxCount < oracle.congestedThreshold {
 		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return 2 wei as the tip cap,
 		// as the base fee is set separately or added manually for legacy transactions.
-		// 1. Set price to 2 as otherwise tx with a 0 tip might be filtered out by the default mempool config.
-		// 2. Since oracle.ignoreprice is set to 2 (DefaultIgnorePrice) by default, we need to set the price to 2 to
-		//    avoid filtering in oracle.getBlockValues().
+		// 1. Set price to at least 1 as otherwise tx with a 0 tip might be filtered out by the default mempool config.
+		// 2. Since oracle.ignoreprice was set to 2 (DefaultIgnorePrice) before by default, we need to set the price
+		//    to 2 to avoid filtering in oracle.getBlockValues() by nodes that did not yet update to this version.
+		//    In the future we can set the price to 1 wei.
 		price := big.NewInt(2)
 		if !oracle.backend.ChainConfig().IsCurie(head.Number) {
 			price = oracle.defaultBasePrice

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -194,10 +194,12 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	// high-priced txs are causing the suggested tip cap to be high.
 	pendingTxCount, _ := oracle.backend.Stats()
 	if pendingTxCount < oracle.congestedThreshold {
-		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return 1 wei as the tip cap,
+		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return 2 wei as the tip cap,
 		// as the base fee is set separately or added manually for legacy transactions.
-		// Set price to 1 as otherwise tx with a 0 tip might be filtered out by the default mempool config.
-		price := big.NewInt(1)
+		// 1. Set price to 2 as otherwise tx with a 0 tip might be filtered out by the default mempool config.
+		// 2. Since oracle.ignoreprice is set to 2 (DefaultIgnorePrice) by default, we need to set the price to 2 to
+		//    avoid filtering in oracle.getBlockValues().
+		price := big.NewInt(2)
 		if !oracle.backend.ChainConfig().IsCurie(head.Number) {
 			price = oracle.defaultBasePrice
 		}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 3         // Patch version component of the current release
+	VersionPatch = 4         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 4         // Patch version component of the current release
+	VersionPatch = 5         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 6         // Patch version component of the current release
+	VersionPatch = 7         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
The gas price oracle uses a `oracle.ignorePrice` to filter out transactions below a certain price/tip. By default it is set to `DefaultIgnorePrice=2 wei`.

This is problematic as we return a gas price of `1 wei` if there's no congestion. This means that other nodes that did not configure with `--gpo.ignoreprice=1` nor `gpo.congestionthreshold` will always ignore these low prices and never adjust their price prediction down. 

By using `2 wei` as the default price if there's no congestion, other nodes that did not explicitly configure the GPO accordingly will also adjust their prices down without needing to upgrade to this version.

Additionally, we set `DefaultIgnorePrice=1 wei` so that in the future we can reduce to `1 wei` as the default price with no congestion.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
