### PR TITLE
fix(verifier,l1follower): update da-codec to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/prometheus/tsdb v0.7.1
 	github.com/rjeczalik/notify v0.9.1
 	github.com/rs/cors v1.7.0
-	github.com/scroll-tech/da-codec v0.1.3-0.20250226072559-f8a8d3898f54
+	github.com/scroll-tech/da-codec v0.1.3-0.20250313120912-344f2d5e33e1
 	github.com/scroll-tech/zktrie v0.8.4
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/sourcegraph/conc v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,8 @@ github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncj
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/scroll-tech/da-codec v0.1.3-0.20250226072559-f8a8d3898f54 h1:qVpsVu1J91opTn6HYeuzWcBRVhQmPR8g05i+PlOjlI4=
-github.com/scroll-tech/da-codec v0.1.3-0.20250226072559-f8a8d3898f54/go.mod h1:xECEHZLVzbdUn+tNbRJhRIjLGTOTmnFQuTgUTeVLX58=
+github.com/scroll-tech/da-codec v0.1.3-0.20250313120912-344f2d5e33e1 h1:Dhd58LE1D+dnoxpgLVeQBMF9uweL/fhQfZHWtWSiOlE=
+github.com/scroll-tech/da-codec v0.1.3-0.20250313120912-344f2d5e33e1/go.mod h1:yhTS9OVC0xQGhg7DN5iV5KZJvnSIlFWAxDdp+6jxQtY=
 github.com/scroll-tech/zktrie v0.8.4 h1:UagmnZ4Z3ITCk+aUq9NQZJNAwnWl4gSxsLb2Nl7IgRE=
 github.com/scroll-tech/zktrie v0.8.4/go.mod h1:XvNo7vAk8yxNyTjBDj5WIiFzYW4bx/gJ78+NK6Zn6Uk=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 24        // Patch version component of the current release
