### PR TITLE
feat: allow calculating diffs between two row consumptions

### DIFF
--- a/core/types/row_consumption.go
+++ b/core/types/row_consumption.go
@@ -1,5 +1,7 @@
 package types
 
+import "slices"
+
 type RowUsage struct {
 	IsOk            bool                 `json:"is_ok"`
 	RowNumber       uint64               `json:"row_number"`
@@ -12,4 +14,38 @@ type SubCircuitRowUsage struct {
 	RowNumber uint64 `json:"row_number" gencodec:"required"`
 }
 
+// RowConsumptionLimit is the max number of row we support per subcircuit
+const RowConsumptionLimit = 1_000_000
+
 type RowConsumption []SubCircuitRowUsage
+
+// IsOverflown returns if any subcircuits are overflown
+func (rc RowConsumption) IsOverflown() bool {
+	return slices.ContainsFunc(rc, func(scru SubCircuitRowUsage) bool {
+		return scru.RowNumber > RowConsumptionLimit
+	})
+}
+
+// Difference returns rc - other
+// Assumes that rc > other for all subcircuits
+func (rc RowConsumption) Difference(other RowConsumption) RowConsumption {
+	subCircuitMap := make(map[string]uint64, len(rc))
+	for _, detail := range rc {
+		subCircuitMap[detail.Name] = detail.RowNumber
+	}
+
+	for _, detail := range other {
+		subCircuitMap[detail.Name] -= detail.RowNumber
+	}
+
+	diff := make([]SubCircuitRowUsage, 0, len(subCircuitMap))
+	for name, rowNumDiff := range subCircuitMap {
+		if rowNumDiff > 0 {
+			diff = append(diff, SubCircuitRowUsage{
+				Name:      name,
+				RowNumber: rowNumDiff,
+			})
+		}
+	}
+	return diff
+}

--- a/core/types/row_consumption_test.go
+++ b/core/types/row_consumption_test.go
@@ -1,0 +1,80 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRowConsumptionDifference(t *testing.T) {
+	tests := []struct {
+		rc1      RowConsumption
+		rc2      RowConsumption
+		expected RowConsumption
+	}{
+		{
+			rc1: RowConsumption{
+				SubCircuitRowUsage{
+					"sc1",
+					123,
+				},
+				SubCircuitRowUsage{
+					"sc2",
+					456,
+				},
+			},
+			rc2: RowConsumption{
+				SubCircuitRowUsage{
+					"sc2",
+					111,
+				},
+			},
+			expected: RowConsumption{
+				SubCircuitRowUsage{
+					"sc1",
+					123,
+				},
+				SubCircuitRowUsage{
+					"sc2",
+					345,
+				},
+			},
+		},
+		{
+			rc1: RowConsumption{
+				SubCircuitRowUsage{
+					"sc1",
+					123,
+				},
+				SubCircuitRowUsage{
+					"sc2",
+					456,
+				},
+			},
+			rc2: RowConsumption{
+				SubCircuitRowUsage{
+					"sc2",
+					456,
+				},
+			},
+			expected: RowConsumption{
+				SubCircuitRowUsage{
+					"sc1",
+					123,
+				},
+			},
+		},
+	}
+
+	makeMap := func(rc RowConsumption) map[string]uint64 {
+		m := make(map[string]uint64)
+		for _, usage := range rc {
+			m[usage.Name] = usage.RowNumber
+		}
+		return m
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, makeMap(test.expected), makeMap(test.rc1.Difference(test.rc2)))
+	}
+}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

this will be useful to allow skipping txns without executing them twice by calculating the contribution of a txn to the overall accumulated row consumption of a block. 

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
