### PR TITLE
fix(l2geth-verifier): only check last batch of the bundle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
-	github.com/scroll-tech/da-codec v0.1.1-0.20240703091800-5b6cded48ab7
+	github.com/scroll-tech/da-codec v0.1.1-0.20240716101216-c55ed9455cf4
 	github.com/scroll-tech/zktrie v0.8.4
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scroll-tech/da-codec v0.1.1-0.20240703091800-5b6cded48ab7 h1:UfiLBLCAMBk9bsTP3fc1fETpNVFSQapQVdLcZveyV0M=
-github.com/scroll-tech/da-codec v0.1.1-0.20240703091800-5b6cded48ab7/go.mod h1:D6XEESeNVJkQJlv3eK+FyR+ufPkgVQbJzERylQi53Bs=
+github.com/scroll-tech/da-codec v0.1.1-0.20240716101216-c55ed9455cf4 h1:40Lby3huKNFZ2EXzxqVpADB+caepDRrNRoUgTsCKN88=
+github.com/scroll-tech/da-codec v0.1.1-0.20240716101216-c55ed9455cf4/go.mod h1:D6XEESeNVJkQJlv3eK+FyR+ufPkgVQbJzERylQi53Bs=
 github.com/scroll-tech/zktrie v0.8.4 h1:UagmnZ4Z3ITCk+aUq9NQZJNAwnWl4gSxsLb2Nl7IgRE=
 github.com/scroll-tech/zktrie v0.8.4/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 12        // Patch version component of the current release
