### PR TITLE
internal/ethapi: eth_call block parameter is optional (#28165)

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1087,8 +1087,12 @@ func (e *revertError) ErrorData() interface{} {
 //
 // Note, this function doesn't make and changes in the state/blockchain and is
 // useful to execute and retrieve values.
-func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Bytes, error) {
-	result, err := DoCall(ctx, s.b, args, blockNrOrHash, overrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
+func (s *PublicBlockChainAPI) Call(ctx context.Context, args TransactionArgs, blockNrOrHash *rpc.BlockNumberOrHash, overrides *StateOverride) (hexutil.Bytes, error) {
+	if blockNrOrHash == nil {
+		latest := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
+		blockNrOrHash = &latest
+	}
+	result, err := DoCall(ctx, s.b, args, *blockNrOrHash, overrides, s.b.RPCEVMTimeout(), s.b.RPCGasCap())
 	if err != nil {
 		return nil, err
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 25        // Patch version component of the current release
+	VersionPatch = 26        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

this PR cherry-picks this commit: https://github.com/ethereum/go-ethereum/commit/adb9b319c9c61f092755000bf0fc4b3349f5cbbc

since in the API spec, the block tag is optional: https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/eth/execute.yaml#L9

as the cherry-picked PR described: "So apparently in the spec the base block parameter of eth_call is optional. I agree that "latest" is a sane default for this that most people would use."

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility in the `Call` method, allowing for optional block number or hash input.
  
- **Bug Fixes**
	- Improved error handling for revert reasons in the `Call` method.

- **Chores**
	- Incremented patch version from 25 to 26 for the go-ethereum library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->