### PR TITLE
fix(system-contract): Check coinbase during header verification

### DIFF
--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -37,7 +37,10 @@ var (
 	// that is not part of the local blockchain.
 	errUnknownBlock = errors.New("unknown block")
 
-	// errNonceNotEmpty is returned if a nonce value is non-zero
+	// errInvalidCoinbase is returned if a coinbase value is non-zero
+	errInvalidCoinbase = errors.New("coinbase not empty")
+
+	// errInvalidNonce is returned if a nonce value is non-zero
 	errInvalidNonce = errors.New("nonce not empty nor zero")
 
 	// errMissingSignature is returned if a block's extra-data section doesn't seem
@@ -115,6 +118,10 @@ func (s *SystemContract) verifyHeader(chain consensus.ChainHeaderReader, header 
 	// Don't waste time checking blocks from the future
 	if header.Time > uint64(time.Now().Unix()) {
 		return consensus.ErrFutureBlock
+	}
+	// Ensure that the coinbase is zero
+	if header.Coinbase != (common.Address{}) {
+		return errInvalidCoinbase
 	}
 	// Ensure that the nonce is zero
 	if header.Nonce != (types.BlockNonce{}) {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 16        // Patch version component of the current release
+	VersionPatch = 17        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Adds a strict check so that peers reject blocks with non-zero coinbase field yet. This is necessary because this field is currently not posted to DA.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced validation for critical data consistency checks during processes.

- **Chores**
  - Updated the patch version to reflect the latest release improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->