### PR TITLE
feat: enable p256Verify in EuclidV2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test: all
 	# genesis test
 	cd ${PWD}/cmd/geth; go test -test.run TestCustomGenesis
 	# module test
-	$(GORUN) build/ci.go test ./consensus ./core ./eth ./miner ./node ./trie ./rollup/...
+	$(GORUN) build/ci.go test ./consensus ./core/... ./eth ./miner ./node ./trie ./rollup/...
 
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ test: all
 	# genesis test
 	cd ${PWD}/cmd/geth; go test -test.run TestCustomGenesis
 	# module test
-	$(GORUN) build/ci.go test ./consensus ./core/... ./eth ./miner ./node ./trie ./rollup/...
+	$(GORUN) build/ci.go test ./consensus ./core ./eth ./miner ./node ./trie ./rollup/...
+	# RIP-7212 (secp256r1) precompiled contract test
+	cd ${PWD}/core/vm; go test -v -run=^TestPrecompiledP256 -bench=^BenchmarkPrecompiledP256
 
 lint: ## Run linters.
 	$(GORUN) build/ci.go lint

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -155,12 +155,6 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{18}): &bls12381MapG2{},
 }
 
-// PrecompiledContractsP256Verify contains the precompiled Ethereum
-// contract specified in RIP-7212. This is exported for testing purposes.
-var PrecompiledContractsP256Verify = map[common.Address]PrecompiledContract{
-	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
-}
-
 var (
 	PrecompiledAddressesEuclidV2   []common.Address
 	PrecompiledAddressesBernoulli  []common.Address

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -126,6 +126,21 @@ var PrecompiledContractsBernoulli = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{9}): &blake2FDisabled{},
 }
 
+// PrecompiledContractsEuclidV2 contains the default set of pre-compiled Ethereum
+// contracts used in the EuclidV2 release. Same as Bernoulli and adds p256Verify
+var PrecompiledContractsEuclidV2 = map[common.Address]PrecompiledContract{
+	common.BytesToAddress([]byte{1}):          &ecrecover{},
+	common.BytesToAddress([]byte{2}):          &sha256hash{},
+	common.BytesToAddress([]byte{3}):          &ripemd160hashDisabled{},
+	common.BytesToAddress([]byte{4}):          &dataCopy{},
+	common.BytesToAddress([]byte{5}):          &bigModExp{eip2565: true},
+	common.BytesToAddress([]byte{6}):          &bn256AddIstanbul{},
+	common.BytesToAddress([]byte{7}):          &bn256ScalarMulIstanbul{},
+	common.BytesToAddress([]byte{8}):          &bn256PairingIstanbul{},
+	common.BytesToAddress([]byte{9}):          &blake2FDisabled{},
+	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
+}
+
 // PrecompiledContractsBLS contains the set of pre-compiled Ethereum
 // contracts specified in EIP-2537. These are exported for testing purposes.
 var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
@@ -141,12 +156,13 @@ var PrecompiledContractsBLS = map[common.Address]PrecompiledContract{
 }
 
 // PrecompiledContractsP256Verify contains the precompiled Ethereum
