### PR TITLE
gc optimize

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	godebug "runtime/debug"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -36,7 +35,6 @@ import (
 	"time"
 
 	pcsclite "github.com/gballet/go-libpcsclite"
-	gopsutil "github.com/shirou/gopsutil/mem"
 	"gopkg.in/urfave/cli.v1"
 
 	"github.com/scroll-tech/go-ethereum/accounts"
@@ -1783,26 +1781,6 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.ShadowForkPeerIDs = ctx.GlobalStringSlice(ShadowforkPeersFlag.Name)
 		log.Info("Shadow fork peers", "ids", cfg.ShadowForkPeerIDs)
 	}
-
-	// Cap the cache allowance and tune the garbage collector
-	mem, err := gopsutil.VirtualMemory()
-	if err == nil {
-		if 32<<(^uintptr(0)>>63) == 32 && mem.Total > 2*1024*1024*1024 {
-			log.Warn("Lowering memory allowance on 32bit arch", "available", mem.Total/1024/1024, "addressable", 2*1024)
-			mem.Total = 2 * 1024 * 1024 * 1024
-		}
-		allowance := int(mem.Total / 1024 / 1024 / 3)
-		if cache := ctx.GlobalInt(CacheFlag.Name); cache > allowance {
-			log.Warn("Sanitizing cache to Go's GC limits", "provided", cache, "updated", allowance)
-			ctx.GlobalSet(CacheFlag.Name, strconv.Itoa(allowance))
-		}
-	}
-	// Ensure Go's GC ignores the database cache for trigger percentage
-	cache := ctx.GlobalInt(CacheFlag.Name)
-	gogc := math.Max(20, math.Min(100, 100/(float64(cache)/1024)))
-
-	log.Debug("Sanitizing Go's GC trigger", "percent", int(gogc))
-	godebug.SetGCPercent(int(gogc))
 
 	if ctx.GlobalIsSet(SyncModeFlag.Name) {
 		cfg.SyncMode = *GlobalTextMarshaler(ctx, SyncModeFlag.Name).(*downloader.SyncMode)

--- a/internal/debug/api.go
+++ b/internal/debug/api.go
@@ -244,6 +244,11 @@ func (*HandlerT) SetGCPercent(v int) int {
 	return debug.SetGCPercent(v)
 }
 
+// SetMemoryLimit sets the GOMEMLIMIT for the process. It returns the previous limit.
+func (*HandlerT) SetMemoryLimit(limit int64) int64 {
+	return debug.SetMemoryLimit(limit)
+}
+
 func writeProfile(name, file string) error {
 	p := pprof.Lookup(name)
 	log.Info("Writing profile records", "count", p.Count(), "type", name, "dump", file)

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -309,8 +309,8 @@ web3._extend({
 			params: 1,
 		}),
 		new web3._extend.Method({
-			name: 'SetMemoryLimit',
-			call: 'debug_SetMemoryLimit',
+			name: 'setMemoryLimit',
+			call: 'debug_setMemoryLimit',
 			params: 1,
 		}),
 		new web3._extend.Method({

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -309,6 +309,11 @@ web3._extend({
 			params: 1,
 		}),
 		new web3._extend.Method({
+			name: 'SetMemoryLimit',
+			call: 'debug_SetMemoryLimit',
+			params: 1,
+		}),
+		new web3._extend.Method({
 			name: 'memStats',
 			call: 'debug_memStats',
 			params: 0,


### PR DESCRIPTION
when send too many transaction to txpool during my benchmark, the golang gc will take 1/3 CPU profile.

<img width="1793" alt="image" src="https://github.com/user-attachments/assets/09cdc6b4-1f93-4a2c-8a2e-7116186377aa" />

I want to use the `ballast` mechanism to reduce the gc times to reduce golang GC CPU cost. I try GOGC = 500 and GOMEMLIMIT=10G, but it doesn't work. mainly because this section of code limits the GOGC to never be over 100. 

https://github.com/scroll-tech/go-ethereum/blob/b3933861aec450bc2035f2b70fdd1714e95dab06/cmd/utils/flags.go#L1788-L1802

Assuming the memory is 30G, GOGC value is 20 after the calculation, this will make the Golang GC very frequent, wasting the CPU resources, so suggest removing this part.

If we wonder about the large number of txs that trigger the OOM, the suggestion is to set GOMEMLIMIT depending on the realistic situation.

For my benchmark, I have enough memory, I don't want the CPU waste on GC, I want to use `ballast` to reduce the GC times, I need a big GOGC value. here is the performance after the adjustment.

<img width="1786" alt="image" src="https://github.com/user-attachments/assets/d18edf61-071b-4b16-8074-d1bd70cb863e" />

The throughput increased 25% from 45Mgas/s to 55Mgas/s

### Before update
![Before update](https://github.com/user-attachments/assets/f736425a-4bca-47f0-b0af-02492a664cfb)

### After update.
![After update](https://github.com/user-attachments/assets/44577280-5b28-4691-ac4f-fa0451cc4c6e)

And most of the time, just keeping the GOGC = 100 is a good decision


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new debugging and web extension functionality that allows manual configuration of process memory limits.
  
- **Refactor**
	- Removed automatic memory management adjustments, shifting control to manual configuration for memory usage and garbage collection tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->