### PR TITLE
feat: update L2 base fee formula

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -55,12 +55,12 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, parentL1BaseF
 		return big.NewInt(10000000) // 0.01 Gwei
 	}
 	l2SequencerFee := big.NewInt(1000000) // 0.001 Gwei
-	provingFee := big.NewInt(33700000)    // 0.0337 Gwei
+	provingFee := big.NewInt(38200000)    // 0.0382 Gwei
 
-	// L1_base_fee * 0.0034
+	// L1_base_fee * 0.00017
 	verificationFee := parentL1BaseFee
-	verificationFee = new(big.Int).Mul(verificationFee, big.NewInt(34))
-	verificationFee = new(big.Int).Div(verificationFee, big.NewInt(10000))
+	verificationFee = new(big.Int).Mul(verificationFee, big.NewInt(17))
+	verificationFee = new(big.Int).Div(verificationFee, big.NewInt(100000))
 
 	baseFee := big.NewInt(0)
 	baseFee.Add(baseFee, l2SequencerFee)

--- a/consensus/misc/eip1559_test.go
+++ b/consensus/misc/eip1559_test.go
@@ -112,13 +112,13 @@ func TestCalcBaseFee(t *testing.T) {
 		parentL1BaseFee   int64
 		expectedL2BaseFee int64
 	}{
-		{0, 34700000},
-		{1000000000, 38100000},
-		{2000000000, 41500000},
-		{100000000000, 374700000},
-		{111111111111, 412477777},
-		{2164000000000, 7392300000},
-		{2931000000000, 10000000000}, // cap at max L2 base fee
+		{0, 39200000},
+		{1000000000, 39370000},
+		{2000000000, 39540000},
+		{100000000000, 56200000},
+		{111111111111, 58088888},
+		{2164000000000, 407080000},
+		{58592942000000, 10000000000}, // cap at max L2 base fee
 	}
 	for i, test := range tests {
 		if have, want := CalcBaseFee(config(), nil, big.NewInt(test.parentL1BaseFee)), big.NewInt(test.expectedL2BaseFee); have.Cmp(want) != 0 {

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -361,13 +361,13 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					mkDynamicCreationTx(0, 500000, common.Big0, misc.CalcBaseFee(config, genesis.Header(), parentL1BaseFee), tooBigInitCode[:]),
 				},
-				want: "could not apply tx 0 [0x8f780c3573ac61e2d7796f7b447afd0ad753623ed95bc99ef94eb083d9e0d039]: max initcode size exceeded: code size 49153 limit 49152",
+				want: "could not apply tx 0 [0xa31de6e26bd5ffba0ca91a2bc29fc2eaad6a6cfc5ad9ab6ffb69cac121e0125c]: max initcode size exceeded: code size 49153 limit 49152",
 			},
 			{ // ErrIntrinsicGas: Not enough gas to cover init code
 				txs: []*types.Transaction{
 					mkDynamicCreationTx(0, 54299, common.Big0, misc.CalcBaseFee(config, genesis.Header(), parentL1BaseFee), smallInitCode[:]),
 				},
-				want: "could not apply tx 0 [0xbf812bb88c3f53402b6cf5488ac89360595e524b65582b648d1f4ef197690e89]: intrinsic gas too low: have 54299, want 54300",
+				want: "could not apply tx 0 [0xf36b7d68cf239f956f7c36be26688a97aaa317ea5f5230d109bb30dbc8598ccb]: intrinsic gas too low: have 54299, want 54300",
 			},
 		} {
 			block := GenerateBadBlock(genesis, ethash.NewFaker(), tt.txs, gspec.Config)

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/common/prque"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	"github.com/scroll-tech/go-ethereum/core/rawdb"
 	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
@@ -1333,9 +1334,9 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	if reset != nil {
 		pool.demoteUnexecutables()
 		if reset.newHead != nil && pool.chainconfig.IsCurie(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
-			// note: we cannot predict the next block's base fee since it is set
-			// by the sequencer, so we use the current block's base fee instead.
-			pool.priced.SetBaseFee(reset.newHead.BaseFee)
+			l1BaseFee := fees.GetL1BaseFee(pool.currentState)
+			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead, l1BaseFee)
+			pool.priced.SetBaseFee(pendingBaseFee)
 		}
 		// Update all accounts to the latest known pending nonce
 		nonces := make(map[common.Address]uint64, len(pool.pending))

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/common/prque"
-	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	"github.com/scroll-tech/go-ethereum/core/rawdb"
 	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
@@ -1334,9 +1333,9 @@ func (pool *TxPool) runReorg(done chan struct{}, reset *txpoolResetRequest, dirt
 	if reset != nil {
 		pool.demoteUnexecutables()
 		if reset.newHead != nil && pool.chainconfig.IsCurie(new(big.Int).Add(reset.newHead.Number, big.NewInt(1))) {
-			l1BaseFee := fees.GetL1BaseFee(pool.currentState)
-			pendingBaseFee := misc.CalcBaseFee(pool.chainconfig, reset.newHead, l1BaseFee)
-			pool.priced.SetBaseFee(pendingBaseFee)
+			// note: we cannot predict the next block's base fee since it is set
+			// by the sequencer, so we use the current block's base fee instead.
+			pool.priced.SetBaseFee(reset.newHead.BaseFee)
 		}
 		// Update all accounts to the latest known pending nonce
 		nonces := make(map[common.Address]uint64, len(pool.pending))

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 22        // Patch version component of the current release
+	VersionPatch = 23        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Update L2 base fee according to new cost estimates.

One nuance is that geth's codebase uses `misc.CalcBaseFee` in a few places to predict the next block's base fee. In our case this does not work. For example, after deploying this change on the sequencer, `CalcBaseFee` will diverge on the sequencer and follower nodes (until they upgrade to a new release). Cases where we use `misc.CalcBaseFee`:
- [miner/scroll_worker.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/miner/scroll_worker.go#L464): No change needed.
- [core/tx_pool.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/core/tx_pool.go#L1338): ~~Changed in this PR to use the current base fee.~~ Follower nodes might manage txpool following a slightly inaccurate base fee estimation.
- [eth/gasprice/feehistory.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/eth/gasprice/feehistory.go#L99): Returned next base fee might be inaccurate.
- [internal/ethapi/api.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/internal/ethapi/api.go#L1414): Base fee returned for pending transaction might be inaccurate.
- [eth/catalyst/api.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/eth/catalyst/api.go#L151): Currently not used.
- [core/genesis.go](https://github.com/scroll-tech/go-ethereum/blob/develop/core/genesis.go#L320): Only used in genesis config, not relevant for us.
- [core/chain_makers.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/core/chain_makers.go#L302) and [core/state_processor_test.go](https://github.com/scroll-tech/go-ethereum/blob/cf1ca84e0e0f5fe96b6e004c16e111317c87a8ab/core/state_processor_test.go#L362): Tests.
- 


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes
