### PR TITLE
fix: account for tx subcircuit confidence factor

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -706,7 +706,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		return ErrOversizedData
 	}
 	// Reject transactions that cannot fit into a block even as a single transaction
-	if !pool.chainconfig.Scroll.IsValidBlockSize(tx.Size()) {
+	if !pool.chainconfig.Scroll.IsValidBlockSizeForMining(tx.Size()) {
 		return ErrOversizedData
 	}
 	// Check whether the init code size has been exceeded.

--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -742,7 +742,7 @@ func (w *worker) processTxn(tx *types.Transaction) (bool, error) {
 		return false, ErrUnexpectedL1MessageIndex
 	}
 
-	if !tx.IsL1MessageTx() && !w.chain.Config().Scroll.IsValidBlockSize(w.current.blockSize+tx.Size()) {
+	if !tx.IsL1MessageTx() && !w.chain.Config().Scroll.IsValidBlockSizeForMining(w.current.blockSize+tx.Size()) {
 		// can't fit this txn in this block, silently ignore and continue looking for more txns
 		return false, errors.New("tx too big")
 	}

--- a/params/config.go
+++ b/params/config.go
@@ -718,6 +718,11 @@ func (s ScrollConfig) IsValidBlockSize(size common.StorageSize) bool {
 	return s.MaxTxPayloadBytesPerBlock == nil || size <= common.StorageSize(*s.MaxTxPayloadBytesPerBlock)
 }
 
+// IsValidBlockSizeForMining is similar to IsValidBlockSize, but it accounts for the confidence factor in Rust CCC
+func (s ScrollConfig) IsValidBlockSizeForMining(size common.StorageSize) bool {
+	return s.IsValidBlockSize(size * (1.0 / 0.95))
+}
+
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.
 type EthashConfig struct{}
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 23        // Patch version component of the current release
+	VersionPatch = 24        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/pipeline/pipeline.go
+++ b/rollup/pipeline/pipeline.go
@@ -272,7 +272,7 @@ func (p *Pipeline) traceAndApplyStage(txsIn <-chan *types.Transaction) (<-chan e
 				continue
 			}
 
-			if !tx.IsL1MessageTx() && !p.chain.Config().Scroll.IsValidBlockSize(p.blockSize+tx.Size()) {
+			if !tx.IsL1MessageTx() && !p.chain.Config().Scroll.IsValidBlockSizeForMining(p.blockSize+tx.Size()) {
 				// can't fit this txn in this block, silently ignore and continue looking for more txns
 				sendCancellable(resCh, nil, p.ctx.Done())
 				continue


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

IsValidBlockSizeForMining is introduced to make sure that BlockValidator still considers old blocks valid which uses IsValidBlockSize.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
