### PR TITLE
 perf: pool and reuse log buffers

### DIFF
--- a/core/types/l2trace.go
+++ b/core/types/l2trace.go
@@ -70,7 +70,7 @@ type ExecutionResult struct {
 	// currently they are just `from` and `to` account
 	AccountsAfter []*AccountWrapper `json:"accountAfter"`
 
-	StructLogs []*StructLogRes `json:"structLogs"`
+	StructLogs []StructLogRes  `json:"structLogs"`
 	CallTrace  json.RawMessage `json:"callTrace"`
 }
 
@@ -91,8 +91,8 @@ type StructLogRes struct {
 
 // NewStructLogResBasic Basic StructLogRes skeleton, Stack&Memory&Storage&ExtraData are separated from it for GC optimization;
 // still need to fill in with Stack&Memory&Storage&ExtraData
-func NewStructLogResBasic(pc uint64, op string, gas, gasCost uint64, depth int, refundCounter uint64, err error) *StructLogRes {
-	logRes := &StructLogRes{
+func NewStructLogResBasic(pc uint64, op string, gas, gasCost uint64, depth int, refundCounter uint64, err error) StructLogRes {
+	logRes := StructLogRes{
 		Pc:            pc,
 		Op:            op,
 		Gas:           gas,

--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -79,8 +79,8 @@ type StructLog struct {
 	Err           error                       `json:"-"`
 }
 
-func NewStructlog(pc uint64, op OpCode, gas, cost uint64, depth int, err error) *StructLog {
-	return &StructLog{
+func NewStructlog(pc uint64, op OpCode, gas, cost uint64, depth int, err error) StructLog {
+	return StructLog{
 		Pc:      pc,
 		Op:      op,
 		Gas:     gas,
@@ -88,14 +88,6 @@ func NewStructlog(pc uint64, op OpCode, gas, cost uint64, depth int, err error) 
 		Depth:   depth,
 		Err:     err,
 	}
-}
-
-func (s *StructLog) clean() {
-	s.Memory.Reset()
-	s.Stack = s.Stack[:0]
-	s.ReturnData.Reset()
-	s.Storage = nil
-	s.Err = nil
 }
 
 // overrides for gencodec
@@ -159,7 +151,7 @@ type StructLogger struct {
 	createdAccount *types.AccountWrapper
 
 	callStackLogInd []int
-	logs            []*StructLog
+	logs            []StructLog
 	output          []byte
 	err             error
 }
@@ -359,7 +351,7 @@ func (l *StructLogger) TracedBytecodes() map[common.Hash]CodeInfo {
 func (l *StructLogger) CreatedAccount() *types.AccountWrapper { return l.createdAccount }
 
 // StructLogs returns the captured log entries.
-func (l *StructLogger) StructLogs() []*StructLog { return l.logs }
+func (l *StructLogger) StructLogs() []StructLog { return l.logs }
 
 // Error returns the VM error captured by the trace.
 func (l *StructLogger) Error() error { return l.err }
@@ -368,7 +360,7 @@ func (l *StructLogger) Error() error { return l.err }
 func (l *StructLogger) Output() []byte { return l.output }
 
 // WriteTrace writes a formatted trace to the given writer
-func WriteTrace(writer io.Writer, logs []*StructLog) {
+func WriteTrace(writer io.Writer, logs []StructLog) {
 	for _, log := range logs {
 		fmt.Fprintf(writer, "%-16spc=%08d gas=%v cost=%v", log.Op, log.Pc, log.Gas, log.GasCost)
 		if log.Err != nil {
@@ -488,8 +480,8 @@ func (t *mdLogger) CaptureEnter(typ OpCode, from common.Address, to common.Addre
 func (t *mdLogger) CaptureExit(output []byte, gasUsed uint64, err error) {}
 
 // FormatLogs formats EVM returned structured logs for json output
-func FormatLogs(logs []*StructLog) []*types.StructLogRes {
-	formatted := make([]*types.StructLogRes, 0, len(logs))
+func FormatLogs(logs []StructLog) []types.StructLogRes {
+	formatted := make([]types.StructLogRes, 0, len(logs))
 
 	for _, trace := range logs {
 		logRes := types.NewStructLogResBasic(trace.Pc, trace.Op.String(), trace.Gas, trace.GasCost, trace.Depth, trace.RefundCounter, trace.Err)

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -227,7 +227,7 @@ func TestTraceCall(t *testing.T) {
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
-				StructLogs:  []*types.StructLogRes{},
+				StructLogs:  []types.StructLogRes{},
 			},
 		},
 		// Standard JSON trace upon the head, plain transfer.
@@ -245,7 +245,7 @@ func TestTraceCall(t *testing.T) {
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
-				StructLogs:  []*types.StructLogRes{},
+				StructLogs:  []types.StructLogRes{},
 			},
 		},
 		// Standard JSON trace upon the non-existent block, error expects
@@ -275,7 +275,7 @@ func TestTraceCall(t *testing.T) {
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
-				StructLogs:  []*types.StructLogRes{},
+				StructLogs:  []types.StructLogRes{},
 			},
 		},
 		// Standard JSON trace upon the pending block
@@ -293,7 +293,7 @@ func TestTraceCall(t *testing.T) {
 				Gas:         params.TxGas,
 				Failed:      false,
 				ReturnValue: "",
-				StructLogs:  []*types.StructLogRes{},
+				StructLogs:  []types.StructLogRes{},
 			},
 		},
 	}
@@ -347,7 +347,7 @@ func TestTraceTransaction(t *testing.T) {
 		Gas:         params.TxGas,
 		Failed:      false,
 		ReturnValue: "",
-		StructLogs:  []*types.StructLogRes{},
+		StructLogs:  []types.StructLogRes{},
 	}) {
 		t.Error("Transaction tracing result is different")
 	}

--- a/rollup/tracing/tracing.go
+++ b/rollup/tracing/tracing.go
@@ -69,7 +69,7 @@ type TraceEnv struct {
 	// The following Mutexes are used to protect against parallel read/write,
 	// since txs are executed in parallel.
 	pMu sync.Mutex // for `TraceEnv.StorageTrace.Proofs`
-	sMu sync.Mutex // for `TraceEnv.state``
+	sMu sync.Mutex // for `TraceEnv.state`
 	cMu sync.Mutex // for `TraceEnv.Codes`
 
 	*types.StorageTrace
@@ -325,6 +325,8 @@ func (env *TraceEnv) getTxResult(state *state.StateDB, index int, block *types.B
 
 	applyMessageStart := time.Now()
 	structLogger := vm.NewStructLogger(env.logConfig)
+	structLogger.InitLogsFromPool()
+	defer structLogger.ReleaseLogsToPool()
 	tracer := NewMuxTracer(structLogger, callTracer)
 	// Run the transaction with tracing enabled.
 	vmenv := vm.NewEVM(env.blockCtx, txContext, state, env.chainConfig, vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

using a slice of pointers and allocating on each step of EVM execution puts a lot of unnecessary load on the garbage collector.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
