### PR TITLE
fix: correctly initialize latest l1msg gauge

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 29        // Patch version component of the current release
+	VersionPatch = 30        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Initialize latest relayed msg hash gauge to avoid it "jumping back to 0" when we redeploy a node.

<img width="928" alt="image" src="https://github.com/user-attachments/assets/aa6821a9-31e8-49f6-a51e-ca0d45688b71" />


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling and processing of transaction metrics within blocks to enhance overall efficiency.
- **Chores**
  - Updated the application’s patch version to reflect the latest release changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->