### PR TITLE
fix(async-ccc): print whole block hash and tx hash when failure

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -202,7 +202,7 @@ func New(stack *node.Node, config *ethconfig.Config, l1Client sync_service.EthCl
 	if config.CheckCircuitCapacity {
 		eth.asyncChecker = ccc.NewAsyncChecker(eth.blockchain, config.CCCMaxWorkers, false)
 		eth.asyncChecker.WithOnFailingBlock(func(b *types.Block, err error) {
-			log.Warn("block failed CCC check, it will be reorged by the sequencer", "hash", b.Hash(), "err", err)
+			log.Warn("block failed CCC check, it will be reorged by the sequencer", "hash", b.Hash().Hex(), "err", err)
 		})
 		eth.blockchain.Validator().WithAsyncValidator(eth.asyncChecker.Check)
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 26        // Patch version component of the current release
+	VersionPatch = 27        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 7         // Minor version component of the current release
-	VersionPatch = 27        // Patch version component of the current release
+	VersionPatch = 28        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/pipeline/pipeline.go
+++ b/rollup/pipeline/pipeline.go
@@ -439,6 +439,7 @@ func (p *Pipeline) cccStage(candidates <-chan *BlockCandidate, deadline time.Tim
 					lastTxn := candidate.Txs[candidate.Txs.Len()-1]
 					cccTimer.UpdateSince(cccStart)
 					if err != nil {
+						log.Warn("failed to apply CCC", "txHash", lastTxn.Hash().Hex(), "err", err)
 						resultCh <- &Result{
 							OverflowingTx:    lastTxn,
 							OverflowingTrace: candidate.LastTrace,


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Migrate the changes from https://github.com/scroll-tech/go-ethereum/pull/1092.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved logging for block validation and CCC application failures to enhance error visibility.
- **Bug Fixes**
	- Updated logging format for block hashes to a more readable hexadecimal representation.
- **Chores**
	- Incremented version patch from 27 to 28 to indicate a new patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->