### PR TITLE
feat: allow changing L1 synced height via admin RPC/CLI

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -833,3 +833,17 @@ func (api *ScrollAPI) CalculateRowConsumptionByBlockNumber(ctx context.Context, 
 	asyncChecker.Wait()
 	return rawdb.ReadBlockRowConsumption(api.eth.ChainDb(), block.Hash()), checkErr
 }
+
+// SetRollupEventSyncL1Height sets the synced L1 height for rollup event synchronization
+func (api *ScrollAPI) SetRollupEventSyncedL1Height(height uint64) error {
+	log.Info("Setting rollup event synced L1 height", "height", height)
+	rawdb.WriteRollupEventSyncedL1BlockNumber(api.eth.ChainDb(), height)
+	return nil
+}
+
+// SetL1MessageSyncL1Height sets the synced L1 height for L1 message synchronization
+func (api *ScrollAPI) SetL1MessageSyncedL1Height(height uint64) error {
+	rawdb.WriteSyncedL1BlockNumber(api.eth.ChainDb(), height)
+	log.Info("Setting L1 message synced L1 height", "height", height)
+	return nil
+}

--- a/eth/api.go
+++ b/eth/api.go
@@ -836,6 +836,19 @@ func (api *ScrollAPI) CalculateRowConsumptionByBlockNumber(ctx context.Context, 
 
 // SetRollupEventSyncedL1Height sets the synced L1 height for rollup event synchronization
 func (api *ScrollAPI) SetRollupEventSyncedL1Height(height uint64) error {
+	prevHeightPtr := rawdb.ReadRollupEventSyncedL1BlockNumber(api.eth.ChainDb())
+
+	if prevHeightPtr == nil {
+		log.Warn("No previous rollup event synced L1 height found in database")
+		return fmt.Errorf("no previous rollup event synced L1 height found in database")
+	}
+
+	prevHeight := *prevHeightPtr
+	if height >= prevHeight {
+		log.Warn("New rollup event synced L1 height is not lower than previous height", "newHeight", height, "prevHeight", prevHeight)
+		return fmt.Errorf("new rollup event synced L1 height (%d) is not lower than previous height (%d)", height, prevHeight)
+	}
+
 	log.Info("Setting rollup event synced L1 height", "height", height)
 	rawdb.WriteRollupEventSyncedL1BlockNumber(api.eth.ChainDb(), height)
 	return nil
@@ -843,7 +856,20 @@ func (api *ScrollAPI) SetRollupEventSyncedL1Height(height uint64) error {
 
 // SetL1MessageSyncedL1Height sets the synced L1 height for L1 message synchronization
 func (api *ScrollAPI) SetL1MessageSyncedL1Height(height uint64) error {
-	rawdb.WriteSyncedL1BlockNumber(api.eth.ChainDb(), height)
+	prevHeightPtr := rawdb.ReadSyncedL1BlockNumber(api.eth.ChainDb())
+
+	if prevHeightPtr == nil {
+		log.Warn("No previous L1 message synced L1 height found in database")
+		return fmt.Errorf("no previous L1 message synced L1 height found in database")
+	}
+
+	prevHeight := *prevHeightPtr
+	if height >= prevHeight {
+		log.Warn("New L1 message synced L1 height is not lower than previous height", "newHeight", height, "prevHeight", prevHeight)
+		return fmt.Errorf("new L1 message synced L1 height (%d) is not lower than previous height (%d)", height, prevHeight)
+	}
+
 	log.Info("Setting L1 message synced L1 height", "height", height)
+	rawdb.WriteSyncedL1BlockNumber(api.eth.ChainDb(), height)
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -836,40 +836,28 @@ func (api *ScrollAPI) CalculateRowConsumptionByBlockNumber(ctx context.Context, 
 
 // SetRollupEventSyncedL1Height sets the synced L1 height for rollup event synchronization
 func (api *ScrollAPI) SetRollupEventSyncedL1Height(height uint64) error {
-	prevHeightPtr := rawdb.ReadRollupEventSyncedL1BlockNumber(api.eth.ChainDb())
-
-	if prevHeightPtr == nil {
-		log.Warn("No previous rollup event synced L1 height found in database")
-		return fmt.Errorf("no previous rollup event synced L1 height found in database")
-	}
-
-	prevHeight := *prevHeightPtr
-	if height >= prevHeight {
-		log.Warn("New rollup event synced L1 height is not lower than previous height", "newHeight", height, "prevHeight", prevHeight)
-		return fmt.Errorf("new rollup event synced L1 height (%d) is not lower than previous height (%d)", height, prevHeight)
+	rollupSyncService := api.eth.GetRollupSyncService()
+	if rollupSyncService == nil {
+		return errors.New("RollupSyncService is not available")
 	}
 
 	log.Info("Setting rollup event synced L1 height", "height", height)
-	rawdb.WriteRollupEventSyncedL1BlockNumber(api.eth.ChainDb(), height)
+
+	rollupSyncService.ResetToHeight(height)
+
 	return nil
 }
 
 // SetL1MessageSyncedL1Height sets the synced L1 height for L1 message synchronization
 func (api *ScrollAPI) SetL1MessageSyncedL1Height(height uint64) error {
-	prevHeightPtr := rawdb.ReadSyncedL1BlockNumber(api.eth.ChainDb())
-
-	if prevHeightPtr == nil {
-		log.Warn("No previous L1 message synced L1 height found in database")
-		return fmt.Errorf("no previous L1 message synced L1 height found in database")
-	}
-
-	prevHeight := *prevHeightPtr
-	if height >= prevHeight {
-		log.Warn("New L1 message synced L1 height is not lower than previous height", "newHeight", height, "prevHeight", prevHeight)
-		return fmt.Errorf("new L1 message synced L1 height (%d) is not lower than previous height (%d)", height, prevHeight)
+	syncService := api.eth.GetSyncService()
+	if syncService == nil {
+		return errors.New("SyncService is not available")
 	}
 
 	log.Info("Setting L1 message synced L1 height", "height", height)
-	rawdb.WriteSyncedL1BlockNumber(api.eth.ChainDb(), height)
+
+	syncService.ResetToHeight(height)
+
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -834,14 +834,14 @@ func (api *ScrollAPI) CalculateRowConsumptionByBlockNumber(ctx context.Context, 
 	return rawdb.ReadBlockRowConsumption(api.eth.ChainDb(), block.Hash()), checkErr
 }
 
-// SetRollupEventSyncL1Height sets the synced L1 height for rollup event synchronization
+// SetRollupEventSyncedL1Height sets the synced L1 height for rollup event synchronization
 func (api *ScrollAPI) SetRollupEventSyncedL1Height(height uint64) error {
 	log.Info("Setting rollup event synced L1 height", "height", height)
 	rawdb.WriteRollupEventSyncedL1BlockNumber(api.eth.ChainDb(), height)
 	return nil
 }
 
-// SetL1MessageSyncL1Height sets the synced L1 height for L1 message synchronization
+// SetL1MessageSyncedL1Height sets the synced L1 height for L1 message synchronization
 func (api *ScrollAPI) SetL1MessageSyncedL1Height(height uint64) error {
 	rawdb.WriteSyncedL1BlockNumber(api.eth.ChainDb(), height)
 	log.Info("Setting L1 message synced L1 height", "height", height)

--- a/eth/api.go
+++ b/eth/api.go
@@ -254,6 +254,34 @@ func (api *PrivateAdminAPI) ImportChain(file string) (bool, error) {
 	return true, nil
 }
 
+// SetRollupEventSyncedL1Height sets the synced L1 height for rollup event synchronization
+func (api *PrivateAdminAPI) SetRollupEventSyncedL1Height(height uint64) error {
+	rollupSyncService := api.eth.GetRollupSyncService()
+	if rollupSyncService == nil {
+		return errors.New("RollupSyncService is not available")
+	}
+
+	log.Info("Setting rollup event synced L1 height", "height", height)
+
+	rollupSyncService.ResetToHeight(height)
+
+	return nil
+}
+
+// SetL1MessageSyncedL1Height sets the synced L1 height for L1 message synchronization
+func (api *PrivateAdminAPI) SetL1MessageSyncedL1Height(height uint64) error {
+	syncService := api.eth.GetSyncService()
+	if syncService == nil {
+		return errors.New("SyncService is not available")
+	}
+
+	log.Info("Setting L1 message synced L1 height", "height", height)
+
+	syncService.ResetToHeight(height)
+
+	return nil
+}
+
 // PublicDebugAPI is the collection of Ethereum full node APIs exposed
 // over the public debugging endpoint.
 type PublicDebugAPI struct {
@@ -832,32 +860,4 @@ func (api *ScrollAPI) CalculateRowConsumptionByBlockNumber(ctx context.Context, 
 	}
 	asyncChecker.Wait()
 	return rawdb.ReadBlockRowConsumption(api.eth.ChainDb(), block.Hash()), checkErr
-}
-
-// SetRollupEventSyncedL1Height sets the synced L1 height for rollup event synchronization
-func (api *ScrollAPI) SetRollupEventSyncedL1Height(height uint64) error {
-	rollupSyncService := api.eth.GetRollupSyncService()
-	if rollupSyncService == nil {
-		return errors.New("RollupSyncService is not available")
-	}
-
-	log.Info("Setting rollup event synced L1 height", "height", height)
-
-	rollupSyncService.ResetToHeight(height)
-
-	return nil
-}
-
-// SetL1MessageSyncedL1Height sets the synced L1 height for L1 message synchronization
-func (api *ScrollAPI) SetL1MessageSyncedL1Height(height uint64) error {
-	syncService := api.eth.GetSyncService()
-	if syncService == nil {
-		return errors.New("SyncService is not available")
-	}
-
-	log.Info("Setting L1 message synced L1 height", "height", height)
-
-	syncService.ResetToHeight(height)
-
-	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -262,8 +262,7 @@ func (api *PrivateAdminAPI) SetRollupEventSyncedL1Height(height uint64) error {
 	}
 
 	log.Info("Setting rollup event synced L1 height", "height", height)
-
-	rollupSyncService.ResetToHeight(height)
+	rollupSyncService.ResetStartSyncHeight(height)
 
 	return nil
 }
@@ -276,8 +275,7 @@ func (api *PrivateAdminAPI) SetL1MessageSyncedL1Height(height uint64) error {
 	}
 
 	log.Info("Setting L1 message synced L1 height", "height", height)
-
-	syncService.ResetToHeight(height)
+	syncService.ResetStartSyncHeight(height)
 
 	return nil
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -609,3 +609,15 @@ func (s *Ethereum) Stop() error {
 
 	return nil
 }
+
+// GetRollupSyncService returns the RollupSyncService of the Ethereum instance.
+// It returns nil if the service is not initialized.
+func (e *Ethereum) GetRollupSyncService() *rollup_sync_service.RollupSyncService {
+	return e.rollupSyncService
+}
+
+// GetSyncService returns the SyncService of the Ethereum instance.
+// It returns nil if the service is not initialized.
+func (e *Ethereum) GetSyncService() *sync_service.SyncService {
+	return e.syncService
+}

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -932,6 +932,16 @@ web3._extend({
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
 		}),
+		new web3._extend.Method({
+			name: 'setRollupEventSyncedL1Height',
+			call: 'scroll_setRollupEventSyncedL1Height',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'setL1MessageSyncedL1Height',
+			call: 'scroll_setL1MessageSyncedL1Height',
+			params: 1
+		}),
 	],
 	properties:
 	[

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -190,6 +190,16 @@ web3._extend({
 			name: 'stopWS',
 			call: 'admin_stopWS'
 		}),
+		new web3._extend.Method({
+			name: 'setRollupEventSyncedL1Height',
+			call: 'admin_setRollupEventSyncedL1Height',
+			params: 1
+		}),
+		new web3._extend.Method({
+			name: 'setL1MessageSyncedL1Height',
+			call: 'admin_setL1MessageSyncedL1Height',
+			params: 1
+		}),
 	],
 	properties: [
 		new web3._extend.Property({
@@ -931,16 +941,6 @@ web3._extend({
 			call: 'scroll_calculateRowConsumptionByBlockNumber',
 			params: 1,
 			inputFormatter: [web3._extend.formatters.inputBlockNumberFormatter]
-		}),
-		new web3._extend.Method({
-			name: 'setRollupEventSyncedL1Height',
-			call: 'scroll_setRollupEventSyncedL1Height',
-			params: 1
-		}),
-		new web3._extend.Method({
-			name: 'setL1MessageSyncedL1Height',
-			call: 'scroll_setL1MessageSyncedL1Height',
-			params: 1
 		}),
 	],
 	properties:

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 17        // Patch version component of the current release
+	VersionPatch = 18        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -159,14 +159,13 @@ func (s *RollupSyncService) Stop() {
 	}
 }
 
-// ResetToHeight resets the RollupSyncService to a specific L1 block height
-func (s *RollupSyncService) ResetToHeight(height uint64) {
+// ResetStartSyncHeight resets the RollupSyncService to a specific L1 block height
+func (s *RollupSyncService) ResetStartSyncHeight(height uint64) {
 	if s == nil {
 		return
 	}
 
 	s.latestProcessedBlock.Store(height)
-
 	log.Info("Reset sync service", "height", height)
 }
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -7,7 +7,7 @@ import (
 	"math/big"
 	"os"
 	"reflect"
-	"runtime/internal/atomic"
+	"sync/atomic"
 	"time"
 
 	"github.com/scroll-tech/da-codec/encoding"

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -178,6 +178,7 @@ func (s *RollupSyncService) fetchRollupEvents() {
 
 	initialProcessedBlock := s.latestProcessedBlock.Load()
 	currentProcessedBlock := initialProcessedBlock
+	defer s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
 
 	log.Trace("Sync service fetch rollup events", "latest processed block", currentProcessedBlock, "latest confirmed", latestConfirmed)
 
@@ -206,8 +207,6 @@ func (s *RollupSyncService) fetchRollupEvents() {
 
 		currentProcessedBlock = to
 	}
-
-	s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
 }
 
 func (s *RollupSyncService) parseAndUpdateRollupEventLogs(logs []types.Log, endBlockNumber uint64) error {

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -178,7 +178,10 @@ func (s *RollupSyncService) fetchRollupEvents() {
 
 	initialProcessedBlock := s.latestProcessedBlock.Load()
 	currentProcessedBlock := initialProcessedBlock
-	defer s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
+	// func() ensures using final currentProcessedBlock value when function returns
+	defer func() {
+		s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
+	}()
 
 	log.Trace("Sync service fetch rollup events", "latest processed block", currentProcessedBlock, "latest confirmed", latestConfirmed)
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -102,10 +102,10 @@ func NewRollupSyncService(ctx context.Context, genesisConfig *params.ChainConfig
 		latestProcessedBlock = *block
 	}
 
-	serviceCtx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 
 	service := RollupSyncService{
-		ctx:                           serviceCtx,
+		ctx:                           ctx,
 		cancel:                        cancel,
 		client:                        client,
 		db:                            db,
@@ -125,9 +125,6 @@ func (s *RollupSyncService) Start() {
 	if s == nil {
 		return
 	}
-
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 
 	log.Info("Starting rollup event sync background service", "latest processed block", s.latestProcessedBlock)
 
@@ -155,9 +152,6 @@ func (s *RollupSyncService) Stop() {
 	if s == nil {
 		return
 	}
-
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 
 	log.Info("Stopping rollup event sync background service")
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -157,6 +157,19 @@ func (s *RollupSyncService) Stop() {
 	}
 }
 
+// ResetToHeight resets the RollupSyncService to a specific L1 block height
+func (s *RollupSyncService) ResetToHeight(height uint64) {
+	s.Stop()
+
+	s.latestProcessedBlock = height
+
+	rawdb.WriteRollupEventSyncedL1BlockNumber(s.db, height)
+
+	log.Info("Reset rollup sync service", "height", height)
+
+	go s.Start()
+}
+
 func (s *RollupSyncService) fetchRollupEvents() {
 	latestConfirmed, err := s.client.getLatestFinalizedBlockNumber()
 	if err != nil {

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -79,10 +79,10 @@ func NewSyncService(ctx context.Context, genesisConfig *params.ChainConfig, node
 		latestProcessedBlock = *block
 	}
 
-	serviceCtx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithCancel(ctx)
 
 	service := SyncService{
-		ctx:                  serviceCtx,
+		ctx:                  ctx,
 		cancel:               cancel,
 		client:               client,
 		db:                   db,
@@ -97,9 +97,6 @@ func (s *SyncService) Start() {
 	if s == nil {
 		return
 	}
-
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 
 	// wait for initial sync before starting node
 	log.Info("Starting L1 message sync service", "latestProcessedBlock", s.latestProcessedBlock)
@@ -134,9 +131,6 @@ func (s *SyncService) Stop() {
 	if s == nil {
 		return
 	}
-
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
 
 	log.Info("Stopping sync service")
 

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -164,10 +164,10 @@ func (s *SyncService) fetchMessages() {
 		return
 	}
 
-	latestProcessedBlock := s.latestProcessedBlock.Load()
-	updatedLatestProcessedBlock := latestProcessedBlock
+	initialProcessedBlock := s.latestProcessedBlock.Load()
+	currentProcessedBlock := initialProcessedBlock
 
-	log.Trace("Sync service fetchMessages", "latestProcessedBlock", latestProcessedBlock, "latestConfirmed", latestConfirmed)
+	log.Trace("Sync service fetchMessages", "latestProcessedBlock", currentProcessedBlock, "latestConfirmed", latestConfirmed)
 
 	// keep track of next queue index we're expecting to see
 	queueIndex := rawdb.ReadHighestSyncedQueueIndex(s.db)
@@ -197,7 +197,7 @@ func (s *SyncService) fetchMessages() {
 			numMessagesPendingDbWrite = 0
 		}
 
-		updatedLatestProcessedBlock = lastBlock
+		currentProcessedBlock = lastBlock
 	}
 
 	// ticker for logging progress
@@ -205,7 +205,7 @@ func (s *SyncService) fetchMessages() {
 	numMsgsCollected := 0
 
 	// query in batches
-	for from := updatedLatestProcessedBlock + 1; from <= latestConfirmed; from += DefaultFetchBlockRange {
+	for from := currentProcessedBlock + 1; from <= latestConfirmed; from += DefaultFetchBlockRange {
 		select {
 		case <-s.ctx.Done():
 			// flush pending writes to database
@@ -214,8 +214,8 @@ func (s *SyncService) fetchMessages() {
 			}
 			return
 		case <-t.C:
-			progress := 100 * float64(updatedLatestProcessedBlock) / float64(latestConfirmed)
-			log.Info("Syncing L1 messages", "processed", updatedLatestProcessedBlock, "confirmed", latestConfirmed, "collected", numMsgsCollected, "progress(%)", progress)
+			progress := 100 * float64(currentProcessedBlock) / float64(latestConfirmed)
+			log.Info("Syncing L1 messages", "processed", currentProcessedBlock, "confirmed", latestConfirmed, "collected", numMsgsCollected, "progress(%)", progress)
 		default:
 		}
 
@@ -260,5 +260,5 @@ func (s *SyncService) fetchMessages() {
 		}
 	}
 
-	s.latestProcessedBlock.CompareAndSwap(latestProcessedBlock, updatedLatestProcessedBlock)
+	s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
 }

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -166,7 +166,10 @@ func (s *SyncService) fetchMessages() {
 
 	initialProcessedBlock := s.latestProcessedBlock.Load()
 	currentProcessedBlock := initialProcessedBlock
-	defer s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
+	// func() ensures using final currentProcessedBlock value when function returns
+	defer func() {
+		s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
+	}()
 
 	log.Trace("Sync service fetchMessages", "latestProcessedBlock", currentProcessedBlock, "latestConfirmed", latestConfirmed)
 

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -141,14 +141,13 @@ func (s *SyncService) Stop() {
 	}
 }
 
-// ResetToHeight resets the SyncService to a specific L1 block height
-func (s *SyncService) ResetToHeight(height uint64) {
+// ResetStartSyncHeight resets the SyncService to a specific L1 block height
+func (s *SyncService) ResetStartSyncHeight(height uint64) {
 	if s == nil {
 		return
 	}
 
 	s.latestProcessedBlock.Store(height)
-
 	log.Info("Reset sync service", "height", height)
 }
 

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -166,6 +166,7 @@ func (s *SyncService) fetchMessages() {
 
 	initialProcessedBlock := s.latestProcessedBlock.Load()
 	currentProcessedBlock := initialProcessedBlock
+	defer s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
 
 	log.Trace("Sync service fetchMessages", "latestProcessedBlock", currentProcessedBlock, "latestConfirmed", latestConfirmed)
 
@@ -259,6 +260,4 @@ func (s *SyncService) fetchMessages() {
 			flush(to)
 		}
 	}
-
-	s.latestProcessedBlock.CompareAndSwap(initialProcessedBlock, currentProcessedBlock)
 }

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -139,6 +139,19 @@ func (s *SyncService) Stop() {
 	}
 }
 
+// ResetToHeight resets the SyncService to a specific L1 block height
+func (s *SyncService) ResetToHeight(height uint64) {
+	s.Stop()
+
+	s.latestProcessedBlock = height
+
+	rawdb.WriteSyncedL1BlockNumber(s.db, height)
+
+	log.Info("Reset sync service", "height", height)
+
+	go s.Start()
+}
+
 // SubscribeNewL1MsgsEvent registers a subscription of NewL1MsgsEvent and
 // starts sending event to the given channel.
 func (s *SyncService) SubscribeNewL1MsgsEvent(ch chan<- core.NewL1MsgsEvent) event.Subscription {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

For two typical errors in the logs:
* "failed to get batch chunk ranges, empty chunk block ranges": revert to a "safe" height, the updates are idempotent.
* "Unexpected queue index in SyncService    expected=805,224 got=805,329": revert to a height that contains the last synced L1 message.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
