### PR TITLE
fix(verifier): nil panic due to batch write

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
-	github.com/scroll-tech/da-codec v0.1.1-0.20240716101216-c55ed9455cf4
+	github.com/scroll-tech/da-codec v0.1.1-0.20240718144756-1875fd490923
 	github.com/scroll-tech/zktrie v0.8.4
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4

--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scroll-tech/da-codec v0.1.1-0.20240716101216-c55ed9455cf4 h1:40Lby3huKNFZ2EXzxqVpADB+caepDRrNRoUgTsCKN88=
-github.com/scroll-tech/da-codec v0.1.1-0.20240716101216-c55ed9455cf4/go.mod h1:D6XEESeNVJkQJlv3eK+FyR+ufPkgVQbJzERylQi53Bs=
+github.com/scroll-tech/da-codec v0.1.1-0.20240718144756-1875fd490923 h1:A1ItzpnFDCHMh4g6cpeBZf7/fPf2lfwHbhjr/FSpk2w=
+github.com/scroll-tech/da-codec v0.1.1-0.20240718144756-1875fd490923/go.mod h1:D6XEESeNVJkQJlv3eK+FyR+ufPkgVQbJzERylQi53Bs=
 github.com/scroll-tech/zktrie v0.8.4 h1:UagmnZ4Z3ITCk+aUq9NQZJNAwnWl4gSxsLb2Nl7IgRE=
 github.com/scroll-tech/zktrie v0.8.4/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 13        // Patch version component of the current release
+	VersionPatch = 14        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

1. fix panic issues.
2. update da-codec dependency to the latest version in `main` branch.
```
2024-07-18 19:28:46 panic: runtime error: invalid memory address or nil pointer dereference
2024-07-18 19:28:46 [signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xcdbc31]
2024-07-18 19:28:46 
2024-07-18 19:28:46 goroutine 116 [running]:
2024-07-18 19:28:46 github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service.validateBatch(0xc0001f26e0?, 0x4?, 0x3?, {0xc003852c00?, 0x2d?, 0x2d?}, 0xc0001b8400?, 0x40?)
2024-07-18 19:28:46     github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service/rollup_sync_service.go:473 +0x91
2024-07-18 19:28:46 github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service.(*RollupSyncService).parseAndUpdateRollupEventLogs(0xc0001f26e0, {0xc006a60840?, 0x2, 0x5?}, 0xc003627e38?)
2024-07-18 19:28:46     github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service/rollup_sync_service.go:252 +0xc88
2024-07-18 19:28:46 github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service.(*RollupSyncService).fetchRollupEvents(0xc0001f26e0)
2024-07-18 19:28:46     github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service/rollup_sync_service.go:185 +0x249
2024-07-18 19:28:46 github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service.(*RollupSyncService).Start.func1()
2024-07-18 19:28:46     github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service/rollup_sync_service.go:138 +0x145
2024-07-18 19:28:46 created by github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service.(*RollupSyncService).Start in goroutine 1
2024-07-18 19:28:46     github.com/scroll-tech/go-ethereum/rollup/rollup_sync_service/rollup_sync_service.go:126 +0xcb
```

this pr is tested by local testnet.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
