### PR TITLE
fix(worker): index out of range panic

### DIFF
--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -590,14 +590,14 @@ func (w *worker) processReorgedTxns(reason error) (bool, error) {
 	reorgedTxns := w.chain.GetBlockByNumber(w.current.header.Number.Uint64()).Transactions()
 	var errorWithTxnIdx *ccc.ErrorWithTxnIdx
 	if len(reorgedTxns) > 0 && errors.As(reason, &errorWithTxnIdx) {
+		if errorWithTxnIdx.ShouldSkip {
+			w.skipTransaction(reorgedTxns[errorWithTxnIdx.TxIdx], reason)
+		}
+
 		if errorWithTxnIdx.TxIdx == 0 {
 			reorgedTxns = reorgedTxns[1:]
 		} else {
 			reorgedTxns = reorgedTxns[:errorWithTxnIdx.TxIdx]
-		}
-
-		if errorWithTxnIdx.ShouldSkip {
-			w.skipTransaction(reorgedTxns[errorWithTxnIdx.TxIdx], reason)
 		}
 	}
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

```
WARN [08-27|11:09:59.758] block failed CCC                         hash=7c01e1..a9cd93 number=6,356,635
panic: runtime error: index out of range [0] with length 0
goroutine 45 [running]:
github.com/scroll-tech/go-ethereum/miner.(*worker).processReorgedTxns(0xc008452000, {0x1c42f80, 0xc0028bb8a0})
	github.com/scroll-tech/go-ethereum/miner/scroll_worker.go:600 +0x18d
github.com/scroll-tech/go-ethereum/miner.(*worker).tryCommitNewWork(0xc008452000, {0xffffffffffffffff?, 0xffffffffffffffff?, 0x28b4800?}, {0x98, 0x4f, 0x36, 0xe1, 0xe5, 0x6a, ...}, ...)
	github.com/scroll-tech/go-ethereum/miner/scroll_worker.go:456 +0x1e5
github.com/scroll-tech/go-ethereum/miner.(*worker).handleReorg(0xc0193fff18?, 0xc0193ffe80)
	github.com/scroll-tech/go-ethereum/miner/scroll_worker.go:960 +0x10e
github.com/scroll-tech/go-ethereum/miner.(*worker).mainLoop(0xc008452000)
	github.com/scroll-tech/go-ethereum/miner/scroll_worker.go:317 +0x68b
created by github.com/scroll-tech/go-ethereum/miner.newWorker in goroutine 1
	github.com/scroll-tech/go-ethereum/miner/scroll_worker.go:205 +0x4e5
```