### PR TITLE
feat: add migration checker cmd

### DIFF
--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
-	"github.com/scroll-tech/go-ethereum/crypto"
 	"github.com/scroll-tech/go-ethereum/ethdb/leveldb"
 	"github.com/scroll-tech/go-ethereum/rlp"
 	"github.com/scroll-tech/go-ethereum/trie"
@@ -110,39 +110,16 @@ func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leaf
 	mptLeafCh := loadMPT(mptTrie, top)
 	zkLeafCh := loadZkTrie(zkTrie, top, paranoid)
 
-	mptLeafMap := <-mptLeafCh
-	zkLeafMap := <-zkLeafCh
+	mptLeafs := <-mptLeafCh
+	zkLeafs := <-zkLeafCh
 
-	if len(mptLeafMap) != len(zkLeafMap) {
-		panic(fmt.Sprintf("%s MPT and ZK trie leaf count mismatch: MPT: %d, ZK: %d", label, len(mptLeafMap), len(zkLeafMap)))
+	if len(mptLeafs) != len(zkLeafs) {
+		panic(fmt.Sprintf("%s MPT and ZK trie leaf count mismatch: MPT: %d, ZK: %d", label, len(mptLeafs), len(zkLeafs)))
 	}
 
-	for preimageKey, zkValue := range zkLeafMap {
-		if top {
-			// ZkTrie pads preimages with 0s to make them 32 bytes.
-			// So we might need to clear those zeroes here since we need 20 byte addresses at top level (ie state trie)
-			if len(preimageKey) > 20 {
-				for _, b := range []byte(preimageKey)[20:] {
-					if b != 0 {
-						panic(fmt.Sprintf("%s padded byte is not 0 (preimage %s)", label, hex.EncodeToString([]byte(preimageKey))))
-					}
-				}
-				preimageKey = preimageKey[:20]
-			}
-		} else if len(preimageKey) != 32 {
-			// storage leafs should have 32 byte keys, pad them if needed
-			zeroes := make([]byte, 32)
-			copy(zeroes, []byte(preimageKey))
-			preimageKey = string(zeroes)
-		}
-
-		mptKey := crypto.Keccak256([]byte(preimageKey))
-		mptVal, ok := mptLeafMap[string(mptKey)]
-		if !ok {
-			panic(fmt.Sprintf("%s key %s (preimage %s) not found in mpt", label, hex.EncodeToString(mptKey), hex.EncodeToString([]byte(preimageKey))))
-		}
-
-		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(preimageKey))), dbs, zkValue, mptVal, paranoid)
+	for index, zkKv := range zkLeafs {
+		mptKv := mptLeafs[index]
+		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(zkKv.key))), dbs, zkKv.value, mptKv.value, paranoid)
 	}
 }
 
@@ -199,7 +176,11 @@ func checkStorageEquality(label string, _ *dbs, zkStorageBytes, mptStorageBytes 
 	}
 }
 
