### PR TITLE
fix: reuse timestamp for blocks failing CCC

### DIFF
--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -440,6 +440,13 @@ func (w *worker) newWork(now time.Time, parentHash common.Hash, reorgReason erro
 		Time:       uint64(now.Unix()),
 	}
 
+	if reorgReason != nil {
+		// if we are replacing a failing block, reuse the timestamp to make sure
+		// the information we get from AsyncChecker is reliable. Changing timestamp
+		// might alter execution flow of reorged transactions.
+		header.Time = w.chain.GetHeaderByNumber(header.Number.Uint64()).Time
+	}
+
 	parentState, err := w.chain.StateAt(parent.Root())
 	if err != nil {
 		return fmt.Errorf("failed to fetch parent state: %w", err)


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

```
we assume that same height wont trigger multiple reorgs to be able to put an upper bound 
on the reorg depth. We rely on the fact that AsyncChecker executes transactions
one-by-one and tells worker the safe set of transactions to include in the replacement block
that wont trigger another error on the same block. If worker changes the timestamp and that
causes significant changes to the execution flow of included transactions; we might have a 
height where multiple reorgs happen.
```

this is extremely unlikely but possible.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
