### PR TITLE
feat(txpool): use GasFeeCapIntCmp to check min fee

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -682,7 +682,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrInvalidSender
 	}
 	// Drop non-local transactions under our own minimal accepted gas price or tip.
-	if !local && tx.GasTipCapIntCmp(pool.gasPrice) < 0 {
+	if !local && tx.GasFeeCapIntCmp(pool.gasPrice) < 0 {
 		return ErrUnderpriced
 	}
 	// Ensure the transaction adheres to nonce ordering

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -1534,7 +1534,7 @@ func TestTransactionPoolRepricingDynamicFee(t *testing.T) {
 	if err := pool.AddRemote(tx); err != ErrUnderpriced {
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}
-	tx = dynamicFeeTx(0, 100000, big.NewInt(2), big.NewInt(1), keys[1])
+	tx = dynamicFeeTx(0, 100000, big.NewInt(1), big.NewInt(1), keys[1])
 	if err := pool.AddRemote(tx); err != ErrUnderpriced {
 		t.Fatalf("adding underpriced pending transaction error mismatch: have %v, want %v", err, ErrUnderpriced)
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 9         // Patch version component of the current release
+	VersionPatch = 10        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Assuming we set `L2GETH_MIN_GAS_PRICE` to `48700001` (min base fee + 1), we can now accept transactions with 1 wei tip.

Previously, `L2GETH_MIN_GAS_PRICE = 48700001` would have set the minimum tip, but `L2GETH_MIN_GAS_PRICE = 1` would have allowed unexecutable legacy txs with 1 wei gas price to enter the txpool.

A motivating example with `L2GETH_MIN_GAS_PRICE = 48700001` and `baseFee = 48700000`:

|                                            | `effectiveGasTipCapCmp` | `gasTipCapCmp` | `gasFeeCapCmp` |
| ------------------------------------------ | ----------------------- | -------------- | -------------- |
| legacy `gasPrice = 1`                      | reject                  | reject         | reject         |
| legacy `gasPrice=48700001`                 | reject **(1)**          | accept         | accept         |
| 1559 `gasFeeCap = 48700001, gasTipCap = 1` | reject                  | reject **(2)** | accept         |

The previous PR (https://github.com/scroll-tech/go-ethereum/pull/825) fixed (1), while this PR aims to fix (2). 

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