-func loadMPT(mptTrie *trie.SecureTrie, top bool) chan map[string][]byte {
+type kv struct {
+	key, value []byte
+}
+
+func loadMPT(mptTrie *trie.SecureTrie, top bool) chan []kv {
 	startKey := make([]byte, 32)
 	workers := 1 << 5
 	if !top {
@@ -207,7 +188,7 @@ func loadMPT(mptTrie *trie.SecureTrie, top bool) chan map[string][]byte {
 	}
 	step := byte(0xFF) / byte(workers)
 
-	mptLeafMap := make(map[string][]byte, 1000)
+	mptLeafs := make([]kv, 0, 1000)
 	var mptLeafMutex sync.Mutex
 
 	var mptWg sync.WaitGroup
@@ -215,40 +196,45 @@ func loadMPT(mptTrie *trie.SecureTrie, top bool) chan map[string][]byte {
 		startKey[0] = byte(i) * step
 		trieIt := trie.NewIterator(mptTrie.NodeIterator(startKey))
 
+		stopKey := byte(i+1) * step
 		mptWg.Add(1)
 		go func() {
 			defer mptWg.Done()
 			for trieIt.Next() {
-				mptLeafMutex.Lock()
-
-				if _, ok := mptLeafMap[string(trieIt.Key)]; ok {
-					mptLeafMutex.Unlock()
+				if trieIt.Key[0] >= stopKey {
 					break
 				}
 
-				mptLeafMap[string(dup(trieIt.Key))] = dup(trieIt.Value)
+				preimageKey := mptTrie.GetKey(trieIt.Key)
+				if len(preimageKey) == 0 {
+					panic(fmt.Sprintf("preimage not found mpt trie %s", hex.EncodeToString(trieIt.Key)))
+				}
 
+				mptLeafMutex.Lock()
+				mptLeafs = append(mptLeafs, kv{key: preimageKey, value: dup(trieIt.Value)})
 				mptLeafMutex.Unlock()
-
-				if top && len(mptLeafMap)%10000 == 0 {
-					fmt.Println("MPT Accounts Loaded:", len(mptLeafMap))
+				if top && len(mptLeafs)%10000 == 0 {
+					fmt.Println("MPT Accounts Loaded:", len(mptLeafs))
 				}
 			}
 		}()
 	}
 
-	respChan := make(chan map[string][]byte)
+	respChan := make(chan []kv)
 	go func() {
 		mptWg.Wait()
-		respChan <- mptLeafMap
+		sort.Slice(mptLeafs, func(i, j int) bool {
+			return bytes.Compare(mptLeafs[i].key, mptLeafs[j].key) < 0
+		})
+		respChan <- mptLeafs
 	}()
 	return respChan
 }
 
-func loadZkTrie(zkTrie *trie.ZkTrie, top, paranoid bool) chan map[string][]byte {
-	zkLeafMap := make(map[string][]byte, 1000)
+func loadZkTrie(zkTrie *trie.ZkTrie, top, paranoid bool) chan []kv {
+	zkLeafs := make([]kv, 0, 1000)
 	var zkLeafMutex sync.Mutex
-	zkDone := make(chan map[string][]byte)
+	zkDone := make(chan []kv)
 	go func() {
 		zkTrie.CountLeaves(func(key, value []byte) {
 			preimageKey := zkTrie.GetKey(key)
@@ -256,17 +242,37 @@ func loadZkTrie(zkTrie *trie.ZkTrie, top, paranoid bool) chan map[string][]byte 
 				panic(fmt.Sprintf("preimage not found zk trie %s", hex.EncodeToString(key)))
 			}
 
+			if top {
+				// ZkTrie pads preimages with 0s to make them 32 bytes.
+				// So we might need to clear those zeroes here since we need 20 byte addresses at top level (ie state trie)
+				if len(preimageKey) > 20 {
+					for _, b := range []byte(preimageKey)[20:] {
+						if b != 0 {
+							panic(fmt.Sprintf("padded byte is not 0 (preimage %s)", hex.EncodeToString([]byte(preimageKey))))
+						}
+					}
+					preimageKey = preimageKey[:20]
+				}
+			} else if len(preimageKey) != 32 {
+				// storage leafs should have 32 byte keys, pad them if needed
+				zeroes := make([]byte, 32)
+				copy(zeroes, []byte(preimageKey))
+				preimageKey = zeroes
+			}
+
 			zkLeafMutex.Lock()
-
-			zkLeafMap[string(dup(preimageKey))] = value
-
+			zkLeafs = append(zkLeafs, kv{key: preimageKey, value: value})
 			zkLeafMutex.Unlock()
 
-			if top && len(zkLeafMap)%10000 == 0 {
-				fmt.Println("ZK Accounts Loaded:", len(zkLeafMap))
+			if top && len(zkLeafs)%10000 == 0 {
+				fmt.Println("ZK Accounts Loaded:", len(zkLeafs))
 			}
 		}, top, paranoid)
-		zkDone <- zkLeafMap
+
+		sort.Slice(zkLeafs, func(i, j int) bool {
+			return bytes.Compare(zkLeafs[i].key, zkLeafs[j].key) < 0
+		})
+		zkDone <- zkLeafs
 	}()
 	return zkDone
 }

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -32,6 +32,7 @@ func main() {
 		zkDbPath  = flag.String("zk-db", "", "path to the ZK node DB")
 		mptRoot   = flag.String("mpt-root", "", "root hash of the MPT node")
 		zkRoot    = flag.String("zk-root", "", "root hash of the ZK node")
+		paranoid  = flag.Bool("paranoid", false, "verifies all node contents against their expected hash")
 	)
 	flag.Parse()
 
@@ -50,7 +51,7 @@ func main() {
 	checkTrieEquality(&dbs{
 		zkDb:  zkDb,
 		mptDb: mptDb,
-	}, zkRootHash, mptRootHash, "", checkAccountEquality, true)
+	}, zkRootHash, mptRootHash, "", checkAccountEquality, true, *paranoid)
 
 	for i := 0; i < runtime.GOMAXPROCS(0)*4; i++ {
 		<-trieCheckers
@@ -66,14 +67,14 @@ func panicOnError(err error, label, msg string) {
 func dup(s []byte) []byte {
 	return append([]byte{}, s...)
 }
-func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leafChecker func(string, *dbs, []byte, []byte), top bool) {
+func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leafChecker func(string, *dbs, []byte, []byte, bool), top, paranoid bool) {
 	zkTrie, err := trie.NewZkTrie(zkRoot, trie.NewZktrieDatabaseFromTriedb(trie.NewDatabaseWithConfig(dbs.zkDb, &trie.Config{Preimages: true})))
 	panicOnError(err, label, "failed to create zk trie")
 	mptTrie, err := trie.NewSecureNoTracer(mptRoot, trie.NewDatabaseWithConfig(dbs.mptDb, &trie.Config{Preimages: true}))
 	panicOnError(err, label, "failed to create mpt trie")
 
 	mptLeafCh := loadMPT(mptTrie, top)
-	zkLeafCh := loadZkTrie(zkTrie, top)
+	zkLeafCh := loadZkTrie(zkTrie, top, paranoid)
 
 	mptLeafMap := <-mptLeafCh
 	zkLeafMap := <-zkLeafCh
@@ -107,11 +108,11 @@ func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leaf
 			panic(fmt.Sprintf("%s key %s (preimage %s) not found in mpt", label, hex.EncodeToString([]byte(mptKey)), hex.EncodeToString([]byte(preimageKey))))
 		}
 
-		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(preimageKey))), dbs, zkValue, mptVal)
+		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(preimageKey))), dbs, zkValue, mptVal, paranoid)
 	}
 }
 
-func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountBytes []byte) {
+func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountBytes []byte, paranoid bool) {
 	mptAccount := &types.StateAccount{}
 	panicOnError(rlp.DecodeBytes(mptAccountBytes, mptAccount), label, "failed to decode mpt account")
 	zkAccount, err := types.UnmarshalStateAccount(zkAccountBytes)
@@ -143,7 +144,7 @@ func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountByte
 				}
 			}()
 
-			checkTrieEquality(dbs, zkRoot, mptRoot, label, checkStorageEquality, false)
+			checkTrieEquality(dbs, zkRoot, mptRoot, label, checkStorageEquality, false, paranoid)
 			accountsDone.Add(1)
 			fmt.Println("Accounts done:", accountsDone.Load())
 			trieCheckers <- struct{}{}
@@ -154,7 +155,7 @@ func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountByte
 	}
 }
 
