### PR TITLE
fix: add failure retries in testWitness

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -368,6 +368,13 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	if err := blockchain.Validator().ValidateState(block, statedb, receipts, usedGas); err != nil {
 		return nil, fmt.Errorf("failed to validate block %d: %w", block.Number(), err)
 	}
+
+	for retries := 0; retries <= 3; retries++ {
+		err = testWitness(blockchain, block, witness)
+		if err == nil {
+			return witness, nil
+		}
+	}
 	return witness, testWitness(blockchain, block, witness)
 }
 
@@ -408,6 +415,7 @@ func testWitness(blockchain *core.BlockChain, block *types.Block, witness *state
 	}
 	retryLimit := 5
 	for retries := 0; retries <= retryLimit; retries++ {
+		statedb.Commit(blockchain.Config().IsEIP158(block.Number()))
 		computedRoot := statedb.IntermediateRoot(blockchain.Config().IsEIP158(block.Number()))
 		if computedRoot == postStateRoot {
 			break

--- a/eth/api.go
+++ b/eth/api.go
@@ -413,22 +413,15 @@ func testWitness(blockchain *core.BlockChain, block *types.Block, witness *state
 		log.Debug("Using disk root for post state root", "postStateRoot", postStateRoot.Hex(), "diskRoot", diskRoot.Hex())
 		postStateRoot = diskRoot
 	}
-	retryLimit := 5
-	for retries := 0; retries <= retryLimit; retries++ {
-		statedb.Commit(blockchain.Config().IsEIP158(block.Number()))
-		computedRoot := statedb.IntermediateRoot(blockchain.Config().IsEIP158(block.Number()))
-		if computedRoot == postStateRoot {
-			break
-		}
+	computedRoot := statedb.GetRootHash()
+	if computedRoot != postStateRoot {
 		log.Debug("State root mismatch", "block", block.Number(), "expected", postStateRoot.Hex(), "got", computedRoot)
-		if retries == retryLimit {
-			executionWitness := ToExecutionWitness(witness)
-			jsonStr, err := json.Marshal(executionWitness)
-			if err != nil {
-				return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, err)
-			}
-			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, string(jsonStr))
+		executionWitness := ToExecutionWitness(witness)
+		jsonStr, err := json.Marshal(executionWitness)
+		if err != nil {
+			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, err)
 		}
+		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, string(jsonStr))
 	}
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -378,6 +378,7 @@ func testWitness(blockchain *core.BlockChain, block *types.Block, witness *state
 		return fmt.Errorf("failed to read disk state root for stateRoot %s: %w", stateRoot.Hex(), err)
 	}
 	if diskRoot != (common.Hash{}) {
+		log.Debug("Using disk root for state root", "stateRoot", stateRoot.Hex(), "diskRoot", diskRoot.Hex())
 		stateRoot = diskRoot
 	}
 
@@ -402,15 +403,17 @@ func testWitness(blockchain *core.BlockChain, block *types.Block, witness *state
 		return fmt.Errorf("failed to read disk state root for postStateRoot %s: %w", postStateRoot.Hex(), err)
 	}
 	if diskRoot != (common.Hash{}) {
+		log.Debug("Using disk root for post state root", "postStateRoot", postStateRoot.Hex(), "diskRoot", diskRoot.Hex())
 		postStateRoot = diskRoot
 	}
-	if statedb.GetRootHash() != postStateRoot {
+	computedRoot := statedb.IntermediateRoot(blockchain.Config().IsEIP158(block.Number()))
+	if computedRoot != postStateRoot {
 		executionWitness := ToExecutionWitness(witness)
 		jsonStr, err := json.Marshal(executionWitness)
 		if err != nil {
-			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), statedb.GetRootHash().Hex(), err)
+			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, err)
 		}