-// contract specified in EIP-7212/RIP-7212. This is exported for testing purposes.
+// contract specified in RIP-7212. This is exported for testing purposes.
 var PrecompiledContractsP256Verify = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{0x01, 0x00}): &p256Verify{},
 }
 
 var (
+	PrecompiledAddressesEuclidV2   []common.Address
 	PrecompiledAddressesBernoulli  []common.Address
 	PrecompiledAddressesArchimedes []common.Address
 	PrecompiledAddressesBerlin     []common.Address
@@ -174,11 +190,16 @@ func init() {
 	for k := range PrecompiledContractsBernoulli {
 		PrecompiledAddressesBernoulli = append(PrecompiledAddressesBernoulli, k)
 	}
+	for k := range PrecompiledContractsEuclidV2 {
+		PrecompiledAddressesEuclidV2 = append(PrecompiledAddressesEuclidV2, k)
+	}
 }
 
 // ActivePrecompiles returns the precompiles enabled with the current configuration.
 func ActivePrecompiles(rules params.Rules) []common.Address {
 	switch {
+	case rules.IsEuclidV2:
+		return PrecompiledAddressesEuclidV2
 	case rules.IsBernoulli:
 		return PrecompiledAddressesBernoulli
 	case rules.IsArchimedes:

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -46,6 +46,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsEuclidV2:
+		precompiles = PrecompiledContractsEuclidV2
 	case evm.chainRules.IsBernoulli:
 		precompiles = PrecompiledContractsBernoulli
 	case evm.chainRules.IsArchimedes:

--- a/params/config.go
+++ b/params/config.go
@@ -1158,6 +1158,6 @@ func (c *ChainConfig) Rules(num *big.Int, time uint64) Rules {
 		IsCurie:          c.IsCurie(num),
 		IsDarwin:         c.IsDarwin(time),
 		IsEuclid:         c.IsEuclid(time),
-    IsEuclidV2:       c.IsEuclidV2(time),
+		IsEuclidV2:       c.IsEuclidV2(time),
 	}
 }

--- a/params/config.go
+++ b/params/config.go
@@ -639,6 +639,7 @@ type ChainConfig struct {
 	DarwinTime          *uint64  `json:"darwinTime,omitempty"`          // Darwin switch time (nil = no fork, 0 = already on darwin)
 	DarwinV2Time        *uint64  `json:"darwinv2Time,omitempty"`        // DarwinV2 switch time (nil = no fork, 0 = already on darwinv2)
 	EuclidTime          *uint64  `json:"euclidTime,omitempty"`          // Euclid switch time (nil = no fork, 0 = already on euclid)
+	EuclidV2Time        *uint64  `json:"euclidv2Time,omitempty"`        // EuclidV2 switch time (nil = no fork, 0 = already on euclidv2)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -916,7 +917,7 @@ func (c *ChainConfig) IsEuclid(now uint64) bool {
 
 // IsEuclidV2 returns whether time is either equal to the EuclidV2 fork time or greater.
 func (c *ChainConfig) IsEuclidV2(now uint64) bool {
-	return false // TODO: add EuclidV2 fork time
+	return isForkedTime(now, c.EuclidV2Time)
 }
 
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.

--- a/params/config.go
+++ b/params/config.go
@@ -910,7 +910,7 @@ func (c *ChainConfig) IsDarwinV2(now uint64) bool {
 	return isForkedTime(now, c.DarwinV2Time)
 }
 
-// IsEuclid returns whether time is either equal to the Darwin fork time or greater.
+// IsEuclid returns whether time is either equal to the Euclid fork time or greater.
 func (c *ChainConfig) IsEuclid(now uint64) bool {
 	return isForkedTime(now, c.EuclidTime)
 }

--- a/params/config.go
+++ b/params/config.go
@@ -878,14 +878,19 @@ func (c *ChainConfig) IsCurie(num *big.Int) bool {
 	return isForked(c.CurieBlock, num)
 }
 
-// IsDarwin returns whether num is either equal to the Darwin fork block or greater.
+// IsDarwin returns whether time is either equal to the Darwin fork time or greater.
 func (c *ChainConfig) IsDarwin(now uint64) bool {
 	return isForkedTime(now, c.DarwinTime)
 }
 
-// IsDarwinV2 returns whether num is either equal to the DarwinV2 fork block or greater.
+// IsDarwinV2 returns whether time is either equal to the DarwinV2 fork time or greater.
 func (c *ChainConfig) IsDarwinV2(now uint64) bool {
 	return isForkedTime(now, c.DarwinV2Time)
+}
+
+// IsEuclidV2 returns whether time is either equal to the EuclidV2 fork time or greater.
+func (c *ChainConfig) IsEuclidV2(now uint64) bool {
+	return false // TODO: add EuclidV2 fork time
 }
 
 // IsTerminalPoWBlock returns whether the given block is the last block of PoW stage.
@@ -1100,7 +1105,7 @@ type Rules struct {
 	IsHomestead, IsEIP150, IsEIP155, IsEIP158               bool
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon, IsArchimedes, IsShanghai            bool
-	IsBernoulli, IsCurie, IsDarwin                          bool
+	IsBernoulli, IsCurie, IsDarwin, IsEuclidV2              bool
 }
 
 // Rules ensures c's ChainID is not nil.
@@ -1126,5 +1131,6 @@ func (c *ChainConfig) Rules(num *big.Int, time uint64) Rules {
 		IsBernoulli:      c.IsBernoulli(num),
 		IsCurie:          c.IsCurie(num),
 		IsDarwin:         c.IsDarwin(time),
+		IsEuclidV2:       c.IsEuclidV2(time),
 	}
 }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR adds the fork activation of `RIP-7212` (`p256Verify`) precompile in `EuclidV2`. together with other small tweaks and typos fixes, including:
- Add RIP-7212 (secp256r1) precompiled contract unit tests to CI.
- Remove "EIP-7212" naming from precompile comments, which is consistent with the latest version of go implementation [here](https://github.com/ulerdogan/go-ethereum/pull/1).
- Fix time-based fork comment: change "block" to "time", which is consistent with the upstream geth's comment style. [An example here](https://github.com/ethereum/go-ethereum/blob/release/1.14/params/config.go#L513).

Revisit of the implementation:
- exactly the same as [this latest implementation](https://github.com/ulerdogan/go-ethereum/pull/1), the main difference from [the original pr](https://github.com/ethereum/go-ethereum/pull/27540) lines in removing [a check of reference point](https://github.com/ulerdogan/go-ethereum/blob/cec0b058115282168c5afc5197de3f6b5479dc4a/crypto/secp256r1/publickey.go#L16-L19) in the precompile, the check is duplicated based on [this comment](https://github.com/ethereum-optimism/op-geth/pull/168#discussion_r1575468793), which is already checked in [elliptic.P256().IsOnCurve(x, y)](https://github.com/ulerdogan/go-ethereum/blob/cec0b058115282168c5afc5197de3f6b5479dc4a/crypto/secp256r1/publickey.go#L12), the test vectors also cover this case [here](https://github.com/scroll-tech/go-ethereum/blob/91262060b77d99303c2af9bf93f5daadc8cab558/core/vm/testdata/precompiles/p256Verify.json#L5448-L5468).
- Test vectors: comprehensive tests based on `p256r1` test vectors in [this repo](https://github.com/C2SP/wycheproof), which is first prepared [in this comment](https://github.com/ethereum-optimism/op-geth/pull/168#issuecomment-1933241701). The test vectors in our repo are [here](https://github.com/scroll-tech/go-ethereum/blob/91262060b77d99303c2af9bf93f5daadc8cab558/core/vm/testdata/precompiles/p256Verify.json).

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced support for the EuclidV2 upgrade, expanding smart contract precompilation and improving chain rule processing.
  - Added a new method for checking EuclidV2 fork time.
- **Bug Fixes**
  - Clarified existing methods to ensure they operate based on time comparisons rather than block number comparisons.
- **Tests**
  - Added new test commands to verify the functionality of the updated contract features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->