+	VersionPatch = 13        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -445,23 +445,34 @@ func (s *RollupSyncService) decodeChunkBlockRanges(txData []byte) ([]*rawdb.Chun
 // Note: This function is compatible with both "finalize by batch" and "finalize by bundle" methods.
 // In "finalize by bundle", only the last batch of each bundle is fully verified.
 func validateBatch(event *L1FinalizeBatchEvent, parentBatchMeta *rawdb.FinalizedBatchMeta, chunks []*encoding.Chunk, chainCfg *params.ChainConfig, stack *node.Node, lastBatch bool) (uint64, *rawdb.FinalizedBatchMeta, error) {
+	log.Info("Starting validateBatch", "batchIndex", event.BatchIndex.Uint64(), "lastBatch", lastBatch)
+
 	if len(chunks) == 0 {
+		log.Error("Invalid argument: length of chunks is 0", "batchIndex", event.BatchIndex.Uint64())
 		return 0, nil, fmt.Errorf("invalid argument: length of chunks is 0, batch index: %v", event.BatchIndex.Uint64())
 	}
 
 	startChunk := chunks[0]
 	if len(startChunk.Blocks) == 0 {
+		log.Error("Invalid argument: block count of start chunk is 0", "batchIndex", event.BatchIndex.Uint64())
 		return 0, nil, fmt.Errorf("invalid argument: block count of start chunk is 0, batch index: %v", event.BatchIndex.Uint64())
 	}
 	startBlock := startChunk.Blocks[0]
 
 	endChunk := chunks[len(chunks)-1]
 	if len(endChunk.Blocks) == 0 {
+		log.Error("Invalid argument: block count of end chunk is 0", "batchIndex", event.BatchIndex.Uint64())
 		return 0, nil, fmt.Errorf("invalid argument: block count of end chunk is 0, batch index: %v", event.BatchIndex.Uint64())
 	}
 	endBlock := endChunk.Blocks[len(endChunk.Blocks)-1]
 
-	// Note: All params of batch are calculated locally based on the block data.
+	log.Info("Batch details",
+		"batchIndex", event.BatchIndex.Uint64(),
+		"startBlockNumber", startBlock.Header.Number.Uint64(),
+		"endBlockNumber", endBlock.Header.Number.Uint64(),
+		"parentBatchHash", parentBatchMeta.BatchHash.Hex(),
+		"parentTotalL1MessagePopped", parentBatchMeta.TotalL1MessagePopped)
+
 	batch := &encoding.Batch{
 		Index:                      event.BatchIndex.Uint64(),
 		TotalL1MessagePoppedBefore: parentBatchMeta.TotalL1MessagePopped,
@@ -470,79 +481,129 @@ func validateBatch(event *L1FinalizeBatchEvent, parentBatchMeta *rawdb.Finalized
 	}
 
 	var localBatchHash common.Hash
-	if startBlock.Header.Number.Uint64() == 0 || !chainCfg.IsBernoulli(startBlock.Header.Number) { // codecv0: genesis batch or batches before Bernoulli
+	var codecVersion string
+
+	if startBlock.Header.Number.Uint64() == 0 || !chainCfg.IsBernoulli(startBlock.Header.Number) {
+		codecVersion = "codecv0"
 		daBatch, err := codecv0.NewDABatch(batch)
 		if err != nil {
+			log.Error("Failed to create codecv0 DA batch", "batchIndex", event.BatchIndex.Uint64(), "error", err)
 			return 0, nil, fmt.Errorf("failed to create codecv0 DA batch, batch index: %v, err: %w", event.BatchIndex.Uint64(), err)
 		}
 		localBatchHash = daBatch.Hash()
-	} else if !chainCfg.IsCurie(startBlock.Header.Number) { // codecv1: batches after Bernoulli and before Curie
+	} else if !chainCfg.IsCurie(startBlock.Header.Number) {
+		codecVersion = "codecv1"
 		daBatch, err := codecv1.NewDABatch(batch)
 		if err != nil {
+			log.Error("Failed to create codecv1 DA batch", "batchIndex", event.BatchIndex.Uint64(), "error", err)
 			return 0, nil, fmt.Errorf("failed to create codecv1 DA batch, batch index: %v, err: %w", event.BatchIndex.Uint64(), err)
 		}
 		localBatchHash = daBatch.Hash()
-	} else if !chainCfg.IsDarwin(startBlock.Header.Time) { // codecv2: batches after Curie and before Darwin
+	} else if !chainCfg.IsDarwin(startBlock.Header.Time) {
+		codecVersion = "codecv2"
 		daBatch, err := codecv2.NewDABatch(batch)
 		if err != nil {
+			log.Error("Failed to create codecv2 DA batch", "batchIndex", event.BatchIndex.Uint64(), "error", err)
 			return 0, nil, fmt.Errorf("failed to create codecv2 DA batch, batch index: %v, err: %w", event.BatchIndex.Uint64(), err)
 		}
 		localBatchHash = daBatch.Hash()
-	} else { // codecv3: batches after Darwin
+	} else {
+		codecVersion = "codecv3"
 		daBatch, err := codecv3.NewDABatch(batch)
 		if err != nil {
+			log.Error("Failed to create codecv3 DA batch", "batchIndex", event.BatchIndex.Uint64(), "error", err)
 			return 0, nil, fmt.Errorf("failed to create codecv3 DA batch, batch index: %v, err: %w", event.BatchIndex.Uint64(), err)
 		}
 		localBatchHash = daBatch.Hash()
 	}
 
+	log.Info("Batch hash calculated",
+		"batchIndex", event.BatchIndex.Uint64(),
+		"codecVersion", codecVersion,
+		"localBatchHash", localBatchHash.Hex())
+
 	localStateRoot := endBlock.Header.Root
 	localWithdrawRoot := endBlock.WithdrawRoot
 
-	// Note: If the state root, withdraw root, and batch headers match, this ensures the consistency of blocks and transactions
-	// (including skipped transactions) between L1 and L2.
-	//
-	// Only check when it's the last batch. This is compatible with both "finalize by batch" and "finalize by bundle":
-	// - finalize by batch: check all batches
-	// - finalize by bundle: check the last batch, because only one event (containing the info of the last batch) is emitted per bundle
+	log.Info("Local roots calculated",
+		"batchIndex", event.BatchIndex.Uint64(),
+		"localStateRoot", localStateRoot.Hex(),
+		"localWithdrawRoot", localWithdrawRoot.Hex())
+
 	if lastBatch {
+		log.Info("Verifying last batch", "batchIndex", event.BatchIndex.Uint64())
+
 		if localStateRoot != event.StateRoot {
-			log.Error("State root mismatch", "batch index", event.BatchIndex.Uint64(), "start block", startBlock.Header.Number.Uint64(), "end block", endBlock.Header.Number.Uint64(), "parent batch hash", parentBatchMeta.BatchHash.Hex(), "l1 finalized state root", event.StateRoot.Hex(), "l2 state root", localStateRoot.Hex())
+			log.Error("State root mismatch",
+				"batchIndex", event.BatchIndex.Uint64(),
+				"startBlock", startBlock.Header.Number.Uint64(),
+				"endBlock", endBlock.Header.Number.Uint64(),
+				"parentBatchHash", parentBatchMeta.BatchHash.Hex(),
+				"l1FinalizedStateRoot", event.StateRoot.Hex(),
+				"l2StateRoot", localStateRoot.Hex())
 			stack.Close()
 			os.Exit(1)
 		}
 
 		if localWithdrawRoot != event.WithdrawRoot {
-			log.Error("Withdraw root mismatch", "batch index", event.BatchIndex.Uint64(), "start block", startBlock.Header.Number.Uint64(), "end block", endBlock.Header.Number.Uint64(), "parent batch hash", parentBatchMeta.BatchHash.Hex(), "l1 finalized withdraw root", event.WithdrawRoot.Hex(), "l2 withdraw root", localWithdrawRoot.Hex())
+			log.Error("Withdraw root mismatch",
+				"batchIndex", event.BatchIndex.Uint64(),
+				"startBlock", startBlock.Header.Number.Uint64(),
+				"endBlock", endBlock.Header.Number.Uint64(),
+				"parentBatchHash", parentBatchMeta.BatchHash.Hex(),
+				"l1FinalizedWithdrawRoot", event.WithdrawRoot.Hex(),
+				"l2WithdrawRoot", localWithdrawRoot.Hex())
 			stack.Close()
 			os.Exit(1)
 		}
 
-		// Verify batch hash
-		// This check ensures the correctness of all batch hashes in the bundle
-		// due to the parent-child relationship between batch hashes
 		if localBatchHash != event.BatchHash {
-			log.Error("Batch hash mismatch", "batch index", event.BatchIndex.Uint64(), "start block", startBlock.Header.Number.Uint64(), "end block", endBlock.Header.Number.Uint64(), "parent batch hash", parentBatchMeta.BatchHash.Hex(), "parent TotalL1MessagePopped", parentBatchMeta.TotalL1MessagePopped, "l1 finalized batch hash", event.BatchHash.Hex(), "l2 batch hash", localBatchHash.Hex())
+			log.Error("Batch hash mismatch",
+				"batchIndex", event.BatchIndex.Uint64(),
+				"startBlock", startBlock.Header.Number.Uint64(),
+				"endBlock", endBlock.Header.Number.Uint64(),
+				"parentBatchHash", parentBatchMeta.BatchHash.Hex(),
+				"parentTotalL1MessagePopped", parentBatchMeta.TotalL1MessagePopped,
+				"l1FinalizedBatchHash", event.BatchHash.Hex(),
+				"l2BatchHash", localBatchHash.Hex())
 			chunksJson, err := json.Marshal(chunks)
 			if err != nil {
-				log.Error("marshal chunks failed", "err", err)
+				log.Error("Marshal chunks failed", "error", err)
 			}
 			log.Error("Chunks", "chunks", string(chunksJson))
 			stack.Close()
 			os.Exit(1)
 		}
+
+		log.Info("Last batch verified successfully", "batchIndex", event.BatchIndex.Uint64())
 	}
 
 	totalL1MessagePopped := parentBatchMeta.TotalL1MessagePopped
-	for _, chunk := range chunks {
-		totalL1MessagePopped += chunk.NumL1Messages(totalL1MessagePopped)
+	for i, chunk := range chunks {
+		chunkL1Messages := chunk.NumL1Messages(totalL1MessagePopped)
+		totalL1MessagePopped += chunkL1Messages
+		log.Info("Chunk L1 messages",
+			"batchIndex", event.BatchIndex.Uint64(),
+			"chunkIndex", i,
+			"chunkL1Messages", chunkL1Messages,
+			"totalL1MessagePopped", totalL1MessagePopped)
 	}
+
 	finalizedBatchMeta := &rawdb.FinalizedBatchMeta{
 		BatchHash:            localBatchHash,
 		TotalL1MessagePopped: totalL1MessagePopped,
 		StateRoot:            localStateRoot,
 		WithdrawRoot:         localWithdrawRoot,
 	}
+
+	log.Info("Batch validation completed",
+		"batchIndex", event.BatchIndex.Uint64(),
+		"endBlockNumber", endBlock.Header.Number.Uint64(),
+		"finalBatchHash", finalizedBatchMeta.BatchHash.Hex(),
+		"finalTotalL1MessagePopped", finalizedBatchMeta.TotalL1MessagePopped,
+		"finalStateRoot", finalizedBatchMeta.StateRoot.Hex(),
+		"finalWithdrawRoot", finalizedBatchMeta.WithdrawRoot.Hex())
+
 	return endBlock.Header.Number.Uint64(), finalizedBatchMeta, nil
 }
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -422,10 +422,10 @@ func (s *RollupSyncService) decodeChunkBlockRanges(txData []byte) ([]*rawdb.Chun
 	return nil, fmt.Errorf("unexpected method name: %v", method.Name)
 }
 
-// validateBatch verifies the consistency between L1 contract and L2 node data.
+// validateBatch verifies the consistency between the L1 contract and L2 node data.
 // It performs the following checks:
 // 1. Recalculates the batch hash locally
-// 2. Compares local state root, withdraw root, and batch hash with L1 data (for the last batch only when "finalize by bundle")
+// 2. Compares local state root, local withdraw root, and locally calculated batch hash with L1 data (for the last batch only when "finalize by bundle")
 //
 // The function will terminate the node and exit if any consistency check fails.
 //
@@ -444,6 +444,7 @@ func (s *RollupSyncService) decodeChunkBlockRanges(txData []byte) ([]*rawdb.Chun
 //
 // Note: This function is compatible with both "finalize by batch" and "finalize by bundle" methods.
 // In "finalize by bundle", only the last batch of each bundle is fully verified.
+// This check still ensures the correctness of all batch hashes in the bundle due to the parent-child relationship between batch hashes.
 func validateBatch(batchIndex uint64, event *L1FinalizeBatchEvent, parentBatchMeta *rawdb.FinalizedBatchMeta, chunks []*encoding.Chunk, chainCfg *params.ChainConfig, stack *node.Node) (uint64, *rawdb.FinalizedBatchMeta, error) {
 	if len(chunks) == 0 {
 		return 0, nil, fmt.Errorf("invalid argument: length of chunks is 0, batch index: %v", batchIndex)

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -263,7 +263,9 @@ func (s *RollupSyncService) parseAndUpdateRollupEventLogs(logs []types.Log, endB
 			}
 
 			if err := batchWriter.Write(); err != nil {
-				log.Crit("Failed to write finalized batch meta to database", "err", err)
+				log.Error("fatal: failed to batch write finalized batch meta to database", "startBatchIndex", startBatchIndex, "endBatchIndex", batchIndex,
+					"batchCount", batchIndex-startBatchIndex+1, "highestFinalizedBlockNumber", highestFinalizedBlockNumber, "err", err)
+				return fmt.Errorf("failed to batch write finalized batch meta to database: %w", err)
 			}
 			rawdb.WriteFinalizedL2BlockNumber(s.db, highestFinalizedBlockNumber)
 			rawdb.WriteLastFinalizedBatchIndex(s.db, batchIndex)

--- a/rollup/rollup_sync_service/rollup_sync_service_test.go
+++ b/rollup/rollup_sync_service/rollup_sync_service_test.go
@@ -552,7 +552,7 @@ func TestValidateBatchCodecv0(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1.BatchIndex.Uint64(), event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -572,7 +572,7 @@ func TestValidateBatchCodecv0(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2.BatchIndex.Uint64(), event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -605,7 +605,7 @@ func TestValidateBatchCodecv1(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1.BatchIndex.Uint64(), event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -625,7 +625,7 @@ func TestValidateBatchCodecv1(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2.BatchIndex.Uint64(), event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -658,7 +658,7 @@ func TestValidateBatchCodecv2(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1.BatchIndex.Uint64(), event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -678,7 +678,7 @@ func TestValidateBatchCodecv2(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2.BatchIndex.Uint64(), event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -711,7 +711,7 @@ func TestValidateBatchCodecv3(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1.BatchIndex.Uint64(), event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -731,7 +731,7 @@ func TestValidateBatchCodecv3(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2.BatchIndex.Uint64(), event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -758,7 +758,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		WithdrawRoot: chunk1.Blocks[len(chunk1.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1}, chainConfig, nil, true)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1.BatchIndex.Uint64(), event1, parentBatchMeta1, []*encoding.Chunk{chunk1}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(2), endBlock1)
 
@@ -778,7 +778,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		StateRoot:    chunk2.Blocks[len(chunk2.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk2.Blocks[len(chunk2.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk2}, chainConfig, nil, true)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2.BatchIndex.Uint64(), event2, parentBatchMeta2, []*encoding.Chunk{chunk2}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(3), endBlock2)
 
@@ -798,7 +798,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		StateRoot:    chunk3.Blocks[len(chunk3.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
-	endBlock3, finalizedBatchMeta3, err := validateBatch(event3, parentBatchMeta3, []*encoding.Chunk{chunk3}, chainConfig, nil, true)
+	endBlock3, finalizedBatchMeta3, err := validateBatch(event3.BatchIndex.Uint64(), event3, parentBatchMeta3, []*encoding.Chunk{chunk3}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock3)
 
@@ -818,7 +818,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock4, finalizedBatchMeta4, err := validateBatch(event4, parentBatchMeta4, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
+	endBlock4, finalizedBatchMeta4, err := validateBatch(event4.BatchIndex.Uint64(), event4, parentBatchMeta4, []*encoding.Chunk{chunk4}, chainConfig, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock4)
 

--- a/rollup/rollup_sync_service/rollup_sync_service_test.go
+++ b/rollup/rollup_sync_service/rollup_sync_service_test.go
@@ -552,7 +552,7 @@ func TestValidateBatchCodecv0(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -572,7 +572,7 @@ func TestValidateBatchCodecv0(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -605,7 +605,7 @@ func TestValidateBatchCodecv1(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -625,7 +625,7 @@ func TestValidateBatchCodecv1(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -658,7 +658,7 @@ func TestValidateBatchCodecv2(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -678,7 +678,7 @@ func TestValidateBatchCodecv2(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -711,7 +711,7 @@ func TestValidateBatchCodecv3(t *testing.T) {
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1, chunk2, chunk3}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock1)
 
@@ -731,7 +731,7 @@ func TestValidateBatchCodecv3(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock2)
 
@@ -758,7 +758,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		WithdrawRoot: chunk1.Blocks[len(chunk1.Blocks)-1].WithdrawRoot,
 	}
 
-	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1}, chainConfig, nil)
+	endBlock1, finalizedBatchMeta1, err := validateBatch(event1, parentBatchMeta1, []*encoding.Chunk{chunk1}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(2), endBlock1)
 
@@ -778,7 +778,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		StateRoot:    chunk2.Blocks[len(chunk2.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk2.Blocks[len(chunk2.Blocks)-1].WithdrawRoot,
 	}
-	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk2}, chainConfig, nil)
+	endBlock2, finalizedBatchMeta2, err := validateBatch(event2, parentBatchMeta2, []*encoding.Chunk{chunk2}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(3), endBlock2)
 
@@ -798,7 +798,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		StateRoot:    chunk3.Blocks[len(chunk3.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk3.Blocks[len(chunk3.Blocks)-1].WithdrawRoot,
 	}
-	endBlock3, finalizedBatchMeta3, err := validateBatch(event3, parentBatchMeta3, []*encoding.Chunk{chunk3}, chainConfig, nil)
+	endBlock3, finalizedBatchMeta3, err := validateBatch(event3, parentBatchMeta3, []*encoding.Chunk{chunk3}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(13), endBlock3)
 
@@ -818,7 +818,7 @@ func TestValidateBatchUpgrades(t *testing.T) {
 		StateRoot:    chunk4.Blocks[len(chunk4.Blocks)-1].Header.Root,
 		WithdrawRoot: chunk4.Blocks[len(chunk4.Blocks)-1].WithdrawRoot,
 	}
-	endBlock4, finalizedBatchMeta4, err := validateBatch(event4, parentBatchMeta4, []*encoding.Chunk{chunk4}, chainConfig, nil)
+	endBlock4, finalizedBatchMeta4, err := validateBatch(event4, parentBatchMeta4, []*encoding.Chunk{chunk4}, chainConfig, nil, true)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(17), endBlock4)
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

In "finalize by bundle", only the last batch of each bundle is fully verified. This check still ensures the correctness of all batch hashes in the bundle due to the parent-child relationship between batch hashes.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