-		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), statedb.GetRootHash().Hex(), string(jsonStr))
+		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, string(jsonStr))
 	}
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -405,7 +405,12 @@ func testWitness(blockchain *core.BlockChain, block *types.Block, witness *state
 		postStateRoot = diskRoot
 	}
 	if statedb.GetRootHash() != postStateRoot {
-		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), statedb.GetRootHash().Hex())
+		executionWitness := ToExecutionWitness(witness)
+		jsonStr, err := json.Marshal(executionWitness)
+		if err != nil {
+			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), statedb.GetRootHash().Hex(), err)
+		}
+		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), statedb.GetRootHash().Hex(), string(jsonStr))
 	}
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -373,31 +373,39 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 
 func testWitness(blockchain *core.BlockChain, block *types.Block, witness *stateless.Witness) error {
 	stateRoot := witness.Root()
-	if diskRoot, _ := rawdb.ReadDiskStateRoot(blockchain.Database(), stateRoot); diskRoot != (common.Hash{}) {
+	diskRoot, err := rawdb.ReadDiskStateRoot(blockchain.Database(), stateRoot)
+	if err != nil {
+		return fmt.Errorf("failed to read disk state root for stateRoot %s: %w", stateRoot.Hex(), err)
+	}
+	if diskRoot != (common.Hash{}) {
 		stateRoot = diskRoot
 	}
 
 	// Create and populate the state database to serve as the stateless backend
 	statedb, err := state.New(stateRoot, state.NewDatabase(witness.MakeHashDB()), nil)
 	if err != nil {
-		return fmt.Errorf("failed to create state database: %w", err)
+		return fmt.Errorf("failed to create state database with stateRoot %s: %w", stateRoot.Hex(), err)
 	}
 
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
 	if err != nil {
-		return fmt.Errorf("failed to process block %d: %w", block.Number(), err)
+		return fmt.Errorf("failed to process block %d (hash: %s): %w", block.Number(), block.Hash().Hex(), err)
 	}
 
 	if err := blockchain.Validator().ValidateState(block, statedb, receipts, usedGas); err != nil {
-		return fmt.Errorf("failed to validate block %d: %w", block.Number(), err)
+		return fmt.Errorf("failed to validate block %d (hash: %s): %w", block.Number(), block.Hash().Hex(), err)
 	}
 
 	postStateRoot := block.Root()
-	if diskRoot, _ := rawdb.ReadDiskStateRoot(blockchain.Database(), postStateRoot); diskRoot != (common.Hash{}) {
+	diskRoot, err = rawdb.ReadDiskStateRoot(blockchain.Database(), postStateRoot)
+	if err != nil {
+		return fmt.Errorf("failed to read disk state root for postStateRoot %s: %w", postStateRoot.Hex(), err)
+	}
+	if diskRoot != (common.Hash{}) {
 		postStateRoot = diskRoot
 	}
 	if statedb.GetRootHash() != postStateRoot {
-		return fmt.Errorf("failed to commit statelessly %d: %w", block.Number(), err)
+		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), statedb.GetRootHash().Hex())
 	}
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -406,14 +406,21 @@ func testWitness(blockchain *core.BlockChain, block *types.Block, witness *state
 		log.Debug("Using disk root for post state root", "postStateRoot", postStateRoot.Hex(), "diskRoot", diskRoot.Hex())
 		postStateRoot = diskRoot
 	}
-	computedRoot := statedb.IntermediateRoot(blockchain.Config().IsEIP158(block.Number()))
-	if computedRoot != postStateRoot {
-		executionWitness := ToExecutionWitness(witness)
-		jsonStr, err := json.Marshal(executionWitness)
-		if err != nil {
-			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, err)
+	retryLimit := 5
+	for retries := 0; retries <= retryLimit; retries++ {
+		computedRoot := statedb.IntermediateRoot(blockchain.Config().IsEIP158(block.Number()))
+		if computedRoot == postStateRoot {
+			break
 		}
-		return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, string(jsonStr))
+		log.Debug("State root mismatch", "block", block.Number(), "expected", postStateRoot.Hex(), "got", computedRoot)
+		if retries == retryLimit {
+			executionWitness := ToExecutionWitness(witness)
+			jsonStr, err := json.Marshal(executionWitness)
+			if err != nil {
+				return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, but failed to marshal witness: %w", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, err)
+			}
+			return fmt.Errorf("state root mismatch after processing block %d (hash: %s): expected %s, got %s, witness: %s", block.Number(), block.Hash().Hex(), postStateRoot.Hex(), computedRoot, string(jsonStr))
+		}
 	}
 	return nil
 }

--- a/eth/api.go
+++ b/eth/api.go
@@ -369,13 +369,12 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 		return nil, fmt.Errorf("failed to validate block %d: %w", block.Number(), err)
 	}
 
-	for retries := 0; retries <= 3; retries++ {
-		err = testWitness(blockchain, block, witness)
-		if err == nil {
+	for retries := 0; retries < 5; retries++ {
+		if err = testWitness(blockchain, block, witness); err == nil {
 			return witness, nil
 		}
 	}
-	return witness, testWitness(blockchain, block, witness)
+	return witness, err
 }
 
 func testWitness(blockchain *core.BlockChain, block *types.Block, witness *stateless.Witness) error {

--- a/eth/api.go
+++ b/eth/api.go
@@ -369,6 +369,8 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 		return nil, fmt.Errorf("failed to validate block %d: %w", block.Number(), err)
 	}
 
+	// FIXME: testWitness will fail from time to time, the problem is caused by occasional state root mismatch
+	// after processing the block based on witness. We need to investigate the root cause and fix it.
 	for retries := 0; retries < 5; retries++ {
 		if err = testWitness(blockchain, block, witness); err == nil {
 			return witness, nil

--- a/eth/api.go
+++ b/eth/api.go
@@ -374,6 +374,8 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	for retries := 0; retries < 5; retries++ {
 		if err = testWitness(blockchain, block, witness); err == nil {
 			return witness, nil
+		} else {
+			log.Warn("Failed to validate witness", "block", block.Number(), "error", err)
 		}
 	}
 	return witness, err

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 31        // Patch version component of the current release
+	VersionPatch = 32        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR adds retries in `testWitness`, which sometimes calculates an incorrect state root. The issue is probably located in `blockchain.Processor().Process`.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error messaging to provide improved context during failure conditions, aiding in troubleshooting.
  
- **Chores**
  - Updated the patch version from 31 to 32 to signal the latest release update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->