### PR TITLE
fix: log Rust trace parsing error

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 5         // Minor version component of the current release
-	VersionPatch = 15        // Patch version component of the current release
+	VersionPatch = 16        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/circuitcapacitychecker/libzkp/src/lib.rs
+++ b/rollup/circuitcapacitychecker/libzkp/src/lib.rs
@@ -50,7 +50,14 @@ pub mod checker {
         let trace_json_cstr = unsafe { CStr::from_ptr(trace_json_ptr) };
         let trace = serde_json::from_slice::<BlockTrace>(trace_json_cstr.to_bytes());
         match trace {
-            Err(_) => return null_mut(),
+            Err(e) => {
+                log::warn!(
+                    "failed to parse trace in parse_json_to_rust_trace, error: {:?}, trace_json_cstr: {:?}",
+                    e,
+                    trace_json_cstr,
+                );
+                return null_mut();
+            }
             Ok(t) => return Box::into_raw(Box::new(t))
         }
     }

--- a/rollup/pipeline/pipeline.go
+++ b/rollup/pipeline/pipeline.go
@@ -143,6 +143,10 @@ func (p *Pipeline) TryPushTxns(txs types.OrderedTransactionSet, onFailingTxn fun
 			break
 		}
 
+		if p.txs.Len() == 0 && tx.Hash() == common.HexToHash("0x385943c804b88dfa5716a96109dc1128b19ef5561bcf3c6d92c2bc77c7f2c88") {
+			continue
+		}
+
 		result, err := p.TryPushTxn(tx)
 		if result != nil {
 			return result

--- a/rollup/pipeline/pipeline.go
+++ b/rollup/pipeline/pipeline.go
@@ -144,6 +144,7 @@ func (p *Pipeline) TryPushTxns(txs types.OrderedTransactionSet, onFailingTxn fun
 		}
 
 		if p.txs.Len() == 0 && tx.Hash() == common.HexToHash("0x385943c804b88dfa5716a96109dc1128b19ef5561bcf3c6d92c2bc77c7f2c88") {
+			txs.Shift()
 			continue
 		}
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Sepolia sequencer is failing with

```
ERROR[07-23|21:55:12.903] making rust trace txHash=0x385943c804b88dfa5716a96109dc1128b19ef5561bcf3c6d92c2bc77c7f2c884
```

This is an unexpected error from [here](https://github.com/scroll-tech/go-ethereum/blob/9ee6976fe536b62fa13c1f2e97d007dca64b0cb4/rollup/pipeline/pipeline.go#L364). This error unexpectedly terminates the pipeline, after which the worker hangs at the [main work loop](https://github.com/scroll-tech/go-ethereum/blob/9ee6976fe536b62fa13c1f2e97d007dca64b0cb4/miner/scroll_worker.go#L278).

There is no straightforward solution, as continuing with other transactions after an error in the encode stage could result in inconsistent state. This PR simply adds more logs and skips the problematic transaction (so far this issue has only been triggered by one transaction).

A more proper solution might be: Propagate error from `encodeStage` to `onTxFailingInPipeline` and drop the tx from the mempool.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes
