### PR TITLE
feat(txpool): only try demoting txns from accounts that were active

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -1448,7 +1448,7 @@ func (pool *TxPool) reset(oldHead, newHead *types.Header) map[common.Address]boo
 					}
 				}
 				reinject = types.TxDifference(discarded, included)
-				collectAffectedAccounts(discarded)
+				collectAffectedAccounts(reinject)
 				collectAffectedAccounts(included)
 			}
 		}

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -2463,7 +2463,7 @@ func benchmarkPendingDemotion(b *testing.B, size int) {
 	// Benchmark the speed of pool validation
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		pool.demoteUnexecutables()
+		pool.demoteUnexecutables(nil)
 	}
 }
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 21        // Patch version component of the current release
+	VersionPatch = 22        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
txpool demotes pending txns only if their nonce is now lower than the nonce in the latest state or the account no longer has enough funds to cover the costs. Unless the account in question was active since the last txpool reorg, there is no way that it's nonce changed or balance decreased.