### PR TITLE
feat(scroll-worker): add nil consumption block metrics

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 13        // Patch version component of the current release
+	VersionPatch = 14        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

* record missing row consumption during restart.
* record missing ancestor's row consumption during runtime.

for scroll-worker panic, should be caught by "panic" in the logs of the below training wheel, thus this PR does not add this metric:
```
defer func() {
	// training wheels on
	// lets not crash the node and allow us some time to inspect
	p := recover()
	if p != nil {
		log.Error("worker mainLoop panic", "panic", p)
	}
}()
```

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
