### PR TITLE
fix: add sload/sstore witness when calculating dynamic gas

### DIFF
--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -101,7 +101,7 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
 	)
 
-	// Get the witness of the SSTORE at first to align with reth's witness implementation.
+	// Get the witness of SSTORE at first to align with reth's witness implementation.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// The legacy gas metering only takes into consideration the current state
@@ -188,7 +188,7 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	)
 	value := common.Hash(y.Bytes32())
 
-	// Get the witness of the SSTORE at first to align with reth's witness implementation.
+	// Get the witness of SSTORE at first to align with reth's witness implementation.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// If we fail the minimum gas availability invariant, fail (0)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -102,7 +102,6 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	)
 
 	// Get the witness of SSTORE at first to align with reth's witness implementation.
-	// It's a temporary fix which might increase DoS vector in some corner cases.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// The legacy gas metering only takes into consideration the current state
@@ -190,7 +189,6 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	value := common.Hash(y.Bytes32())
 
 	// Get the witness of SSTORE at first to align with reth's witness implementation.
-	// It's a temporary fix which might increase DoS vector in some corner cases.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// If we fail the minimum gas availability invariant, fail (0)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -102,6 +102,7 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	)
 
 	// Get the witness of SSTORE at first to align with reth's witness implementation.
+	// It's a temporary fix which might increase DoS vector in some corner cases.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// The legacy gas metering only takes into consideration the current state
@@ -189,6 +190,7 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	value := common.Hash(y.Bytes32())
 
 	// Get the witness of SSTORE at first to align with reth's witness implementation.
+	// It's a temporary fix which might increase DoS vector in some corner cases.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// If we fail the minimum gas availability invariant, fail (0)

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -100,6 +100,10 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 		y, x    = stack.Back(1), stack.Back(0)
 		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
 	)
+
+	// Get the witness of the SSTORE at first to align with reth's witness implementation.
+	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
+
 	// The legacy gas metering only takes into consideration the current state
 	// Legacy rules should be applied if we are in Petersburg (removal of EIP-1283)
 	// OR Constantinople is not active
@@ -137,7 +141,6 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	if current == value { // noop (1)
 		return params.NetSstoreNoopGas, nil
 	}
-	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 	if original == current {
 		if original == (common.Hash{}) { // create slot (2.1.1)
 			return params.NetSstoreInitGas, nil
@@ -178,10 +181,6 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 //       2.2.2.1. If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter.
 //       2.2.2.2. Otherwise, add SSTORE_RESET_GAS - SLOAD_GAS gas to refund counter.
 func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-	// If we fail the minimum gas availability invariant, fail (0)
-	if contract.Gas <= params.SstoreSentryGasEIP2200 {
-		return 0, errors.New("not enough gas for reentrancy sentry")
-	}
 	// Gas sentry honoured, do the actual gas calculation based on the stored value
 	var (
 		y, x    = stack.Back(1), stack.Back(0)
@@ -189,10 +188,17 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	)
 	value := common.Hash(y.Bytes32())
 
+	// Get the witness of the SSTORE at first to align with reth's witness implementation.
+	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
+
+	// If we fail the minimum gas availability invariant, fail (0)
+	if contract.Gas <= params.SstoreSentryGasEIP2200 {
+		return 0, errors.New("not enough gas for reentrancy sentry")
+	}
+
 	if current == value { // noop (1)
 		return params.SloadGasEIP2200, nil
 	}
-	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 	if original == current {
 		if original == (common.Hash{}) { // create slot (2.1.1)
 			return params.SstoreSetGasEIP2200, nil

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -101,7 +101,7 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 		current = evm.StateDB.GetState(contract.Address(), x.Bytes32())
 	)
 
-	// Get the witness of SSTORE at first to align with reth's witness implementation.
+	// Try updating the witness of SSTORE at first to align with reth's witness implementation.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// The legacy gas metering only takes into consideration the current state
@@ -188,7 +188,7 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	)
 	value := common.Hash(y.Bytes32())
 
-	// Get the witness of SSTORE at first to align with reth's witness implementation.
+	// Try updating the witness of SSTORE at first to align with reth's witness implementation.
 	original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 	// If we fail the minimum gas availability invariant, fail (0)

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -35,13 +35,13 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			cost    = uint64(0)
 		)
 
+		// Get the witness of SSTORE at first to align with reth's witness implementation.
+		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
+
 		// If we fail the minimum gas availability invariant, fail (0)
 		if contract.Gas <= params.SstoreSentryGasEIP2200 {
 			return 0, errors.New("not enough gas for reentrancy sentry")
 		}
-
-		// Get the witness of SSTORE at first to align with reth's witness implementation.
-		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 		// Check slot presence in the access list
 		if addrPresent, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -36,6 +36,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		)
 
 		// Get the witness of SSTORE at first to align with reth's witness implementation.
