### PR TITLE
chore(libzkp): upgrade to speedup rust-ccc(poseidon) by 30%

### DIFF
--- a/rollup/ccc/libzkp/Cargo.lock
+++ b/rollup/ccc/libzkp/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "aggregator"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "ark-std 0.3.0",
  "bitstream-io",
@@ -537,7 +537,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 [[package]]
 name = "bus-mapping"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "base64 0.13.1",
  "ethers-core",
@@ -1283,7 +1283,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "eth-types",
  "halo2_proofs",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "env_logger 0.10.0",
  "gobuild",
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "eth-types",
  "ethers-core",
@@ -2252,7 +2252,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "eth-types",
  "halo2curves",
@@ -2635,17 +2635,18 @@ dependencies = [
 [[package]]
 name = "poseidon-base"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=main#7b96835c6201afdbfaf3d13d641efbaaf5db2d20"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=main#6cc36ab9dfa153f554ff7b84305f39838366a8df"
 dependencies = [
  "bitvec",
  "halo2curves",
  "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "poseidon-circuit"
 version = "0.1.0"
-source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=main#7b96835c6201afdbfaf3d13d641efbaaf5db2d20"
+source = "git+https://github.com/scroll-tech/poseidon-circuit.git?branch=main#6cc36ab9dfa153f554ff7b84305f39838366a8df"
 dependencies = [
  "ff",
  "halo2_proofs",
@@ -2724,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "prover"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "aggregator",
  "anyhow",
@@ -4361,7 +4362,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.11.0"
-source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.7#ee33165f2005125310553af08c91f5a5bfe61b42"
+source = "git+https://github.com/scroll-tech/zkevm-circuits.git?tag=v0.11.8#1f2f15c48edcd56ad05bad9dc04bfbec1ed36c05"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/rollup/ccc/libzkp/Cargo.toml
+++ b/rollup/ccc/libzkp/Cargo.toml
@@ -23,7 +23,7 @@ poseidon = { git = "https://github.com/scroll-tech/poseidon.git", branch = "main
 bls12_381 = { git = "https://github.com/scroll-tech/bls12_381", branch = "feat/impl_scalar_field" }
 
 [dependencies]
-prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.7", default-features = false, features = ["parallel_syn", "scroll", "strict-ccc"] }
+prover = { git = "https://github.com/scroll-tech/zkevm-circuits.git", tag = "v0.11.8", default-features = false, features = ["parallel_syn", "scroll", "strict-ccc"] }
 
 anyhow = "1.0"
 base64 = "0.13.0"


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

fix some silly bad code in poseidon-base lib, rust ccc (lightMode=false) reduce run time by 30%.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [x] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