-func checkStorageEquality(label string, _ *dbs, zkStorageBytes, mptStorageBytes []byte) {
+func checkStorageEquality(label string, _ *dbs, zkStorageBytes, mptStorageBytes []byte, _ bool) {
 	zkValue := common.BytesToHash(zkStorageBytes)
 	_, content, _, err := rlp.Split(mptStorageBytes)
 	panicOnError(err, label, "failed to decode mpt storage")
@@ -214,7 +215,7 @@ func loadMPT(mptTrie *trie.SecureTrie, parallel bool) chan map[string][]byte {
 	return respChan
 }
 
-func loadZkTrie(zkTrie *trie.ZkTrie, parallel bool) chan map[string][]byte {
+func loadZkTrie(zkTrie *trie.ZkTrie, parallel, paranoid bool) chan map[string][]byte {
 	zkLeafMap := make(map[string][]byte, 1000)
 	var zkLeafMutex sync.Mutex
 	zkDone := make(chan map[string][]byte)
@@ -238,7 +239,7 @@ func loadZkTrie(zkTrie *trie.ZkTrie, parallel bool) chan map[string][]byte {
 			if parallel && len(zkLeafMap)%10000 == 0 {
 				fmt.Println("ZK Accounts Loaded:", len(zkLeafMap))
 			}
-		}, parallel)
+		}, parallel, paranoid)
 		zkDone <- zkLeafMap
 	}()
 	return zkDone

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -105,7 +105,7 @@ func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leaf
 		mptKey := crypto.Keccak256([]byte(preimageKey))
 		mptVal, ok := mptLeafMap[string(mptKey)]
 		if !ok {
-			panic(fmt.Sprintf("%s key %s (preimage %s) not found in mpt", label, hex.EncodeToString([]byte(mptKey)), hex.EncodeToString([]byte(preimageKey))))
+			panic(fmt.Sprintf("%s key %s (preimage %s) not found in mpt", label, hex.EncodeToString(mptKey), hex.EncodeToString([]byte(preimageKey))))
 		}
 
 		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(preimageKey))), dbs, zkValue, mptVal, paranoid)

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -36,6 +36,7 @@ func main() {
 		zkRoot               = flag.String("zk-root", "", "root hash of the ZK node")
 		paranoid             = flag.Bool("paranoid", false, "verifies all node contents against their expected hash")
 		parallelismMultipler = flag.Int("parallelism-multiplier", 4, "multiplier for the number of parallel workers")
+		startFrom            = flag.Int("start-form", 0, "start checking from account at the given index")
 	)
 	flag.Parse()
 
@@ -67,10 +68,16 @@ func main() {
 	}()
 	defer close(done)
 
+	startFromSafe := *startFrom - len(trieCheckers)
+	if startFromSafe < 0 {
+		startFromSafe = 0
+	}
+	accountsDone.Add(uint64(startFromSafe))
+
 	checkTrieEquality(&dbs{
 		zkDb:  zkDb,
 		mptDb: mptDb,
-	}, zkRootHash, mptRootHash, "", checkAccountEquality, true, *paranoid)
+	}, zkRootHash, mptRootHash, "", checkAccountEquality, true, *paranoid, startFromSafe)
 
 	for i := 0; i < numTrieCheckers; i++ {
 		<-trieCheckers
@@ -86,7 +93,7 @@ func panicOnError(err error, label, msg string) {
 func dup(s []byte) []byte {
 	return append([]byte{}, s...)
 }
-func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leafChecker func(string, *dbs, []byte, []byte, bool), top, paranoid bool) {
+func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leafChecker func(string, *dbs, []byte, []byte, bool), top, paranoid bool, startFrom int) {
 	done := make(chan struct{})
 	start := time.Now()
 	if !top {
@@ -120,8 +127,9 @@ func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leaf
 		totalAccounts = len(mptLeafs)
 	}
 
-	for index, zkKv := range zkLeafs {
-		mptKv := mptLeafs[index]
+	for i := startFrom; i < len(zkLeafs); i++ {
+		zkKv := zkLeafs[i]
+		mptKv := mptLeafs[i]
 		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(zkKv.key))), dbs, zkKv.value, mptKv.value, paranoid)
 	}
 }
@@ -158,7 +166,7 @@ func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountByte
 				}
 			}()
 
-			checkTrieEquality(dbs, zkRoot, mptRoot, label, checkStorageEquality, false, paranoid)
+			checkTrieEquality(dbs, zkRoot, mptRoot, label, checkStorageEquality, false, paranoid, 0)
 			accountsDone.Add(1)
 			fmt.Println("Accounts done:", accountsDone.Load(), "/", totalAccounts)
 			trieCheckers <- struct{}{}

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
@@ -48,6 +49,20 @@ func main() {
 		trieCheckers <- struct{}{}
 	}
 