+		// It's a temporary fix which might increase DoS vector in some corner cases.
 		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 		// If we fail the minimum gas availability invariant, fail (0)
@@ -109,18 +110,19 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
 
-	// Get the witness of SLOAD at first to align with reth's witness implementation.
-	// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929.
-	// Frontier gas cost simply uses params.SloadGasFrontier (i.e., 50 gas), so changing the gas cost there
-	// might affect code cleanliness. Usually, this won't be a problem because EIP-2929 is enabled by default.
-	// Thus, adding the SLOAD witness before EIP-2929 is left as a TODO here.
-	evm.StateDB.GetCommittedState(contract.Address(), loc.Bytes32())
-
 	// Check slot presence in the access list
 	if _, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 		// If the caller cannot afford the cost, this change will be rolled back
 		// If he does afford it, we can skip checking the same thing later on, during execution
 		evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
+
+		// Get the witness of SLOAD at first to align with reth's witness implementation.
+		// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929.
+		// Frontier gas cost simply uses params.SloadGasFrontier (i.e., 50 gas), so changing the gas cost there
+		// might affect code cleanliness. Usually, this won't be a problem because EIP-2929 is enabled by default.
+		// Thus, adding the SLOAD witness before EIP-2929 is left as a TODO here.
+		evm.StateDB.GetCommittedState(contract.Address(), loc.Bytes32())
+
 		return params.ColdSloadCostEIP2929, nil
 	}
 	return params.WarmStorageReadCostEIP2929, nil

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -104,6 +104,13 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
+
+	// Get the witness of SLOAD operation to align with revm witness
+	// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929
+	// Frontier gas cost simply uses params.SloadGasFrontier (i.e. 50 gas), so changing the gas cost there would affect code cleanliness
+	// Usually this won't be a problem, leaving it as a TODO here.
+	evm.StateDB.GetCommittedState(contract.Address(), loc.Bytes32())
+
 	// Check slot presence in the access list
 	if _, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 		// If the caller cannot afford the cost, this change will be rolled back

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -27,10 +27,6 @@ import (
 
 func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 	return func(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
-		// If we fail the minimum gas availability invariant, fail (0)
-		if contract.Gas <= params.SstoreSentryGasEIP2200 {
-			return 0, errors.New("not enough gas for reentrancy sentry")
-		}
 		// Gas sentry honoured, do the actual gas calculation based on the stored value
 		var (
 			y, x    = stack.Back(1), stack.peek()
@@ -38,6 +34,15 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			current = evm.StateDB.GetState(contract.Address(), slot)
 			cost    = uint64(0)
 		)
+
+		// If we fail the minimum gas availability invariant, fail (0)
+		if contract.Gas <= params.SstoreSentryGasEIP2200 {
+			return 0, errors.New("not enough gas for reentrancy sentry")
+		}
+
+		// Get the witness of the SSTORE at first to align with reth's witness implementation.
+		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
+
 		// Check slot presence in the access list
 		if addrPresent, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 			cost = params.ColdSloadCostEIP2929
@@ -57,7 +62,6 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			//		return params.SloadGasEIP2200, nil
 			return cost + params.WarmStorageReadCostEIP2929, nil // SLOAD_GAS
 		}
-		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 		if original == current {
 			if original == (common.Hash{}) { // create slot (2.1.1)
 				return cost + params.SstoreSetGasEIP2200, nil
@@ -105,10 +109,11 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
 
-	// Get the witness of SLOAD operation to align with revm witness
-	// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929
-	// Frontier gas cost simply uses params.SloadGasFrontier (i.e. 50 gas), so changing the gas cost there would affect code cleanliness
-	// Usually this won't be a problem, leaving it as a TODO here.
+	// Get the witness of the SLOAD at first to align with reth's witness implementation.
+	// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929.
+	// Frontier gas cost simply uses params.SloadGasFrontier (i.e., 50 gas), so changing the gas cost there
+	// might affect code cleanliness. Usually, this won't be a problem because EIP-2929 is enabled by default.
+	// Thus, adding the SLOAD witness before EIP-2929 is left as a TODO here.
 	evm.StateDB.GetCommittedState(contract.Address(), loc.Bytes32())
 
 	// Check slot presence in the access list

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -40,7 +40,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			return 0, errors.New("not enough gas for reentrancy sentry")
 		}
 
-		// Get the witness of the SSTORE at first to align with reth's witness implementation.
+		// Get the witness of SSTORE at first to align with reth's witness implementation.
 		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 		// Check slot presence in the access list
@@ -109,7 +109,7 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
 
-	// Get the witness of the SLOAD at first to align with reth's witness implementation.
+	// Get the witness of SLOAD at first to align with reth's witness implementation.
 	// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929.
 	// Frontier gas cost simply uses params.SloadGasFrontier (i.e., 50 gas), so changing the gas cost there
 	// might affect code cleanliness. Usually, this won't be a problem because EIP-2929 is enabled by default.

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -36,7 +36,6 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		)
 
 		// Get the witness of SSTORE at first to align with reth's witness implementation.
-		// It's a temporary fix which might increase DoS vector in some corner cases.
 		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 		// If we fail the minimum gas availability invariant, fail (0)

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -35,7 +35,7 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 			cost    = uint64(0)
 		)
 
