### PR TITLE
feat: track latest relayed l1 message

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 26        // Patch version component of the current release
+	VersionPatch = 27        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Expose metric `chain/head/l1msg`, which tracks the latest seen L1 message queue index.

This is generally increasing (unless there is a reorg).

We can use it to track L1 message inclusion and detect if it is stuck for some reason.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - We've introduced enhanced monitoring that offers detailed insights into message processing within the blockchain system. This improvement enables users to observe operational performance and understand key processing trends.

- **Chores**
  - The patch version has been incremented to 27, reflecting the latest maintenance and quality improvements, which contribute to better system stability and overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->