### PR TITLE
feat(txpool): StatsWithMinBaseFee

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -510,8 +510,7 @@ func (pool *TxPool) StatsWithMinBaseFee(minBaseFee *big.Int) (int, int) {
 func (pool *TxPool) statsWithMinBaseFee(minBaseFee *big.Int) (int, int) {
 	pending := 0
 	for _, list := range pool.pending {
-		txs := list.Flatten()
-		for _, tx := range txs {
+		for _, tx := range list.txs.flatten() {
 			if _, err := tx.EffectiveGasTip(minBaseFee); err != nil {
 				break // basefee too low, discard rest of txs with higher nonces from the account
 			}
@@ -521,8 +520,7 @@ func (pool *TxPool) statsWithMinBaseFee(minBaseFee *big.Int) (int, int) {
 
 	queued := 0
 	for _, list := range pool.queue {
-		txs := list.Flatten()
-		for _, tx := range txs {
+		for _, tx := range list.txs.flatten() {
 			if _, err := tx.EffectiveGasTip(minBaseFee); err != nil {
 				break // basefee too low, discard rest of txs with higher nonces from the account
 			}

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -496,6 +496,42 @@ func (pool *TxPool) stats() (int, int) {
 	return pending, queued
 }
 
+// StatsWithMinBaseFee retrieves the current pool stats, namely the number of pending and the
+// number of queued (non-executable) transactions greater equal minBaseFee.
+func (pool *TxPool) StatsWithMinBaseFee(minBaseFee *big.Int) (int, int) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	return pool.statsWithMinBaseFee(minBaseFee)
+}
+
+// statsWithMinBaseFee retrieves the current pool stats, namely the number of pending and the
+// number of queued (non-executable) transactions greater equal minBaseFee.
+func (pool *TxPool) statsWithMinBaseFee(minBaseFee *big.Int) (int, int) {
+	pending := 0
+	for _, list := range pool.pending {
+		txs := list.Flatten()
+		for _, tx := range txs {
+			if _, err := tx.EffectiveGasTip(minBaseFee); err != nil {
+				break // basefee too low, discard rest of txs with higher nonces from the account
+			}
+			pending++
+		}
+	}
+
+	queued := 0
+	for _, list := range pool.queue {
+		txs := list.Flatten()
+		for _, tx := range txs {
+			if _, err := tx.EffectiveGasTip(minBaseFee); err != nil {
+				break // basefee too low, discard rest of txs with higher nonces from the account
+			}
+			queued++
+		}
+	}
+	return pending, queued
+}
+
 // Content retrieves the data content of the transaction pool, returning all the
 // pending as well as queued transactions, grouped by account and sorted by nonce.
 func (pool *TxPool) Content() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -292,6 +292,10 @@ func (b *EthAPIBackend) Stats() (pending int, queued int) {
 	return b.eth.txPool.Stats()
 }
 
+func (b *EthAPIBackend) StatsWithMinBaseFee(minBaseFee *big.Int) (pending int, queued int) {
+	return b.eth.txPool.StatsWithMinBaseFee(minBaseFee)
+}
+
 func (b *EthAPIBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
 	return b.eth.TxPool().Content()
 }

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -64,6 +64,7 @@ type OracleBackend interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	StateAt(root common.Hash) (*state.StateDB, error)
 	Stats() (pending int, queued int)
+	StatsWithMinBaseFee(minBaseFee *big.Int) (pending int, queued int)
 }
 
 // Oracle recommends gas prices based on the content of recent
@@ -192,7 +193,7 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	// If pending txs are less than oracle.congestedThreshold, we consider the network to be non-congested and suggest
 	// a minimal tip cap. This is to prevent users from overpaying for gas when the network is not congested and a few
 	// high-priced txs are causing the suggested tip cap to be high.
-	pendingTxCount, _ := oracle.backend.Stats()
+	pendingTxCount, _ := oracle.backend.StatsWithMinBaseFee(head.BaseFee)
 	if pendingTxCount < oracle.congestedThreshold {
 		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return 1 wei as the tip cap,
 		// as the base fee is set separately or added manually for legacy transactions.

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -101,6 +101,10 @@ func (b *testBackend) Stats() (int, int) {
 	return b.pendingTxCount, 0
 }
 
+func (b *testBackend) StatsWithMinBaseFee(minBaseFee *big.Int) (int, int) {
+	return b.pendingTxCount, 0
+}
+
 func newTestBackend(t *testing.T, londonBlock *big.Int, pending bool, pendingTxCount int) *testBackend {
 	var (
 		key, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -225,6 +225,10 @@ func (b *LesApiBackend) Stats() (pending int, queued int) {
 	return b.eth.txPool.Stats(), 0
 }
 
+func (b *LesApiBackend) StatsWithMinBaseFee(minBaseFee *big.Int) (pending int, queued int) {
+	return b.eth.txPool.StatsWithMinBaseFee(minBaseFee), 0
+}
+
 func (b *LesApiBackend) TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions) {
 	return b.eth.txPool.Content()
 }

--- a/light/txpool.go
+++ b/light/txpool.go
@@ -353,6 +353,20 @@ func (pool *TxPool) Stats() (pending int) {
 	return
 }
 
+// StatsWithMinBaseFee returns the number of currently pending (locally created) transactions and ignores the base fee.
+func (pool *TxPool) StatsWithMinBaseFee(minBaseFee *big.Int) (pending int) {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	for _, tx := range pool.pending {
+		if _, err := tx.EffectiveGasTip(minBaseFee); err == nil {
+			pending++
+		}
+	}
+
+	return pending
+}
+
 // validateTx checks whether a transaction is valid according to the consensus rules.
 func (pool *TxPool) validateTx(ctx context.Context, tx *types.Transaction) error {
 	// Validate sender

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 7         // Patch version component of the current release
+	VersionPatch = 8         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
When the base fee changes, transactions which are now below the base fee, stay in the txpool as `pending`. However, since we use the amount of `pending` tx in the GPO to determine the current congestion level of the network, this wouldn't yield any meaningful information anymore. 

This PR, therefore, introduces a function `StatsWithMinBaseFee` to the txpool so that the GPO can query the `pending` transactions that are meaningful right now.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
