### PR TITLE
feat: notify miner to skip obviously large txns without executing them twice

### DIFF
--- a/core/types/row_consumption.go
+++ b/core/types/row_consumption.go
@@ -2,12 +2,6 @@ package types
 
 import "slices"
 
-type RowUsage struct {
-	IsOk            bool                 `json:"is_ok"`
-	RowNumber       uint64               `json:"row_number"`
-	RowUsageDetails []SubCircuitRowUsage `json:"row_usage_details"`
-}
-
 //go:generate gencodec -type SubCircuitRowUsage -out gen_row_consumption_json.go
 type SubCircuitRowUsage struct {
 	Name      string `json:"name" gencodec:"required"`
@@ -15,7 +9,8 @@ type SubCircuitRowUsage struct {
 }
 
 // RowConsumptionLimit is the max number of row we support per subcircuit
-const RowConsumptionLimit = 1_000_000
+// the actual limit is 1M but for safety we go with 950k
+const RowConsumptionLimit = 950_000
 
 type RowConsumption []SubCircuitRowUsage
 

--- a/rollup/ccc/checker.go
+++ b/rollup/ccc/checker.go
@@ -113,7 +113,7 @@ func (ccc *Checker) applyTransactionRustTrace(rustTrace unsafe.Pointer) (*types.
 		return nil, ErrUnknown
 	}
 	if !result.AccRowUsage.IsOk {
-		return nil, ErrBlockRowConsumptionOverflow
+		return (*types.RowConsumption)(&result.AccRowUsage.RowUsageDetails), ErrBlockRowConsumptionOverflow
 	}
 	return (*types.RowConsumption)(&result.AccRowUsage.RowUsageDetails), nil
 }
@@ -153,7 +153,7 @@ func (ccc *Checker) ApplyBlock(traces *types.BlockTrace) (*types.RowConsumption,
 		return nil, ErrUnknown
 	}
 	if !result.AccRowUsage.IsOk {
-		return nil, ErrBlockRowConsumptionOverflow
+		return (*types.RowConsumption)(&result.AccRowUsage.RowUsageDetails), ErrBlockRowConsumptionOverflow
 	}
 	return (*types.RowConsumption)(&result.AccRowUsage.RowUsageDetails), nil
 }

--- a/rollup/ccc/mock_checker.go
+++ b/rollup/ccc/mock_checker.go
@@ -44,7 +44,10 @@ func (ccc *Checker) ApplyTransaction(traces *types.BlockTrace) (*types.RowConsum
 	}
 	if ccc.skipError != nil {
 		if traces.Transactions[0].TxHash == ccc.skipHash {
-			return nil, ccc.skipError
+			return &types.RowConsumption{types.SubCircuitRowUsage{
+				Name:      "mock",
+				RowNumber: 1_000_001,
+			}}, ccc.skipError
 		}
 	}
 	return &types.RowConsumption{types.SubCircuitRowUsage{

--- a/rollup/ccc/types.go
+++ b/rollup/ccc/types.go
@@ -15,9 +15,15 @@ type WrappedCommonResult struct {
 	Error string `json:"error,omitempty"`
 }
 
+type RowUsage struct {
+	IsOk            bool                       `json:"is_ok"`
+	RowNumber       uint64                     `json:"row_number"`
+	RowUsageDetails []types.SubCircuitRowUsage `json:"row_usage_details"`
+}
+
 type WrappedRowUsage struct {
-	AccRowUsage *types.RowUsage `json:"acc_row_usage,omitempty"`
-	Error       string          `json:"error,omitempty"`
+	AccRowUsage *RowUsage `json:"acc_row_usage,omitempty"`
+	Error       string    `json:"error,omitempty"`
 }
 
 type WrappedTxNum struct {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

miner will skip a txn if it counter-based CCC says so, but there might be cases where counter-based CCC thinks a txn is OK but Rust CCC thinks otherwise.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
