### PR TITLE
fix(GPO): make default gas tip configurable

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -741,9 +741,9 @@ var (
 		Usage: "Number of pending transactions to consider the network congested and suggest a minimum tip cap",
 		Value: ethconfig.Defaults.GPO.CongestedThreshold,
 	}
-	GpoDefaultGasTipFlag = cli.Int64Flag{
-		Name:  "gpo.defaultgastip",
-		Usage: "Default minimum tip cap (in wei) to be used after Curie fork (EIP-1559)",
+	GpoDefaultGasTipCapFlag = cli.Int64Flag{
+		Name:  "gpo.DefaultGasTipCap",
+		Usage: "Default minimum gas tip cap (in wei) to be used after Curie fork (EIP-1559)",
 	}
 
 	// Metrics flags
@@ -1454,8 +1454,8 @@ func setGPO(ctx *cli.Context, cfg *gasprice.Config, light bool) {
 	if ctx.GlobalIsSet(GpoCongestionThresholdFlag.Name) {
 		cfg.CongestedThreshold = ctx.GlobalInt(GpoCongestionThresholdFlag.Name)
 	}
-	if ctx.GlobalIsSet(GpoDefaultGasTipFlag.Name) {
-		cfg.DefaultGasTip = big.NewInt(ctx.GlobalInt64(GpoDefaultGasTipFlag.Name))
+	if ctx.GlobalIsSet(GpoDefaultGasTipCapFlag.Name) {
+		cfg.DefaultGasTipCap = big.NewInt(ctx.GlobalInt64(GpoDefaultGasTipCapFlag.Name))
 	}
 }
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -742,7 +742,7 @@ var (
 		Value: ethconfig.Defaults.GPO.CongestedThreshold,
 	}
 	GpoDefaultGasTipCapFlag = cli.Int64Flag{
-		Name:  "gpo.DefaultGasTipCap",
+		Name:  "gpo.defaultgastipcap",
 		Usage: "Default minimum gas tip cap (in wei) to be used after Curie fork (EIP-1559)",
 	}
 

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -743,7 +743,7 @@ var (
 	}
 	GpoDefaultGasTipCapFlag = cli.Int64Flag{
 		Name:  "gpo.defaultgastipcap",
-		Usage: "Default minimum gas tip cap (in wei) to be used after Curie fork (EIP-1559)",
+		Usage: "Default minimum gas tip cap (in wei) to be used after Curie fork (EIP-1559) (default: 100)",
 	}
 
 	// Metrics flags

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -741,6 +741,10 @@ var (
 		Usage: "Number of pending transactions to consider the network congested and suggest a minimum tip cap",
 		Value: ethconfig.Defaults.GPO.CongestedThreshold,
 	}
+	GpoDefaultGasTipFlag = cli.Int64Flag{
+		Name:  "gpo.defaultgastip",
+		Usage: "Default minimum tip cap (in wei) to be used after Curie fork (EIP-1559)",
+	}
 
 	// Metrics flags
 	MetricsEnabledFlag = cli.BoolFlag{
@@ -1449,6 +1453,9 @@ func setGPO(ctx *cli.Context, cfg *gasprice.Config, light bool) {
 	}
 	if ctx.GlobalIsSet(GpoCongestionThresholdFlag.Name) {
 		cfg.CongestedThreshold = ctx.GlobalInt(GpoCongestionThresholdFlag.Name)
+	}
+	if ctx.GlobalIsSet(GpoDefaultGasTipFlag.Name) {
+		cfg.DefaultGasTip = big.NewInt(ctx.GlobalInt64(GpoDefaultGasTipFlag.Name))
 	}
 }
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -40,12 +40,12 @@ var (
 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
 	DefaultIgnorePrice = big.NewInt(1 * params.Wei)
 	DefaultBasePrice   = big.NewInt(0)
-	// DefaultGasTip is set to 100 wei instead of 1 wei for the following reasons:
+	// DefaultGasTipCap is set to 100 wei instead of 1 wei for the following reasons:
 	// 1. It prevents issues with very low tip values (e.g., 1 wei):
-	//    - Transaction pools commonly prevent replacing transactions with the same tip cap.
+	//    - Transaction pools commonly prevent replacing transactions with the same gas tip cap.
 	//    - Extremely low tips like 1 wei may fail to increase due to rounding in integer arithmetic of SDK implementations (e.g. 1 wei * 1.5 = 1 wei).
-	// 2. The cost of gas tip 100 wei is negligible compared to base fee normally.
-	DefaultGasTip = big.NewInt(100) // Default minimum tip cap in wei (used after Curie/EIP-1559).
+	// 2. The cost of gas tip cap 100 wei is negligible compared to base fee normally.
+	DefaultGasTipCap = big.NewInt(100) // Default minimum gas tip cap in wei (used after Curie/EIP-1559).
 )
 
 type Config struct {
@@ -58,7 +58,7 @@ type Config struct {
 	IgnorePrice        *big.Int `toml:",omitempty"`
 	CongestedThreshold int      // Number of pending transactions to consider the network congested and suggest a minimum tip cap.
 	DefaultBasePrice   *big.Int `toml:",omitempty"` // Base price to set when CongestedThreshold is reached before Curie (EIP 1559).
-	DefaultGasTip      *big.Int `toml:",omitempty"` // Default minimum tip cap to use after Curie (EIP 1559).
+	DefaultGasTipCap   *big.Int `toml:",omitempty"` // Default minimum gas tip cap to use after Curie (EIP 1559).
 }
 
 // OracleBackend includes all necessary background APIs for oracle.
@@ -89,7 +89,7 @@ type Oracle struct {
 	maxHeaderHistory, maxBlockHistory int
 	congestedThreshold                int      // Number of pending transactions to consider the network congested and suggest a minimum tip cap.
 	defaultBasePrice                  *big.Int // Base price to set when CongestedThreshold is reached before Curie (EIP 1559).
-	defaultGasTip                     *big.Int // Default gas tip to suggest when the network is not congested.
+	defaultGasTipCap                  *big.Int // Default gas tip cap to suggest when the network is not congested.
 	historyCache                      *lru.Cache
 }
 
@@ -141,10 +141,10 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 		defaultBasePrice = DefaultBasePrice
 		log.Warn("Sanitizing invalid gasprice oracle default base price", "provided", params.DefaultBasePrice, "updated", defaultBasePrice)
 	}
-	defaultGasTip := params.DefaultGasTip
-	if defaultGasTip == nil || defaultGasTip.Int64() < 0 {
-		defaultGasTip = DefaultGasTip
-		log.Warn("Sanitizing invalid gasprice oracle default gas tip", "provided", params.DefaultGasTip, "updated", defaultGasTip)
+	defaultGasTipCap := params.DefaultGasTipCap
+	if defaultGasTipCap == nil || defaultGasTipCap.Int64() < 0 {
+		defaultGasTipCap = DefaultGasTipCap
+		log.Warn("Sanitizing invalid gasprice oracle default gas tip cap", "provided", params.DefaultGasTipCap, "updated", DefaultGasTipCap)
 	}
 
 	cache, _ := lru.New(2048)
@@ -171,7 +171,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 		maxBlockHistory:    maxBlockHistory,
 		congestedThreshold: congestedThreshold,
 		defaultBasePrice:   defaultBasePrice,
-		defaultGasTip:      defaultGasTip,
+		defaultGasTipCap:   defaultGasTipCap,
 		historyCache:       cache,
 	}
 }
@@ -209,9 +209,9 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	// high-priced txs are causing the suggested tip cap to be high.
 	pendingTxCount, _ := oracle.backend.StatsWithMinBaseFee(head.BaseFee)
 	if pendingTxCount < oracle.congestedThreshold {
-		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return defaultGasTip wei as the tip cap,
+		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return defaultGasTipCap wei as the tip cap,
 		// as the base fee is set separately or added manually for legacy transactions.
-		price := oracle.defaultGasTip
+		price := oracle.defaultGasTipCap
 		if !oracle.backend.ChainConfig().IsCurie(head.Number) {
 			price = oracle.defaultBasePrice
 		}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -89,7 +89,7 @@ type Oracle struct {
 	maxHeaderHistory, maxBlockHistory int
 	congestedThreshold                int      // Number of pending transactions to consider the network congested and suggest a minimum tip cap.
 	defaultBasePrice                  *big.Int // Base price to set when CongestedThreshold is reached before Curie (EIP 1559).
-	defaultGasTipCap                  *big.Int // Default gas tip cap to suggest when the network is not congested.
+	defaultGasTipCap                  *big.Int // Default gas tip cap to suggest after Curie (EIP 1559) when the network is not congested.
 	historyCache                      *lru.Cache
 }
 

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -171,6 +171,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 		maxBlockHistory:    maxBlockHistory,
 		congestedThreshold: congestedThreshold,
 		defaultBasePrice:   defaultBasePrice,
+		defaultGasTip:      defaultGasTip,
 		historyCache:       cache,
 	}
 }

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -208,9 +208,8 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	// high-priced txs are causing the suggested tip cap to be high.
 	pendingTxCount, _ := oracle.backend.StatsWithMinBaseFee(head.BaseFee)
 	if pendingTxCount < oracle.congestedThreshold {
-		// Determine the suggested gas price based on the network configuration:
-		// - Before Curie (EIP-1559): total gas price = base fee + tip cap.
-		// - After Curie (EIP-1559): use the default tip cap.
+		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return defaultGasTip wei as the tip cap,
+		// as the base fee is set separately or added manually for legacy transactions.
 		price := oracle.defaultGasTip
 		if !oracle.backend.ChainConfig().IsCurie(head.Number) {
 			price = oracle.defaultBasePrice

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -142,7 +142,7 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 		log.Warn("Sanitizing invalid gasprice oracle default base price", "provided", params.DefaultBasePrice, "updated", defaultBasePrice)
 	}
 	defaultGasTipCap := params.DefaultGasTipCap
-	if defaultGasTipCap == nil || defaultGasTipCap.Int64() < 0 {
+	if defaultGasTipCap == nil || defaultGasTipCap.Int64() <= 0 {
 		defaultGasTipCap = DefaultGasTipCap
 		log.Warn("Sanitizing invalid gasprice oracle default gas tip cap", "provided", params.DefaultGasTipCap, "updated", DefaultGasTipCap)
 	}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -40,6 +40,12 @@ var (
 	DefaultMaxPrice    = big.NewInt(500 * params.GWei)
 	DefaultIgnorePrice = big.NewInt(1 * params.Wei)
 	DefaultBasePrice   = big.NewInt(0)
+	// DefaultGasTip is set to 100 wei instead of 1 wei for the following reasons:
+	// 1. It prevents issues with very low tip values (e.g., 1 wei):
+	//    - Transaction pools commonly prevent replacing transactions with the same tip cap.
+	//    - Extremely low tips like 1 wei may fail to increase due to rounding in integer arithmetic of SDK implementations (e.g. 1 wei * 1.5 = 1 wei).
+	// 2. The cost of gas tip 100 wei is negligible compared to base fee normally.
+	DefaultGasTip = big.NewInt(100) // Default minimum tip cap in wei (used after Curie/EIP-1559).
 )
 
 type Config struct {
@@ -52,6 +58,7 @@ type Config struct {
 	IgnorePrice        *big.Int `toml:",omitempty"`
 	CongestedThreshold int      // Number of pending transactions to consider the network congested and suggest a minimum tip cap.
 	DefaultBasePrice   *big.Int `toml:",omitempty"` // Base price to set when CongestedThreshold is reached before Curie (EIP 1559).
+	DefaultGasTip      *big.Int `toml:",omitempty"` // Default minimum tip cap to use after Curie (EIP 1559).
 }
 
 // OracleBackend includes all necessary background APIs for oracle.
@@ -82,6 +89,7 @@ type Oracle struct {
 	maxHeaderHistory, maxBlockHistory int
 	congestedThreshold                int      // Number of pending transactions to consider the network congested and suggest a minimum tip cap.
 	defaultBasePrice                  *big.Int // Base price to set when CongestedThreshold is reached before Curie (EIP 1559).
+	defaultGasTip                     *big.Int // Default gas tip to suggest when the network is not congested.
 	historyCache                      *lru.Cache
 }
 
@@ -132,6 +140,11 @@ func NewOracle(backend OracleBackend, params Config) *Oracle {
 	if defaultBasePrice == nil || defaultBasePrice.Int64() < 0 {
 		defaultBasePrice = DefaultBasePrice
 		log.Warn("Sanitizing invalid gasprice oracle default base price", "provided", params.DefaultBasePrice, "updated", defaultBasePrice)
+	}
+	defaultGasTip := params.DefaultGasTip
+	if defaultGasTip == nil || defaultGasTip.Int64() < 0 {
+		defaultGasTip = DefaultGasTip
+		log.Warn("Sanitizing invalid gasprice oracle default gas tip", "provided", params.DefaultGasTip, "updated", defaultGasTip)
 	}
 
 	cache, _ := lru.New(2048)
@@ -195,14 +208,10 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	// high-priced txs are causing the suggested tip cap to be high.
 	pendingTxCount, _ := oracle.backend.StatsWithMinBaseFee(head.BaseFee)
 	if pendingTxCount < oracle.congestedThreshold {
-		// Before Curie (EIP-1559), we need to return the total suggested gas price (base fee + tip cap).
-		// After Curie, a minimum tip cap of 100 wei is used to avoid issues with extremely low values like 1 wei:
-		// 1. txpool protections:
-		//   - txpool commonly prevents replacing transactions with the same tip cap.
-		//   - A 1 wei tip may fail to increase (e.g., 1.1x rounds down to 1 wei) due to integer arithmetic.
-		// 2. Negligible cost:
-		//   - Both 100 wei and 1 wei are almost zero in cost, so this change has no noticeable impact on users.
-		price := big.NewInt(100)
+		// Determine the suggested gas price based on the network configuration:
+		// - Before Curie (EIP-1559): total gas price = base fee + tip cap.
+		// - After Curie (EIP-1559): use the default tip cap.
+		price := oracle.defaultGasTip
 		if !oracle.backend.ChainConfig().IsCurie(head.Number) {
 			price = oracle.defaultBasePrice
 		}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -195,13 +195,14 @@ func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
 	// high-priced txs are causing the suggested tip cap to be high.
 	pendingTxCount, _ := oracle.backend.StatsWithMinBaseFee(head.BaseFee)
 	if pendingTxCount < oracle.congestedThreshold {
-		// Before Curie (EIP-1559), we need to return the total suggested gas price. After Curie we return 2 wei as the tip cap,
-		// as the base fee is set separately or added manually for legacy transactions.
-		// 1. Set price to at least 1 as otherwise tx with a 0 tip might be filtered out by the default mempool config.
-		// 2. Since oracle.ignoreprice was set to 2 (DefaultIgnorePrice) before by default, we need to set the price
-		//    to 2 to avoid filtering in oracle.getBlockValues() by nodes that did not yet update to this version.
-		//    In the future we can set the price to 1 wei.
-		price := big.NewInt(2)
+		// Before Curie (EIP-1559), we need to return the total suggested gas price (base fee + tip cap).
+		// After Curie, a minimum tip cap of 100 wei is used to avoid issues with extremely low values like 1 wei:
+		// 1. txpool protections:
+		//   - txpool commonly prevents replacing transactions with the same tip cap.
+		//   - A 1 wei tip may fail to increase (e.g., 1.1x rounds down to 1 wei) due to integer arithmetic.
+		// 2. Negligible cost:
+		//   - Both 100 wei and 1 wei are almost zero in cost, so this change has no noticeable impact on users.
+		price := big.NewInt(100)
 		if !oracle.backend.ChainConfig().IsCurie(head.Number) {
 			price = oracle.defaultBasePrice
 		}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -41,10 +41,10 @@ var (
 	DefaultIgnorePrice = big.NewInt(1 * params.Wei)
 	DefaultBasePrice   = big.NewInt(0)
 	// DefaultGasTipCap is set to 100 wei instead of 1 wei for the following reasons:
-	// 1. It prevents issues with very low tip values (e.g., 1 wei):
-	//    - Transaction pools commonly prevent replacing transactions with the same gas tip cap.
-	//    - Extremely low tips like 1 wei may fail to increase due to rounding in integer arithmetic of SDK implementations (e.g. 1 wei * 1.5 = 1 wei).
-	// 2. The cost of gas tip cap 100 wei is negligible compared to base fee normally.
+	// 1. Very low tip values (e.g. 1 wei) can cause issues because transaction pools often reject replacing transactions
+	//    with the same gas tip cap. This becomes problematic when low tips like 1 wei fail to increase due to rounding
+	//    in some SDK implementations (e.g. 1 wei * 1.5 = 1 wei).
+	// 2. The cost of a gas tip cap of 100 wei is negligible compared to the base fee in most cases.
 	DefaultGasTipCap = big.NewInt(100) // Default minimum gas tip cap in wei (used after Curie/EIP-1559).
 )
 

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -213,7 +213,7 @@ func TestSuggestTipCap(t *testing.T) {
 
 func TestSuggestTipCapCongestedThreshold(t *testing.T) {
 	expectedDefaultBasePricePreCurie := big.NewInt(2000)
-	expectedDefaultBasePricePostCurie := big.NewInt(1)
+	expectedDefaultBasePricePostCurie := big.NewInt(100)
 
 	config := Config{
 		Blocks:             3,

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 26        // Patch version component of the current release
+	VersionPatch = 27        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR makes the default gas tip configurable. The default value has been updated to 100 wei (from previous 2 wei) for the following reasons:
- Prevents issues with very low tip values (e.g., 1 wei):
    - Transaction pools often reject transactions with the same tip cap.
    - Extremely low tips (e.g., 1 wei) can fail to increase due to rounding issues in integer arithmetic (e.g., 1 wei * 1.5 = 1 wei).
- Negligible cost:
    - A gas tip of 100 wei is insignificant compared to the base fee under normal conditions.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated minimum tip cap for gas price suggestions from 1 wei to 100 wei to enhance transaction processing.
	- Introduced a new command-line flag to specify a default minimum gas tip cap for transactions.

- **Bug Fixes**
	- Adjusted expected gas price behavior in tests to reflect the updated minimum tip cap.

- **Chores**
	- Incremented patch version from 28 to 29 for the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->