+	done := make(chan struct{})
+	totalCheckers := len(trieCheckers)
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case <-time.After(time.Minute):
+				fmt.Println("Active checkers:", totalCheckers-len(trieCheckers))
+			}
+		}
+	}()
+	defer close(done)
+
 	checkTrieEquality(&dbs{
 		zkDb:  zkDb,
 		mptDb: mptDb,
@@ -68,6 +83,22 @@ func dup(s []byte) []byte {
 	return append([]byte{}, s...)
 }
 func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leafChecker func(string, *dbs, []byte, []byte, bool), top, paranoid bool) {
+	done := make(chan struct{})
+	start := time.Now()
+	if !top {
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				case <-time.After(time.Minute):
+					fmt.Println("Checking trie", label, "for", time.Since(start))
+				}
+			}
+		}()
+	}
+	defer close(done)
+
 	zkTrie, err := trie.NewZkTrie(zkRoot, trie.NewZktrieDatabaseFromTriedb(trie.NewDatabaseWithConfig(dbs.zkDb, &trie.Config{Preimages: true})))
 	panicOnError(err, label, "failed to create zk trie")
 	mptTrie, err := trie.NewSecureNoTracer(mptRoot, trie.NewDatabaseWithConfig(dbs.mptDb, &trie.Config{Preimages: true}))

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 var accountsDone atomic.Uint64
-var trieCheckers = make(chan struct{}, runtime.GOMAXPROCS(0)*4)
+var trieCheckers chan struct{}
 
 type dbs struct {
 	zkDb  *leveldb.Database
@@ -29,11 +29,12 @@ type dbs struct {
 
 func main() {
 	var (
-		mptDbPath = flag.String("mpt-db", "", "path to the MPT node DB")
-		zkDbPath  = flag.String("zk-db", "", "path to the ZK node DB")
-		mptRoot   = flag.String("mpt-root", "", "root hash of the MPT node")
-		zkRoot    = flag.String("zk-root", "", "root hash of the ZK node")
-		paranoid  = flag.Bool("paranoid", false, "verifies all node contents against their expected hash")
+		mptDbPath            = flag.String("mpt-db", "", "path to the MPT node DB")
+		zkDbPath             = flag.String("zk-db", "", "path to the ZK node DB")
+		mptRoot              = flag.String("mpt-root", "", "root hash of the MPT node")
+		zkRoot               = flag.String("zk-root", "", "root hash of the ZK node")
+		paranoid             = flag.Bool("paranoid", false, "verifies all node contents against their expected hash")
+		parallelismMultipler = flag.Int("parallelism-multiplier", 4, "multiplier for the number of parallel workers")
 	)
 	flag.Parse()
 
@@ -45,7 +46,9 @@ func main() {
 	zkRootHash := common.HexToHash(*zkRoot)
 	mptRootHash := common.HexToHash(*mptRoot)
 
-	for i := 0; i < runtime.GOMAXPROCS(0)*4; i++ {
+	numTrieCheckers := runtime.GOMAXPROCS(0) * (*parallelismMultipler)
+	trieCheckers = make(chan struct{}, numTrieCheckers)
+	for i := 0; i < numTrieCheckers; i++ {
 		trieCheckers <- struct{}{}
 	}
 
@@ -68,7 +71,7 @@ func main() {
 		mptDb: mptDb,
 	}, zkRootHash, mptRootHash, "", checkAccountEquality, true, *paranoid)
 
-	for i := 0; i < runtime.GOMAXPROCS(0)*4; i++ {
+	for i := 0; i < numTrieCheckers; i++ {
 		<-trieCheckers
 	}
 }

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -36,7 +36,7 @@ func main() {
 		zkRoot               = flag.String("zk-root", "", "root hash of the ZK node")
 		paranoid             = flag.Bool("paranoid", false, "verifies all node contents against their expected hash")
 		parallelismMultipler = flag.Int("parallelism-multiplier", 4, "multiplier for the number of parallel workers")
-		startFrom            = flag.Int("start-form", 0, "start checking from account at the given index")
+		startFrom            = flag.Int("start-from", 0, "start checking from account at the given index")
 	)
 	flag.Parse()
 
@@ -53,20 +53,6 @@ func main() {
 	for i := 0; i < numTrieCheckers; i++ {
 		trieCheckers <- struct{}{}
 	}
-
-	done := make(chan struct{})
-	totalCheckers := len(trieCheckers)
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			case <-time.After(time.Minute):
-				fmt.Println("Active checkers:", totalCheckers-len(trieCheckers))
-			}
-		}
-	}()
-	defer close(done)
 
 	startFromSafe := *startFrom - len(trieCheckers)
 	if startFromSafe < 0 {

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -51,6 +51,10 @@ func main() {
 		zkDb:  zkDb,
 		mptDb: mptDb,
 	}, zkRootHash, mptRootHash, "", checkAccountEquality, true)
+
+	for i := 0; i < runtime.GOMAXPROCS(0)*4; i++ {
+		<-trieCheckers
+	}
 }
 
 func panicOnError(err error, label, msg string) {

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -20,6 +20,7 @@ import (
 )
 
 var accountsDone atomic.Uint64
+var totalAccounts int
 var trieCheckers chan struct{}
 
 type dbs struct {
@@ -115,6 +116,8 @@ func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leaf
 
 	if len(mptLeafs) != len(zkLeafs) {
 		panic(fmt.Sprintf("%s MPT and ZK trie leaf count mismatch: MPT: %d, ZK: %d", label, len(mptLeafs), len(zkLeafs)))
+	} else if top {
+		totalAccounts = len(mptLeafs)
 	}
 
 	for index, zkKv := range zkLeafs {
@@ -157,12 +160,12 @@ func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountByte
 
 			checkTrieEquality(dbs, zkRoot, mptRoot, label, checkStorageEquality, false, paranoid)
 			accountsDone.Add(1)
-			fmt.Println("Accounts done:", accountsDone.Load())
+			fmt.Println("Accounts done:", accountsDone.Load(), "/", totalAccounts)
 			trieCheckers <- struct{}{}
 		}()
 	} else {
 		accountsDone.Add(1)
-		fmt.Println("Accounts done:", accountsDone.Load())
+		fmt.Println("Accounts done:", accountsDone.Load(), "/", totalAccounts)
 	}
 }
 

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -186,7 +186,7 @@ func loadMPT(mptTrie *trie.SecureTrie, top bool) chan []kv {
 	if !top {
 		workers = 1 << 3
 	}
-	step := byte(0xFF) / byte(workers)
+	step := byte(256 / workers)
 
 	mptLeafs := make([]kv, 0, 1000)
 	var mptLeafMutex sync.Mutex
@@ -196,12 +196,12 @@ func loadMPT(mptTrie *trie.SecureTrie, top bool) chan []kv {
 		startKey[0] = byte(i) * step
 		trieIt := trie.NewIterator(mptTrie.NodeIterator(startKey))
 
-		stopKey := byte(i+1) * step
+		stopKey := (i + 1) * int(step)
 		mptWg.Add(1)
 		go func() {
 			defer mptWg.Done()
 			for trieIt.Next() {
-				if trieIt.Key[0] >= stopKey {
+				if int(trieIt.Key[0]) >= stopKey {
 					break
 				}
 

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -199,11 +199,11 @@ func checkStorageEquality(label string, _ *dbs, zkStorageBytes, mptStorageBytes 
 	}
 }
 
-func loadMPT(mptTrie *trie.SecureTrie, parallel bool) chan map[string][]byte {
+func loadMPT(mptTrie *trie.SecureTrie, top bool) chan map[string][]byte {
 	startKey := make([]byte, 32)
 	workers := 1 << 5
-	if !parallel {
-		workers = 1
+	if !top {
+		workers = 1 << 3
 	}
 	step := byte(0xFF) / byte(workers)
 
@@ -219,9 +219,7 @@ func loadMPT(mptTrie *trie.SecureTrie, parallel bool) chan map[string][]byte {
 		go func() {
 			defer mptWg.Done()
 			for trieIt.Next() {
-				if parallel {
-					mptLeafMutex.Lock()
-				}
+				mptLeafMutex.Lock()
 
 				if _, ok := mptLeafMap[string(trieIt.Key)]; ok {
 					mptLeafMutex.Unlock()
@@ -230,11 +228,9 @@ func loadMPT(mptTrie *trie.SecureTrie, parallel bool) chan map[string][]byte {
 
 				mptLeafMap[string(dup(trieIt.Key))] = dup(trieIt.Value)
 
-				if parallel {
-					mptLeafMutex.Unlock()
-				}
+				mptLeafMutex.Unlock()
 
-				if parallel && len(mptLeafMap)%10000 == 0 {
+				if top && len(mptLeafMap)%10000 == 0 {
 					fmt.Println("MPT Accounts Loaded:", len(mptLeafMap))
 				}
 			}
@@ -249,7 +245,7 @@ func loadMPT(mptTrie *trie.SecureTrie, parallel bool) chan map[string][]byte {
 	return respChan
 }
 
-func loadZkTrie(zkTrie *trie.ZkTrie, parallel, paranoid bool) chan map[string][]byte {
+func loadZkTrie(zkTrie *trie.ZkTrie, top, paranoid bool) chan map[string][]byte {
 	zkLeafMap := make(map[string][]byte, 1000)
 	var zkLeafMutex sync.Mutex
 	zkDone := make(chan map[string][]byte)
@@ -260,20 +256,16 @@ func loadZkTrie(zkTrie *trie.ZkTrie, parallel, paranoid bool) chan map[string][]
 				panic(fmt.Sprintf("preimage not found zk trie %s", hex.EncodeToString(key)))
 			}
 
-			if parallel {
-				zkLeafMutex.Lock()
-			}
+			zkLeafMutex.Lock()
 
 			zkLeafMap[string(dup(preimageKey))] = value
 
-			if parallel {
-				zkLeafMutex.Unlock()
-			}
+			zkLeafMutex.Unlock()
 
-			if parallel && len(zkLeafMap)%10000 == 0 {
+			if top && len(zkLeafMap)%10000 == 0 {
 				fmt.Println("ZK Accounts Loaded:", len(zkLeafMap))
 			}
-		}, parallel, paranoid)
+		}, top, paranoid)
 		zkDone <- zkLeafMap
 	}()
 	return zkDone

--- a/cmd/migration-checker/main.go
+++ b/cmd/migration-checker/main.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
+
+	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/core/types"
+	"github.com/scroll-tech/go-ethereum/crypto"
+	"github.com/scroll-tech/go-ethereum/ethdb/leveldb"
+	"github.com/scroll-tech/go-ethereum/rlp"
+	"github.com/scroll-tech/go-ethereum/trie"
+)
+
+var accountsDone atomic.Uint64
+var trieCheckers = make(chan struct{}, runtime.GOMAXPROCS(0)*4)
+
+type dbs struct {
+	zkDb  *leveldb.Database
+	mptDb *leveldb.Database
+}
+
+func main() {
+	var (
+		mptDbPath = flag.String("mpt-db", "", "path to the MPT node DB")
+		zkDbPath  = flag.String("zk-db", "", "path to the ZK node DB")
+		mptRoot   = flag.String("mpt-root", "", "root hash of the MPT node")
+		zkRoot    = flag.String("zk-root", "", "root hash of the ZK node")
+	)
+	flag.Parse()
+
+	zkDb, err := leveldb.New(*zkDbPath, 1024, 128, "", true)
+	panicOnError(err, "", "failed to open zk db")
+	mptDb, err := leveldb.New(*mptDbPath, 1024, 128, "", true)
+	panicOnError(err, "", "failed to open mpt db")
+
+	zkRootHash := common.HexToHash(*zkRoot)
+	mptRootHash := common.HexToHash(*mptRoot)
+
+	for i := 0; i < runtime.GOMAXPROCS(0)*4; i++ {
+		trieCheckers <- struct{}{}
+	}
+
+	checkTrieEquality(&dbs{
+		zkDb:  zkDb,
+		mptDb: mptDb,
+	}, zkRootHash, mptRootHash, "", checkAccountEquality, true)
+}
+
+func panicOnError(err error, label, msg string) {
+	if err != nil {
+		panic(fmt.Sprint(label, " error: ", msg, " ", err))
+	}
+}
+
+func dup(s []byte) []byte {
+	return append([]byte{}, s...)
+}
+func checkTrieEquality(dbs *dbs, zkRoot, mptRoot common.Hash, label string, leafChecker func(string, *dbs, []byte, []byte), top bool) {
+	zkTrie, err := trie.NewZkTrie(zkRoot, trie.NewZktrieDatabaseFromTriedb(trie.NewDatabaseWithConfig(dbs.zkDb, &trie.Config{Preimages: true})))
+	panicOnError(err, label, "failed to create zk trie")
+	mptTrie, err := trie.NewSecureNoTracer(mptRoot, trie.NewDatabaseWithConfig(dbs.mptDb, &trie.Config{Preimages: true}))
+	panicOnError(err, label, "failed to create mpt trie")
+
+	mptLeafCh := loadMPT(mptTrie, top)
+	zkLeafCh := loadZkTrie(zkTrie, top)
+
+	mptLeafMap := <-mptLeafCh
+	zkLeafMap := <-zkLeafCh
+
+	if len(mptLeafMap) != len(zkLeafMap) {
+		panic(fmt.Sprintf("%s MPT and ZK trie leaf count mismatch: MPT: %d, ZK: %d", label, len(mptLeafMap), len(zkLeafMap)))
+	}
+
+	for preimageKey, zkValue := range zkLeafMap {
+		if top {
+			// ZkTrie pads preimages with 0s to make them 32 bytes.
+			// So we might need to clear those zeroes here since we need 20 byte addresses at top level (ie state trie)
+			if len(preimageKey) > 20 {
+				for _, b := range []byte(preimageKey)[20:] {
+					if b != 0 {
+						panic(fmt.Sprintf("%s padded byte is not 0 (preimage %s)", label, hex.EncodeToString([]byte(preimageKey))))
+					}
+				}
+				preimageKey = preimageKey[:20]
+			}
+		} else if len(preimageKey) != 32 {
+			// storage leafs should have 32 byte keys, pad them if needed
+			zeroes := make([]byte, 32)
+			copy(zeroes, []byte(preimageKey))
+			preimageKey = string(zeroes)
+		}
+
+		mptKey := crypto.Keccak256([]byte(preimageKey))
+		mptVal, ok := mptLeafMap[string(mptKey)]
+		if !ok {
+			panic(fmt.Sprintf("%s key %s (preimage %s) not found in mpt", label, hex.EncodeToString([]byte(mptKey)), hex.EncodeToString([]byte(preimageKey))))
+		}
+
+		leafChecker(fmt.Sprintf("%s key: %s", label, hex.EncodeToString([]byte(preimageKey))), dbs, zkValue, mptVal)
+	}
+}
+
+func checkAccountEquality(label string, dbs *dbs, zkAccountBytes, mptAccountBytes []byte) {
+	mptAccount := &types.StateAccount{}
+	panicOnError(rlp.DecodeBytes(mptAccountBytes, mptAccount), label, "failed to decode mpt account")
+	zkAccount, err := types.UnmarshalStateAccount(zkAccountBytes)
+	panicOnError(err, label, "failed to decode zk account")
+
+	if mptAccount.Nonce != zkAccount.Nonce {
+		panic(fmt.Sprintf("%s nonce mismatch: zk: %d, mpt: %d", label, zkAccount.Nonce, mptAccount.Nonce))
+	}
+
+	if mptAccount.Balance.Cmp(zkAccount.Balance) != 0 {
+		panic(fmt.Sprintf("%s balance mismatch: zk: %s, mpt: %s", label, zkAccount.Balance.String(), mptAccount.Balance.String()))
+	}
+
+	if !bytes.Equal(mptAccount.KeccakCodeHash, zkAccount.KeccakCodeHash) {
+		panic(fmt.Sprintf("%s code hash mismatch: zk: %s, mpt: %s", label, hex.EncodeToString(zkAccount.KeccakCodeHash), hex.EncodeToString(mptAccount.KeccakCodeHash)))
+	}
+
+	if (zkAccount.Root == common.Hash{}) != (mptAccount.Root == types.EmptyRootHash) {
+		panic(fmt.Sprintf("%s empty account root mismatch", label))
+	} else if zkAccount.Root != (common.Hash{}) {
+		zkRoot := common.BytesToHash(zkAccount.Root[:])
+		mptRoot := common.BytesToHash(mptAccount.Root[:])
+		<-trieCheckers
+		go func() {
+			defer func() {
+				if p := recover(); p != nil {
+					fmt.Println(p)
+					os.Exit(1)
+				}
+			}()
+
+			checkTrieEquality(dbs, zkRoot, mptRoot, label, checkStorageEquality, false)
+			accountsDone.Add(1)
+			fmt.Println("Accounts done:", accountsDone.Load())
+			trieCheckers <- struct{}{}
+		}()
+	} else {
+		accountsDone.Add(1)
+		fmt.Println("Accounts done:", accountsDone.Load())
+	}
+}
+
+func checkStorageEquality(label string, _ *dbs, zkStorageBytes, mptStorageBytes []byte) {
+	zkValue := common.BytesToHash(zkStorageBytes)
+	_, content, _, err := rlp.Split(mptStorageBytes)
+	panicOnError(err, label, "failed to decode mpt storage")
+	mptValue := common.BytesToHash(content)
+	if !bytes.Equal(zkValue[:], mptValue[:]) {
+		panic(fmt.Sprintf("%s storage mismatch: zk: %s, mpt: %s", label, zkValue.Hex(), mptValue.Hex()))
+	}
+}
+
+func loadMPT(mptTrie *trie.SecureTrie, parallel bool) chan map[string][]byte {
+	startKey := make([]byte, 32)
+	workers := 1 << 5
+	if !parallel {
+		workers = 1
+	}
+	step := byte(0xFF) / byte(workers)
+
+	mptLeafMap := make(map[string][]byte, 1000)
+	var mptLeafMutex sync.Mutex
+
+	var mptWg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		startKey[0] = byte(i) * step
+		trieIt := trie.NewIterator(mptTrie.NodeIterator(startKey))
+
+		mptWg.Add(1)
+		go func() {
+			defer mptWg.Done()
+			for trieIt.Next() {
+				if parallel {
+					mptLeafMutex.Lock()
+				}
+
+				if _, ok := mptLeafMap[string(trieIt.Key)]; ok {
+					mptLeafMutex.Unlock()
+					break
+				}
+
+				mptLeafMap[string(dup(trieIt.Key))] = dup(trieIt.Value)
+
+				if parallel {
+					mptLeafMutex.Unlock()
+				}
+
+				if parallel && len(mptLeafMap)%10000 == 0 {
+					fmt.Println("MPT Accounts Loaded:", len(mptLeafMap))
+				}
+			}
+		}()
+	}
+
+	respChan := make(chan map[string][]byte)
+	go func() {
+		mptWg.Wait()
+		respChan <- mptLeafMap
+	}()
+	return respChan
+}
+
+func loadZkTrie(zkTrie *trie.ZkTrie, parallel bool) chan map[string][]byte {
+	zkLeafMap := make(map[string][]byte, 1000)
+	var zkLeafMutex sync.Mutex
+	zkDone := make(chan map[string][]byte)
+	go func() {
+		zkTrie.CountLeaves(func(key, value []byte) {
+			preimageKey := zkTrie.GetKey(key)
+			if len(preimageKey) == 0 {
+				panic(fmt.Sprintf("preimage not found zk trie %s", hex.EncodeToString(key)))
+			}
+
+			if parallel {
+				zkLeafMutex.Lock()
+			}
+
+			zkLeafMap[string(dup(preimageKey))] = value
+
+			if parallel {
+				zkLeafMutex.Unlock()
+			}
+
+			if parallel && len(zkLeafMap)%10000 == 0 {
+				fmt.Println("ZK Accounts Loaded:", len(zkLeafMap))
+			}
+		}, parallel)
+		zkDone <- zkLeafMap
+	}()
+	return zkDone
+}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -65,6 +65,16 @@ func NewSecure(root common.Hash, db *Database) (*SecureTrie, error) {
 	return &SecureTrie{trie: *trie, preimages: db.preimages}, nil
 }
 
+func NewSecureNoTracer(root common.Hash, db *Database) (*SecureTrie, error) {
+	t, err := NewSecure(root, db)
+	if err != nil {
+		return nil, err
+	}
+
+	t.trie.tracer = nil
+	return t, nil
+}
+
 // Get returns the value for key stored in the trie.
 // The value bytes must not be modified by the caller.
 func (t *SecureTrie) Get(key []byte) []byte {

--- a/trie/tracer.go
+++ b/trie/tracer.go
@@ -60,6 +60,10 @@ func newTracer() *tracer {
 // blob internally. Don't change the value outside of function since
 // it's not deep-copied.
 func (t *tracer) onRead(path []byte, val []byte) {
+	if t == nil {
+		return
+	}
+
 	t.accessList[string(path)] = val
 }
 
@@ -67,6 +71,10 @@ func (t *tracer) onRead(path []byte, val []byte) {
 // in the deletion set (resurrected node), then just wipe it from
 // the deletion set as it's "untouched".
 func (t *tracer) onInsert(path []byte) {
+	if t == nil {
+		return
+	}
+
 	if _, present := t.deletes[string(path)]; present {
 		delete(t.deletes, string(path))
 		return
@@ -78,6 +86,10 @@ func (t *tracer) onInsert(path []byte) {
 // in the addition set, then just wipe it from the addition set
 // as it's untouched.
 func (t *tracer) onDelete(path []byte) {
+	if t == nil {
+		return
+	}
+
 	if _, present := t.inserts[string(path)]; present {
 		delete(t.inserts, string(path))
 		return
@@ -87,6 +99,10 @@ func (t *tracer) onDelete(path []byte) {
 
 // reset clears the content tracked by tracer.
 func (t *tracer) reset() {
+	if t == nil {
+		return
+	}
+
 	t.inserts = make(map[string]struct{})
 	t.deletes = make(map[string]struct{})
 	t.accessList = make(map[string][]byte)
@@ -94,6 +110,10 @@ func (t *tracer) reset() {
 
 // copy returns a deep copied tracer instance.
 func (t *tracer) copy() *tracer {
+	if t == nil {
+		return nil
+	}
+
 	accessList := make(map[string][]byte, len(t.accessList))
 	for path, blob := range t.accessList {
 		accessList[path] = common.CopyBytes(blob)
@@ -107,6 +127,10 @@ func (t *tracer) copy() *tracer {
 
 // deletedNodes returns a list of node paths which are deleted from the trie.
 func (t *tracer) deletedNodes() []string {
+	if t == nil {
+		return nil
+	}
+
 	var paths []string
 	for path := range t.deletes {
 		// It's possible a few deleted nodes were embedded

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -239,15 +239,15 @@ func (t *ZkTrie) Witness() map[string]struct{} {
 	panic("not implemented")
 }
 
-func (t *ZkTrie) CountLeaves(cb func(key, value []byte), parallel, verifyNodeHashes bool) uint64 {
+func (t *ZkTrie) CountLeaves(cb func(key, value []byte), top, verifyNodeHashes bool) uint64 {
 	root, err := t.ZkTrie.Tree().Root()
 	if err != nil {
 		panic("CountLeaves cannot get root")
 	}
-	return t.countLeaves(root, cb, 0, parallel, verifyNodeHashes)
+	return t.countLeaves(root, cb, 0, top, verifyNodeHashes)
 }
 
-func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth int, parallel, verifyNodeHashes bool) uint64 {
+func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth int, top, verifyNodeHashes bool) uint64 {
 	if root == nil {
 		return 0
 	}
@@ -271,19 +271,24 @@ func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth i
 		cb(append([]byte{}, rootNode.NodeKey.Bytes()...), append([]byte{}, rootNode.Data()...))
 		return 1
 	} else {
-		if parallel && depth < 5 {
+		parallelismDepth := 5
+		if !top {
+			parallelismDepth = 3
+		}
+
+		if depth < parallelismDepth {
 			count := make(chan uint64)
 			leftT := t.Copy()
 			rightT := t.Copy()
 			go func() {
-				count <- leftT.countLeaves(rootNode.ChildL, cb, depth+1, parallel, verifyNodeHashes)
+				count <- leftT.countLeaves(rootNode.ChildL, cb, depth+1, top, verifyNodeHashes)
 			}()
 			go func() {
-				count <- rightT.countLeaves(rootNode.ChildR, cb, depth+1, parallel, verifyNodeHashes)
+				count <- rightT.countLeaves(rootNode.ChildR, cb, depth+1, top, verifyNodeHashes)
 			}()
 			return <-count + <-count
 		} else {
-			return t.countLeaves(rootNode.ChildL, cb, depth+1, parallel, verifyNodeHashes) + t.countLeaves(rootNode.ChildR, cb, depth+1, parallel, verifyNodeHashes)
+			return t.countLeaves(rootNode.ChildL, cb, depth+1, top, verifyNodeHashes) + t.countLeaves(rootNode.ChildR, cb, depth+1, top, verifyNodeHashes)
 		}
 	}
 }

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -239,15 +239,15 @@ func (t *ZkTrie) Witness() map[string]struct{} {
 	panic("not implemented")
 }
 
-func (t *ZkTrie) CountLeaves(cb func(key, value []byte), parallel bool) uint64 {
+func (t *ZkTrie) CountLeaves(cb func(key, value []byte), parallel, verifyNodeHashes bool) uint64 {
 	root, err := t.ZkTrie.Tree().Root()
 	if err != nil {
 		panic("CountLeaves cannot get root")
 	}
-	return t.countLeaves(root, cb, 0, parallel)
+	return t.countLeaves(root, cb, 0, parallel, verifyNodeHashes)
 }
 
-func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth int, parallel bool) uint64 {
+func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth int, parallel, verifyNodeHashes bool) uint64 {
 	if root == nil {
 		return 0
 	}
@@ -258,6 +258,16 @@ func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth i
 	}
 
 	if rootNode.Type == zktrie.NodeTypeLeaf_New {
+		if verifyNodeHashes {
+			calculatedNodeHash, err := rootNode.NodeHash()
+			if err != nil {
+				panic("countLeaves cannot get calculatedNodeHash")
+			}
+			if *calculatedNodeHash != *root {
+				panic("countLeaves node hash mismatch")
+			}
+		}
+
 		cb(append([]byte{}, rootNode.NodeKey.Bytes()...), append([]byte{}, rootNode.Data()...))
 		return 1
 	} else {
@@ -266,14 +276,14 @@ func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth i
 			leftT := t.Copy()
 			rightT := t.Copy()
 			go func() {
-				count <- leftT.countLeaves(rootNode.ChildL, cb, depth+1, parallel)
+				count <- leftT.countLeaves(rootNode.ChildL, cb, depth+1, parallel, verifyNodeHashes)
 			}()
 			go func() {
-				count <- rightT.countLeaves(rootNode.ChildR, cb, depth+1, parallel)
+				count <- rightT.countLeaves(rootNode.ChildR, cb, depth+1, parallel, verifyNodeHashes)
 			}()
 			return <-count + <-count
 		} else {
-			return t.countLeaves(rootNode.ChildL, cb, depth+1, parallel) + t.countLeaves(rootNode.ChildR, cb, depth+1, parallel)
+			return t.countLeaves(rootNode.ChildL, cb, depth+1, parallel, verifyNodeHashes) + t.countLeaves(rootNode.ChildR, cb, depth+1, parallel, verifyNodeHashes)
 		}
 	}
 }

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -238,3 +238,42 @@ func VerifyProofSMT(rootHash common.Hash, key []byte, proofDb ethdb.KeyValueRead
 func (t *ZkTrie) Witness() map[string]struct{} {
 	panic("not implemented")
 }
+
+func (t *ZkTrie) CountLeaves(cb func(key, value []byte), parallel bool) uint64 {
+	root, err := t.ZkTrie.Tree().Root()
+	if err != nil {
+		panic("CountLeaves cannot get root")
+	}
+	return t.countLeaves(root, cb, 0, parallel)
+}
+
+func (t *ZkTrie) countLeaves(root *zkt.Hash, cb func(key, value []byte), depth int, parallel bool) uint64 {
+	if root == nil {
+		return 0
+	}
+
+	rootNode, err := t.ZkTrie.Tree().GetNode(root)
+	if err != nil {
+		panic("countLeaves cannot get rootNode")
+	}
+
+	if rootNode.Type == zktrie.NodeTypeLeaf_New {
+		cb(append([]byte{}, rootNode.NodeKey.Bytes()...), append([]byte{}, rootNode.Data()...))
+		return 1
+	} else {
+		if parallel && depth < 5 {
+			count := make(chan uint64)
+			leftT := t.Copy()
+			rightT := t.Copy()
+			go func() {
+				count <- leftT.countLeaves(rootNode.ChildL, cb, depth+1, parallel)
+			}()
+			go func() {
+				count <- rightT.countLeaves(rootNode.ChildR, cb, depth+1, parallel)
+			}()
+			return <-count + <-count
+		} else {
+			return t.countLeaves(rootNode.ChildL, cb, depth+1, parallel) + t.countLeaves(rootNode.ChildR, cb, depth+1, parallel)
+		}
+	}
+}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

...


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to initialize a `SecureTrie` instance without tracing.
	- Added functionality to count leaf nodes in `ZkTrie` with optional hash verification and parallel execution support.
	- Implemented logging and profiling capabilities for monitoring application performance.
	- Added a comprehensive implementation for checking the equality of two database structures.

- **Bug Fixes**
	- Improved error handling to prevent runtime exceptions during data comparisons and processing.
	- Added checks to prevent operations on uninitialized components, enhancing overall robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->