### PR TITLE
fix(rollup-verifier): delete committed batch meta when reverting a batch

### DIFF
--- a/core/rawdb/accessors_rollup_event.go
+++ b/core/rawdb/accessors_rollup_event.go
@@ -211,7 +211,6 @@ func ReadCommittedBatchMeta(db ethdb.Reader, batchIndex uint64) *CommittedBatchM
 
 // DeleteCommittedBatchMeta removes the block ranges of all chunks associated with a specific batch from the database.
 // Note: Only non-finalized batches can be reverted.
-// for backward compatibility, new info is also stored in CommittedBatchMeta.
 func DeleteCommittedBatchMeta(db ethdb.KeyValueWriter, batchIndex uint64) {
 	if err := db.Delete(committedBatchMetaKey(batchIndex)); err != nil {
 		log.Crit("failed to delete committed batch metadata", "batch index", batchIndex, "err", err)

--- a/core/rawdb/accessors_rollup_event.go
+++ b/core/rawdb/accessors_rollup_event.go
@@ -208,3 +208,12 @@ func ReadCommittedBatchMeta(db ethdb.Reader, batchIndex uint64) *CommittedBatchM
 	}
 	return cbm
 }
+
+// DeleteCommittedBatchMeta removes the block ranges of all chunks associated with a specific batch from the database.
+// Note: Only non-finalized batches can be reverted.
+// for backward compatibility, new info is also stored in CommittedBatchMeta.
+func DeleteCommittedBatchMeta(db ethdb.KeyValueWriter, batchIndex uint64) {
+	if err := db.Delete(committedBatchMetaKey(batchIndex)); err != nil {
+		log.Crit("failed to delete committed batch metadata", "batch index", batchIndex, "err", err)
+	}
+}

--- a/core/rawdb/accessors_rollup_event_test.go
+++ b/core/rawdb/accessors_rollup_event_test.go
@@ -211,7 +211,7 @@ func TestBatchChunkRanges(t *testing.T) {
 	DeleteBatchChunkRanges(db, uint64(len(chunks)+1))
 }
 
-func TestWriteReadCommittedBatchMeta(t *testing.T) {
+func TestWriteReadDeleteCommittedBatchMeta(t *testing.T) {
 	db := NewMemoryDatabase()
 
 	testCases := []struct {
@@ -261,6 +261,19 @@ func TestWriteReadCommittedBatchMeta(t *testing.T) {
 	if got := ReadCommittedBatchMeta(db, 256); got != nil {
 		t.Fatalf("Expected nil for non-existing value, got %+v", got)
 	}
+
+	// delete: revert batch
+	for _, tc := range testCases {
+		DeleteCommittedBatchMeta(db, tc.batchIndex)
+
+		readChunkRange := ReadCommittedBatchMeta(db, tc.batchIndex)
+		if readChunkRange != nil {
+			t.Fatal("Committed batch metadata was not deleted", "batch index", tc.batchIndex)
+		}
+	}
+
+	// delete non-existing value: ensure the delete operation handles non-existing values without errors.
+	DeleteCommittedBatchMeta(db, 256)
 }
 
 func TestOverwriteCommittedBatchMeta(t *testing.T) {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 6         // Minor version component of the current release
-	VersionPatch = 4         // Patch version component of the current release
+	VersionPatch = 5         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -219,6 +219,7 @@ func (s *RollupSyncService) parseAndUpdateRollupEventLogs(logs []types.Log, endB
 			batchIndex := event.BatchIndex.Uint64()
 			log.Trace("found new RevertBatch event", "batch index", batchIndex)
 
+			rawdb.DeleteCommittedBatchMeta(s.db, batchIndex)
 			rawdb.DeleteBatchChunkRanges(s.db, batchIndex)
 
 		case s.l1FinalizeBatchEventSignature:


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Only for logic completeness sake.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