-		// Get the witness of SSTORE at first to align with reth's witness implementation.
+		// Try updating the witness of SSTORE at first to align with reth's witness implementation.
 		original := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 
 		// If we fail the minimum gas availability invariant, fail (0)
@@ -115,7 +115,7 @@ func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, me
 		// If he does afford it, we can skip checking the same thing later on, during execution
 		evm.StateDB.AddSlotToAccessList(contract.Address(), slot)
 
-		// Get the witness of SLOAD at first to align with reth's witness implementation.
+		// Try updating the witness of SLOAD to align with reth's witness implementation.
 		// Another place that needs to change is when calculating the gas cost after Frontier and before EIP-2929.
 		// Frontier gas cost simply uses params.SloadGasFrontier (i.e., 50 gas), so changing the gas cost there
 		// might affect code cleanliness. Usually, this won't be a problem because EIP-2929 is enabled by default.

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -108,7 +108,6 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 func gasSLoadEIP2929(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySize uint64) (uint64, error) {
 	loc := stack.peek()
 	slot := common.Hash(loc.Bytes32())
-
 	// Check slot presence in the access list
 	if _, slotPresent := evm.StateDB.SlotInAccessList(contract.Address(), slot); !slotPresent {
 		// If the caller cannot afford the cost, this change will be rolled back

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 29        // Patch version component of the current release
+	VersionPatch = 30        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR gets the witness of `SLOAD` and `SSTORE`immediately before calculating their dynamic gas, to align with `reth`'s witness implementation.

Another place that needs to change for `SLOAD` witness loading is when calculating the gas cost after Frontier and before EIP-2929. Frontier gas cost simply uses `params.SloadGasFrontier` (i.e. 50 gas), so changing the gas cost there might affect code cleanliness. Usually, this won't be a problem because EIP-2929 is enabled by default, thus leaving adding `SLOAD` witness before EIP-2929 as a TODO.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Improved the sequence of operations for state retrieval and gas calculations in multiple functions.

- **Chore**
  - Incremented the patch version to reflect the latest release (VersionPatch updated from 29 to 30).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->