### PR TITLE
fix(sync service): skip messages with lower index

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 20        // Patch version component of the current release
+	VersionPatch = 21        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -1,6 +1,7 @@
 package sync_service
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
@@ -15,6 +16,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/metrics"
 	"github.com/scroll-tech/go-ethereum/node"
 	"github.com/scroll-tech/go-ethereum/params"
+	"github.com/scroll-tech/go-ethereum/rlp"
 )
 
 const (
@@ -82,7 +84,8 @@ func NewSyncService(ctx context.Context, genesisConfig *params.ChainConfig, node
 	// otherwise there's no way for the node to know if it missed any messages of the V2 queue (as it was not querying it before)
 	// but continued to query the V1 queue (which after V2 deployment does not contain any messages anymore).
 	// this is a one-time operation and will not be repeated on subsequent restarts.
-	if genesisConfig.Scroll.L1Config.L1MessageQueueV2DeploymentBlock > 0 &&
+	if genesisConfig.IsEuclidV2(uint64(time.Now().Unix())) &&
+		genesisConfig.Scroll.L1Config.L1MessageQueueV2DeploymentBlock > 0 &&
 		genesisConfig.Scroll.L1Config.L1MessageQueueV2DeploymentBlock < latestProcessedBlock { // node synced after V2 deployment
 
 		// this means the node has never synced V2 messages before -> we need to reset the synced height to re-fetch V2 messages.
@@ -272,19 +275,43 @@ func (s *SyncService) fetchMessages() {
 
 		if len(msgs) > 0 {
 			log.Debug("Received new L1 events", "fromBlock", from, "toBlock", to, "count", len(msgs))
-			rawdb.WriteL1Messages(batchWriter, msgs) // collect messages in memory
-			numMsgsCollected += len(msgs)
 		}
 
 		for _, msg := range msgs {
 			if msg.QueueIndex > 0 {
 				queueIndex++
 			}
+
 			// check if received queue index matches expected queue index
-			if msg.QueueIndex != queueIndex {
+			if msg.QueueIndex > queueIndex {
 				log.Error("Unexpected queue index in SyncService", "expected", queueIndex, "got", msg.QueueIndex, "msg", msg)
 				return // do not flush inconsistent data to disk
 			}
+
+			// compare with stored message in database, abort if not equal, ignore if already exists
+			if msg.QueueIndex < queueIndex {
+				log.Info("Duplicate queue index in SyncService", "expected", queueIndex, "got", msg.QueueIndex)
+
+				receivedMsgBytes, err := rlp.EncodeToBytes(msg)
+				if err != nil {
+					log.Error("Failed to encode message", "err", err)
+					return
+				}
+				storedMsgBytes := rawdb.ReadL1MessageRLP(s.db, msg.QueueIndex)
+				if !bytes.Equal(storedMsgBytes, receivedMsgBytes) {
+					storedL1Message := rawdb.ReadL1Message(s.db, msg.QueueIndex)
+					log.Error("Stored message at same queue index does not match received message", "queueIndex", msg.QueueIndex, "expected", storedL1Message, "got", msg)
+					return
+				}
+
+				// already exists, ignore
+				queueIndex--
+				continue
+			}
+
+			// store message to database (collected in memory and flushed periodically)
+			rawdb.WriteL1Message(batchWriter, msg)
+			numMsgsCollected++
 		}
 
 		numBlocksPendingDbWrite += to - from + 1

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -84,8 +84,7 @@ func NewSyncService(ctx context.Context, genesisConfig *params.ChainConfig, node
 	// otherwise there's no way for the node to know if it missed any messages of the V2 queue (as it was not querying it before)
 	// but continued to query the V1 queue (which after V2 deployment does not contain any messages anymore).
 	// this is a one-time operation and will not be repeated on subsequent restarts.
-	if genesisConfig.IsEuclidV2(uint64(time.Now().Unix())) &&
-		genesisConfig.Scroll.L1Config.L1MessageQueueV2DeploymentBlock > 0 &&
+	if genesisConfig.Scroll.L1Config.L1MessageQueueV2DeploymentBlock > 0 &&
 		genesisConfig.Scroll.L1Config.L1MessageQueueV2DeploymentBlock < latestProcessedBlock { // node synced after V2 deployment
 
 		// this means the node has never synced V2 messages before -> we need to reset the synced height to re-fetch V2 messages.
@@ -290,7 +289,7 @@ func (s *SyncService) fetchMessages() {
 
 			// compare with stored message in database, abort if not equal, ignore if already exists
 			if msg.QueueIndex < queueIndex {
-				log.Info("Duplicate queue index in SyncService", "expected", queueIndex, "got", msg.QueueIndex)
+				log.Warn("Duplicate queue index in SyncService", "expected", queueIndex, "got", msg.QueueIndex)
 
 				receivedMsgBytes, err := rlp.EncodeToBytes(msg)
 				if err != nil {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR adds skipping for already existing L1 messages if the received message is equal to the already stored one. This allows us to reset `SyncedL1BlockNumber` to a lower value and simply "replaying" the L1Messages. This is needed for nodes upgrading too late to `EuclidV2`: https://github.com/scroll-tech/go-ethereum/blob/3186613c9f0dada02ab72600e7da076cf8cb5960/rollup/sync_service/sync_service.go#L87


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced message synchronization reliability with improved error handling.
	- Updated processing checks to detect unexpected message ordering and manage duplicate messages for consistent data processing.
	- Improved control flow for writing messages to the database after duplicate checks.
  
- **Chores**
	- Incremented the patch version from 20 to 21 to reflect the latest updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->