### PR TITLE
ci: update Rust version for build-geth workflow

### DIFF
--- a/.github/workflows/l2geth_ci.yml
+++ b/.github/workflows/l2geth_ci.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly-2022-12-10
+        toolchain: nightly-2023-12-03
         override: true
         components: rustfmt, clippy
     - name: Checkout code


### PR DESCRIPTION
Fix CI issue:

```
Run make libzkp
cd /home/runner/work/go-ethereum/go-ethereum/rollup/ccc/libzkp && make libzkp
make[1]: Entering directory '/home/runner/work/go-ethereum/go-ethereum/rollup/ccc/libzkp'
cargo build --release
error: toolchain 'nightly-2023-12-03-x[8](https://github.com/scroll-tech/go-ethereum/actions/runs/13634481166/job/38150972989#step:5:9)6_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install nightly-2023-12-03-x86_64-unknown-linux-gnu` to install it
make[1]: *** [Makefile:8: libzkp] Error 1
make[1]: Leaving directory '/home/runner/work/go-ethereum/go-ethereum/rollup/ccc/libzkp'
make: *** [Makefile:[12](https://github.com/scroll-tech/go-ethereum/actions/runs/13634481166/job/38150972989#step:5:13): libzkp] Error 2
Error: Process completed with exit code 2.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the continuous integration setup to use a more recent nightly Rust toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->