### PR TITLE
fix(api): change gas_price to use pending block

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -68,8 +68,13 @@ func (s *PublicEthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) 
 	if err != nil {
 		return nil, err
 	}
-	if head := s.b.CurrentHeader(); head.BaseFee != nil {
-		tipcap.Add(tipcap, head.BaseFee)
+	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
+	block, err := s.b.BlockByNumberOrHash(ctx, bNrOrHash)
+	if err != nil {
+		return &hexutil.Big{}, err
+	}
+	if block.BaseFee() != nil {
+		tipcap.Add(tipcap, block.BaseFee())
 	}
 	return (*hexutil.Big)(tipcap), err
 }

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -71,7 +71,7 @@ func (s *PublicEthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) 
 	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
 	block, err := s.b.BlockByNumberOrHash(ctx, bNrOrHash)
 	if err != nil {
-		return &hexutil.Big{}, err
+		return nil, err
 	}
 	if block.BaseFee() != nil {
 		tipcap.Add(tipcap, block.BaseFee())

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -68,13 +68,9 @@ func (s *PublicEthereumAPI) GasPrice(ctx context.Context) (*hexutil.Big, error) 
 	if err != nil {
 		return nil, err
 	}
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.PendingBlockNumber)
-	block, err := s.b.BlockByNumberOrHash(ctx, bNrOrHash)
-	if err != nil {
-		return nil, err
-	}
-	if block.BaseFee() != nil {
-		tipcap.Add(tipcap, block.BaseFee())
+	pendingBlock, _ := s.b.PendingBlockAndReceipts()
+	if pendingBlock != nil && pendingBlock.BaseFee() != nil {
+		tipcap.Add(tipcap, pendingBlock.BaseFee())
 	}
 	return (*hexutil.Big)(tipcap), err
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -63,6 +63,7 @@ type Backend interface {
 	BlockByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Block, error)
 	BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error)
 	BlockByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*types.Block, error)
+	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
 	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	StateAt(root common.Hash) (*state.StateDB, error)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 24        // Patch version component of the current release
+	VersionPatch = 25        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

The eth_gasPrice API returns gas price based on latest block, but eth_estimateGas use gas price based on pending block. So if we use the eth_gasPrice API gas price to do an eth_estimateGas API call, there is a possibility it will fail and return `max fee per gas less than block base fee`. that's because if L1 gas spike and gas-oracle updates the l1BaseFee, the pending block baseFee will be higher than the one based on latest block.
So I think we could change eth_gasPrice API to return gas price based on pending block, that will prevent this issue, and provides a more accurate suggest gas price.

See more details here: https://www.notion.so/scrollzkp/l2geth-returns-wrong-gas-price-issue-1297792d22af8045bbb1e57ff974e6c7


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced gas price suggestion logic for improved accuracy.
	- Streamlined transaction sending process with clearer method naming.
	- Added method for retrieving pending block data and receipts.

- **Bug Fixes**
	- Improved error handling pathways for block retrieval in gas price calculations.

- **Chores**
	- Incremented patch version from 24 to 25, reflecting updates in the software release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->