### PR TITLE
feat: implement simple pipeline reset

### DIFF
--- a/common/heap.go
+++ b/common/heap.go
@@ -41,6 +41,10 @@ func (h *Heap[T]) Remove(element *HeapElement[T]) {
 	heap.Remove(&h.heap, element.index)
 }
 
+func (h *Heap[T]) Clear() {
+	h.heap = make(innerHeap[T], 0)
+}
+
 type innerHeap[T Comparable[T]] []*HeapElement[T]
 
 func (h innerHeap[T]) Len() int {

--- a/common/shrinkingmap.go
+++ b/common/shrinkingmap.go
@@ -51,6 +51,11 @@ func (s *ShrinkingMap[K, V]) Size() (size int) {
 	return len(s.m)
 }
 
+func (s *ShrinkingMap[K, V]) Clear() {
+	s.m = make(map[K]V)
+	s.deletedKeys = 0
+}
+
 func (s *ShrinkingMap[K, V]) shouldShrink() bool {
 	return s.shrinkAfterDeletionsCount > 0 && s.deletedKeys >= s.shrinkAfterDeletionsCount
 }

--- a/rollup/da_syncer/batch_queue.go
+++ b/rollup/da_syncer/batch_queue.go
@@ -95,6 +95,7 @@ func (bq *BatchQueue) deleteBatch(batch da.Entry) {
 }
 
 func (bq *BatchQueue) Reset(height uint64) {
-	bq.batches = common.NewHeap[da.Entry]()
+	bq.batches.Clear()
+	bq.batchesMap.Clear()
 	bq.DAQueue.Reset(height)
 }

--- a/rollup/da_syncer/block_queue.go
+++ b/rollup/da_syncer/block_queue.go
@@ -50,3 +50,8 @@ func (bq *BlockQueue) getBlocksFromBatch(ctx context.Context) error {
 
 	return nil
 }
+
+func (bq *BlockQueue) Reset(height uint64) {
+	bq.blocks = make([]*da.PartialBlock, 0)
+	bq.batchQueue.Reset(height)
+}

--- a/rollup/da_syncer/da_queue.go
+++ b/rollup/da_syncer/da_queue.go
@@ -2,6 +2,7 @@ package da_syncer
 
 import (
 	"context"
+	"errors"
 
 	"github.com/scroll-tech/go-ethereum/rollup/da_syncer/da"
 )
@@ -42,15 +43,24 @@ func (dq *DAQueue) getNextData(ctx context.Context) error {
 			return err
 		}
 	}
+
 	dq.da, err = dq.dataSource.NextData()
+	if err == nil {
+		return nil
+	}
+
 	// previous dataSource has been exhausted, create new
-	if err == da.ErrSourceExhausted {
+	if errors.Is(err, da.ErrSourceExhausted) {
 		dq.l1height = dq.dataSource.L1Height()
 		dq.dataSource = nil
 		return dq.getNextData(ctx)
 	}
-	if err != nil {
-		return err
-	}
-	return nil
+
+	return err
+}
+
+func (dq *DAQueue) Reset(height uint64) {
+	dq.l1height = height
+	dq.dataSource = nil
+	dq.da = make(da.Entries, 0)
 }

--- a/rollup/da_syncer/da_syncer.go
+++ b/rollup/da_syncer/da_syncer.go
@@ -40,8 +40,8 @@ func (s *DASyncer) SyncOneBlock(block *da.PartialBlock) error {
 		return fmt.Errorf("failed building and writing block, number: %d, error: %v", block.PartialHeader.Number, err)
 	}
 
-	if s.blockchain.CurrentBlock().Header().Number.Uint64()%100 == 0 {
-		log.Info("inserted block", "blockhain height", s.blockchain.CurrentBlock().Header().Number, "block hash", s.blockchain.CurrentBlock().Header().Hash(), "root", s.blockchain.CurrentBlock().Header().Root)
+	if s.blockchain.CurrentBlock().Header().Number.Uint64()%1000 == 0 {
+		log.Info("L1 sync progress", "blockhain height", s.blockchain.CurrentBlock().Header().Number, "block hash", s.blockchain.CurrentBlock().Header().Hash(), "root", s.blockchain.CurrentBlock().Header().Root)
 	}
 
 	return nil

--- a/rollup/da_syncer/da_syncer.go
+++ b/rollup/da_syncer/da_syncer.go
@@ -25,15 +25,13 @@ func NewDASyncer(blockchain *core.BlockChain) *DASyncer {
 
 func (s *DASyncer) SyncOneBlock(block *da.PartialBlock) error {
 	parentBlock := s.blockchain.CurrentBlock()
+	// we expect blocks to be consecutive. block.PartialHeader.Number == parentBlock.Number+1.
 	if block.PartialHeader.Number <= parentBlock.NumberU64() {
 		log.Debug("block number is too low", "block number", block.PartialHeader.Number, "parent block number", parentBlock.NumberU64())
 		return ErrBlockTooLow
 	} else if block.PartialHeader.Number > parentBlock.NumberU64()+1 {
 		log.Debug("block number is too high", "block number", block.PartialHeader.Number, "parent block number", parentBlock.NumberU64())
 		return ErrBlockTooHigh
-	}
-	if parentBlock.NumberU64()+1 != block.PartialHeader.Number {
-		return fmt.Errorf("not consecutive block, number: %d, chain height: %d", block.PartialHeader.Number, parentBlock.NumberU64())
 	}
 
 	if _, err := s.blockchain.BuildAndWriteBlock(parentBlock, block.PartialHeader.ToHeader(), block.Transactions); err != nil {

--- a/rollup/da_syncer/da_syncer.go
+++ b/rollup/da_syncer/da_syncer.go
@@ -8,6 +8,11 @@ import (
 	"github.com/scroll-tech/go-ethereum/rollup/da_syncer/da"
 )
 
+var (
+	ErrBlockTooLow  = fmt.Errorf("block number is too low")
+	ErrBlockTooHigh = fmt.Errorf("block number is too high")
+)
+
 type DASyncer struct {
 	blockchain *core.BlockChain
 }
@@ -20,6 +25,13 @@ func NewDASyncer(blockchain *core.BlockChain) *DASyncer {
 
 func (s *DASyncer) SyncOneBlock(block *da.PartialBlock) error {
 	parentBlock := s.blockchain.CurrentBlock()
+	if block.PartialHeader.Number <= parentBlock.NumberU64() {
+		log.Debug("block number is too low", "block number", block.PartialHeader.Number, "parent block number", parentBlock.NumberU64())
+		return ErrBlockTooLow
+	} else if block.PartialHeader.Number > parentBlock.NumberU64()+1 {
+		log.Debug("block number is too high", "block number", block.PartialHeader.Number, "parent block number", parentBlock.NumberU64())
+		return ErrBlockTooHigh
+	}
 	if parentBlock.NumberU64()+1 != block.PartialHeader.Number {
 		return fmt.Errorf("not consecutive block, number: %d, chain height: %d", block.PartialHeader.Number, parentBlock.NumberU64())
 	}


### PR DESCRIPTION
This PR implements graceful handling of skipping blocks in the past and resetting of pipeline for too new blocks until we're at the correct block height again. This way the pipeline is more resilient and can handle arbitrary restarts/crashes of the node.