+	VersionPatch = 25        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -209,7 +209,7 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 		if err = s.updateRollupEvents(daEntries); err != nil {
 			if errors.Is(err, ErrShouldResetSyncHeight) {
 				log.Warn("Resetting sync height to L1 block 7892672 to fix L1 message queue hash calculation")
-				s.callDataBlobSource.SetL1Height(7892672)
+				s.callDataBlobSource.SetL1Height(7892668)
 
 				return nil
 			}

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -208,7 +208,7 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 
 		if err = s.updateRollupEvents(daEntries); err != nil {
 			if errors.Is(err, ErrShouldResetSyncHeight) {
-				log.Warn("Resetting sync height to L1 block 7892672 to fix L1 message queue hash calculation")
+				log.Warn("Resetting sync height to L1 block 7892668 to fix L1 message queue hash calculation")
 				s.callDataBlobSource.SetL1Height(7892668)
 
 				return nil

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -577,8 +577,8 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 			// hashes. These in turn lead to a wrongly computed batch hash locally.
 			// This happened after upgrading to EuclidV2 where da-codec was not updated in l2geth.
 			// If the batch hash is the same as the hardcoded one, this means the node ran into this issue.
-			// We need to reset the sync height to the last batch in CodecV6. The node will overwrite the wrongly computed
-			// message queue hashes.
+			// We need to reset the sync height to 1 block before the L1 block in which the last batch in CodecV6 was committed.
+			// The node will overwrite the wrongly computed message queue hashes.
 			if localBatchHash == common.HexToHash("0x0b671dc4155c589ffa13dd481271c7b944a778f5ce23d5100546e2b45da61ba6") {
 				return 0, nil, ErrShouldResetSyncHeight
 			}

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -42,6 +42,8 @@ const (
 	defaultLogInterval = 5 * time.Minute
 )
 
+var ErrShouldResetSyncHeight = errors.New("ErrShouldResetSyncHeight")
+
 // RollupSyncService collects ScrollChain batch commit/revert/finalize events and stores metadata into db.
 type RollupSyncService struct {
 	ctx     context.Context
@@ -205,6 +207,12 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 		}
 
 		if err = s.updateRollupEvents(daEntries); err != nil {
+			if errors.Is(err, ErrShouldResetSyncHeight) {
+				log.Warn("Resetting sync height to L1 block 7892672 to fix L1 message queue hash calculation")
+				s.callDataBlobSource.SetL1Height(7892672)
+
+				return nil
+			}
 			// Reset the L1 height to the previous value to retry fetching the same data.
 			s.callDataBlobSource.SetL1Height(prevL1Height)
 			return fmt.Errorf("failed to parse and update rollup event logs: %w", err)
@@ -565,6 +573,16 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 		// This check ensures the correctness of all batch hashes in the bundle
 		// due to the parent-child relationship between batch hashes
 		if localBatchHash != event.BatchHash() {
+			// This is hotfix for the L1 message hash mismatch issue which lead to wrong committedBatchMeta.PostL1MessageQueueHash
+			// hashes. These in turn lead to a wrongly computed batch hash locally.
+			// This happened after upgrading to EuclidV2 where da-codec was not updated in l2geth.
+			// If the batch hash is the same as the hardcoded one, this means the node ran into this issue.
+			// We need to reset the sync height to the last batch in CodecV6. The node will overwrite the wrongly computed
+			// message queue hashes.
+			if localBatchHash == common.HexToHash("0x0b671dc4155c589ffa13dd481271c7b944a778f5ce23d5100546e2b45da61ba6") {
+				return 0, nil, ErrShouldResetSyncHeight
+			}
+
 			log.Error("Batch hash mismatch", "batch index", event.BatchIndex().Uint64(), "start block", startBlock.Header.Number.Uint64(), "end block", endBlock.Header.Number.Uint64(), "parent batch hash", parentFinalizedBatchMeta.BatchHash.Hex(), "parent TotalL1MessagePopped", parentFinalizedBatchMeta.TotalL1MessagePopped, "l1 finalized batch hash", event.BatchHash().Hex(), "l2 batch hash", localBatchHash.Hex())
 			chunksJson, err := json.Marshal(chunks)
 			if err != nil {

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -543,6 +544,15 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 
 	daBatch, err := codec.NewDABatch(batch)
 	if err != nil {
+		// This is hotfix for the L1 message hash mismatch issue which lead to wrong committedBatchMeta.PostL1MessageQueueHash
+		// hashes. These in turn lead to a wrongly computed batch hash locally.
+		// This happened after upgrading to EuclidV2 where da-codec was not updated in l2geth.
+		// If the batch hash is the same as the hardcoded one, this means the node ran into this issue.
+		// We need to reset the sync height to 1 block before the L1 block in which the last batch in CodecV6 was committed.
+		// The node will overwrite the wrongly computed message queue hashes.
+		if strings.Contains(err.Error(), "0xaa16faf2a1685fe1d7e0f2810b1a0e98c2841aef96596d10456a6d0f00000000") {
+			return 0, nil, ErrShouldResetSyncHeight
+		}
 		return 0, nil, fmt.Errorf("failed to create DA batch, batch index: %v, codec version: %v, err: %w", batchIndex, codecVersion, err)
 	}
 	localBatchHash := daBatch.Hash()
@@ -573,16 +583,6 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 		// This check ensures the correctness of all batch hashes in the bundle
 		// due to the parent-child relationship between batch hashes
 		if localBatchHash != event.BatchHash() {
-			// This is hotfix for the L1 message hash mismatch issue which lead to wrong committedBatchMeta.PostL1MessageQueueHash
-			// hashes. These in turn lead to a wrongly computed batch hash locally.
-			// This happened after upgrading to EuclidV2 where da-codec was not updated in l2geth.
-			// If the batch hash is the same as the hardcoded one, this means the node ran into this issue.
-			// We need to reset the sync height to 1 block before the L1 block in which the last batch in CodecV6 was committed.
-			// The node will overwrite the wrongly computed message queue hashes.
-			if localBatchHash == common.HexToHash("0x0b671dc4155c589ffa13dd481271c7b944a778f5ce23d5100546e2b45da61ba6") {
-				return 0, nil, ErrShouldResetSyncHeight
-			}
-
 			log.Error("Batch hash mismatch", "batch index", event.BatchIndex().Uint64(), "start block", startBlock.Header.Number.Uint64(), "end block", endBlock.Header.Number.Uint64(), "parent batch hash", parentFinalizedBatchMeta.BatchHash.Hex(), "parent TotalL1MessagePopped", parentFinalizedBatchMeta.TotalL1MessagePopped, "l1 finalized batch hash", event.BatchHash().Hex(), "l2 batch hash", localBatchHash.Hex())
 			chunksJson, err := json.Marshal(chunks)
 			if err != nil {

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -544,10 +544,11 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 
 	daBatch, err := codec.NewDABatch(batch)
 	if err != nil {
-		// This is hotfix for the L1 message hash mismatch issue which lead to wrong committedBatchMeta.PostL1MessageQueueHash
-		// hashes. These in turn lead to a wrongly computed batch hash locally.
-		// This happened after upgrading to EuclidV2 where da-codec was not updated in l2geth.
-		// If the batch hash is the same as the hardcoded one, this means the node ran into this issue.
+		// This is hotfix for the L1 message hash mismatch issue which lead to wrong committedBatchMeta.PostL1MessageQueueHash hashes.
+		// These in turn lead to a wrongly computed batch hash locally. This happened after upgrading to EuclidV2
+		// where da-codec was not updated to the latest version in l2geth.
+		// If the error message due to mismatching PostL1MessageQueueHash contains the same hash as the hardcoded one,
+		// this means the node ran into this issue.
 		// We need to reset the sync height to 1 block before the L1 block in which the last batch in CodecV6 was committed.
 		// The node will overwrite the wrongly computed message queue hashes.
 		if strings.Contains(err.Error(), "0xaa16faf2a1685fe1d7e0f2810b1a0e98c2841aef96596d10456a6d0f00000000") {


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

A recent da-codec change was not adopted in `l2geth` which lead to nodes halting with an error message like this:

```
ERROR[03-13|13:47:18.231|rollup/rollup_sync_service/rollup_sync_service.go:568]   Batch hash mismatch                      batch index=85915 start block=8,484,738 end block=8,484,738 parent batch hash=0x6fcd38355bb2e0ae33bdb2af733c75843f5806db2e3d2b18c5b9109884530ed9 parent TotalL1MessagePopped=1,062,112 l1 finalized batch hash=0x4e2d2be908e693058dd3c82b88ac275233673a361610eb2c27d74d0191569e7a l2 batch hash=0x0b671dc4155c589ffa13dd481271c7b944a778f5ce23d5100546e2b45da61ba6
```

As a workaround, we bump the codec version and add logic to allow nodes to automatically recover by re-syncing recent batches from L1.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Upgraded a core dependency to a newer build, enhancing overall stability and performance improvements.
- **New Features**
  - Introduced a new error handling mechanism that allows for a reset of the sync height under specific conditions, improving the robustness of rollup event processing.
- **Bug Fixes**
  - Implemented a hotfix to address L1 message hash mismatches, ensuring correct batch hash calculations.
- **Documentation**
  - Updated the versioning system to reflect the increment of the patch version from 24 to 25.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->