### PR TITLE
feat(tx-pool): migrate upstream setcode transaction changes

### DIFF
--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -477,15 +477,23 @@ func (tx *Transaction) SetCodeAuthorizations() []SetCodeAuthorization {
 	return setcodetx.AuthList
 }
 
-// SetCodeAuthorities returns a list of each authorization's corresponding authority.
+// SetCodeAuthorities returns a list of unique authorities from the
+// authorization list.
 func (tx *Transaction) SetCodeAuthorities() []common.Address {
 	setcodetx, ok := tx.inner.(*SetCodeTx)
 	if !ok {
 		return nil
 	}
-	auths := make([]common.Address, 0, len(setcodetx.AuthList))
+	var (
+		marks = make(map[common.Address]bool)
+		auths = make([]common.Address, 0, len(setcodetx.AuthList))
+	)
 	for _, auth := range setcodetx.AuthList {
 		if addr, err := auth.Authority(); err == nil {
+			if marks[addr] {
+				continue
+			}
+			marks[addr] = true
 			auths = append(auths, addr)
 		}
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 25        // Patch version component of the current release
+	VersionPatch = 26        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR migrates some recent upstream changes:
* Remove incorrect error logs and perf of `removeAuthorities`: https://github.com/ethereum/go-ethereum/pull/31249
* A `setCodeTx` reorg test: https://github.com/ethereum/go-ethereum/pull/31206
* Error message and validation changes: https://github.com/ethereum/go-ethereum/pull/31209

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] feat: A new feature

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Revamped transaction validations to provide clearer error messaging when the in-flight transaction limit is reached and to ensure unique tracking of authorizations.
- **Tests**
	- Expanded test coverage to validate enhanced transaction processing, including improved handling during chain reorganization scenarios.
- **Chores**
	- Incremented the patch version to reflect these updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->