### PR TITLE
fix: account proof generation and preimage storage

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -357,13 +357,8 @@ func (s *StateDB) GetState(addr common.Address, hash common.Hash) common.Hash {
 
 // GetProof returns the Merkle proof for a given account.
 func (s *StateDB) GetProof(addr common.Address) ([][]byte, error) {
-	return s.GetProofByHash(common.BytesToHash(addr.Bytes()))
-}
-
-// GetProofByHash returns the Merkle proof for a given account.
-func (s *StateDB) GetProofByHash(addrHash common.Hash) ([][]byte, error) {
 	var proof zkproof.ProofList
-	err := s.trie.Prove(addrHash[:] /*, 0*/, &proof)
+	err := s.trie.Prove(addr.Bytes(), &proof)
 	return proof, err
 }
 

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -176,7 +176,7 @@ func (mt *ZkTrie) TryUpdate(key []byte, vFlag uint32, vPreimage []Byte32) error 
 	mt.lock.Lock()
 	defer mt.lock.Unlock()
 
-	mt.secKeyCache[string(nodeKey.Bytes())] = key
+	mt.secKeyCache[string(nodeKey.Bytes())] = append([]byte{}, key...)
 
 	newRootKey, _, err := mt.addLeaf(newLeafNode, mt.rootKey, 0, path)
 	// sanity check
@@ -293,8 +293,9 @@ func (mt *ZkTrie) commit(nodeHash *Hash, path []byte, nodeSet *trienode.NodeSet,
 
 	if node.Type == NodeTypeLeaf_New {
 		if mt.preimages != nil {
+			nodeKeyBytes := node.NodeKey.Bytes()
 			mt.preimages.insertPreimage(map[common.Hash][]byte{
-				common.BytesToHash(nodeHash.Bytes()): node.NodeKey.Bytes(),
+				common.BytesToHash(nodeKeyBytes): mt.secKeyCache[string(nodeKeyBytes)],
 			})
 		}
 		if collectLeaf {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

we should also use `--cache.preimages` if we want a node to be able to generate traces for proving.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes
