### PR TITLE
feat(worker): allow empty blocks

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -133,6 +133,7 @@ var (
 		utils.MinerNoVerifyFlag,
 		utils.MinerStoreSkippedTxTracesFlag,
 		utils.MinerMaxAccountsNumFlag,
+		utils.MinerAllowEmptyFlag,
 		utils.NATFlag,
 		utils.NoDiscoverFlag,
 		utils.DiscoveryV5Flag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -197,6 +197,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.MinerNoVerifyFlag,
 			utils.MinerStoreSkippedTxTracesFlag,
 			utils.MinerMaxAccountsNumFlag,
+			utils.MinerAllowEmptyFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -515,6 +515,10 @@ var (
 		Usage: "Maximum number of accounts that miner will fetch the pending transactions of when building a new block",
 		Value: math.MaxInt,
 	}
+	MinerAllowEmptyFlag = cli.BoolFlag{
+		Name:  "miner.allowempty",
+		Usage: "Allow sealing empty blocks",
+	}
 	// Account settings
 	UnlockedAccountFlag = cli.StringFlag{
 		Name:  "unlock",
@@ -1619,6 +1623,9 @@ func setMiner(ctx *cli.Context, cfg *miner.Config) {
 	}
 	if ctx.GlobalIsSet(MinerMaxAccountsNumFlag.Name) {
 		cfg.MaxAccountsNum = ctx.GlobalInt(MinerMaxAccountsNumFlag.Name)
+	}
+	if ctx.GlobalIsSet(MinerAllowEmptyFlag.Name) {
+		cfg.AllowEmpty = ctx.GlobalBool(MinerAllowEmptyFlag.Name)
 	}
 	if ctx.GlobalIsSet(LegacyMinerGasTargetFlag.Name) {
 		log.Warn("The generic --miner.gastarget flag is deprecated and will be removed in the future!")

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -60,6 +60,7 @@ type Config struct {
 	StoreSkippedTxTraces bool // Whether store the wrapped traces when storing a skipped tx
 	MaxAccountsNum       int  // Maximum number of accounts that miner will fetch the pending transactions of when building a new block
 	CCCMaxWorkers        int  // Maximum number of workers to use for async CCC tasks
+	AllowEmpty           bool // If true, then we allow sealing empty blocks
 
 	SigningDisabled bool // Whether to disable signing blocks with consensus enginek
 }

--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -400,6 +400,9 @@ func (w *worker) mainLoop() {
 			w.current.deadlineReached = true
 			if len(w.current.txs) > 0 {
 				_, err = w.commit()
+			} else if w.config.AllowEmpty {
+				log.Warn("Committing empty block", "number", w.current.header.Number)
+				_, err = w.commit()
 			}
 		case ev := <-w.txsCh:
 			idleTimer.UpdateSince(idleStart)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 28        // Patch version component of the current release
+	VersionPatch = 29        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

When the sequencer is run with `--miner.allowempty`, we allow producing empty blocks. The goal is to have relatively stable block time even when there are few transactions.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a configuration option enabling the miner to seal empty blocks when no transactions are available, enhancing block processing flexibility.

- **Chores**
  - Updated the client version patch number to reflect the latest release changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->