### PR TITLE
fix(rollup-fee): support set code tx in asUnsignedTx

### DIFF
--- a/core/vm/logger.go
+++ b/core/vm/logger.go
@@ -208,6 +208,8 @@ func (l *StructLogger) CaptureStart(env *EVM, from common.Address, to common.Add
 		// because contract creation is not allowed in set code transactions
 		for _, auth := range authorizationResults {
 			if auth.Success {
+				// Does not record the createdAccount account yet, since it will change the return value of CreatedAccount,
+				// which is used in assigning the "to" field of transaction in scroll_getBlockTraceByNumberOrHash.
 				l.statesAffected[auth.Authority] = struct{}{}
 			}
 		}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 12        // Patch version component of the current release
+	VersionPatch = 13        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/holiman/uint256"
+
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto"

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -141,9 +141,8 @@ func asUnsignedDynamicTx(msg Message, chainID *big.Int) *types.Transaction {
 }
 
 func asUnsignedSetCodeTx(msg Message, chainID *big.Int) *types.Transaction {
-	return types.NewTx(&types.SetCodeTx{
+	tx := types.SetCodeTx{
 		Nonce:      msg.Nonce(),
-		To:         *msg.To(),
 		Value:      uint256.MustFromBig(msg.Value()),
 		Gas:        msg.Gas(),
 		GasFeeCap:  uint256.MustFromBig(msg.GasFeeCap()),
@@ -152,7 +151,11 @@ func asUnsignedSetCodeTx(msg Message, chainID *big.Int) *types.Transaction {
 		AccessList: msg.AccessList(),
 		AuthList:   msg.SetCodeAuthorizations(),
 		ChainID:    uint256.MustFromBig(chainID),
-	})
+	}
+	if msg.To() != nil {
+		tx.To = *msg.To()
+	}
+	return types.NewTx(&tx)
 }
 
 func readGPOStorageSlots(addr common.Address, state StateDB) gpoState {

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"math/big"
 
+	"github.com/holiman/uint256"
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/crypto"
@@ -35,6 +36,7 @@ type Message interface {
 	Data() []byte
 	AccessList() types.AccessList
 	IsL1MessageTx() bool
+	SetCodeAuthorizations() []types.SetCodeAuthorization
 }
 
 // StateDB represents the StateDB interface
@@ -92,7 +94,11 @@ func asUnsignedTx(msg Message, baseFee, chainID *big.Int) *types.Transaction {
 		return asUnsignedAccessListTx(msg, chainID)
 	}
 
-	return asUnsignedDynamicTx(msg, chainID)
+	if msg.SetCodeAuthorizations() == nil {
+		return asUnsignedDynamicTx(msg, chainID)
+	}
+
+	return asUnsignedSetCodeTx(msg, chainID)
 }
 
 func asUnsignedLegacyTx(msg Message) *types.Transaction {
@@ -130,6 +136,21 @@ func asUnsignedDynamicTx(msg Message, chainID *big.Int) *types.Transaction {
 		Data:       msg.Data(),
 		AccessList: msg.AccessList(),
 		ChainID:    chainID,
+	})
+}
+
+func asUnsignedSetCodeTx(msg Message, chainID *big.Int) *types.Transaction {
+	return types.NewTx(&types.SetCodeTx{
+		Nonce:      msg.Nonce(),
+		To:         *msg.To(),
+		Value:      uint256.MustFromBig(msg.Value()),
+		Gas:        msg.Gas(),
+		GasFeeCap:  uint256.MustFromBig(msg.GasFeeCap()),
+		GasTipCap:  uint256.MustFromBig(msg.GasTipCap()),
+		Data:       msg.Data(),
+		AccessList: msg.AccessList(),
+		AuthList:   msg.SetCodeAuthorizations(),
+		ChainID:    uint256.MustFromBig(chainID),
 	})
 }
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR fixes `EstimateL1DataFeeForMessage` by supporting set code tx in `asUnsignedTx`.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced transaction processing now supports an additional flow when transactions include authorization details.

- **Chores**
  - Incremented the patch version to reflect the latest updates and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->