### PR TITLE
fix(api): eth_getProof crash

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -679,7 +679,7 @@ type StorageResult struct {
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
-	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
@@ -732,7 +732,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		StorageProof:   storageProof,
 	}
 
-	if !s.b.ChainConfig().IsEuclid(header.Time) {
+	if state.IsZktrie() {
 		if storageTrie != nil {
 			result.PoseidonCodeHash = state.GetPoseidonCodeHash(address)
 		} else {

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -679,7 +679,7 @@ type StorageResult struct {
 
 // GetProof returns the Merkle-proof for a given account and optionally some storage keys.
 func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Address, storageKeys []string, blockNrOrHash rpc.BlockNumberOrHash) (*AccountResult, error) {
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	state, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if state == nil || err != nil {
 		return nil, err
 	}
@@ -721,7 +721,7 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		return nil, proofErr
 	}
 
-	return &AccountResult{
+	result := &AccountResult{
 		Address:        address,
 		AccountProof:   toHexSlice(accountProof),
 		Balance:        (*hexutil.Big)(state.GetBalance(address)),
@@ -730,7 +730,17 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		Nonce:          hexutil.Uint64(state.GetNonce(address)),
 		StorageHash:    storageHash,
 		StorageProof:   storageProof,
-	}, state.Error()
+	}
+
+	if !s.b.ChainConfig().IsEuclid(header.Time) {
+		if storageTrie != nil {
+			result.PoseidonCodeHash = state.GetPoseidonCodeHash(address)
+		} else {
+			result.PoseidonCodeHash = codehash.EmptyPoseidonCodeHash
+		}
+	}
+
+	return result, state.Error()
 }
 
 // GetHeaderByNumber returns the requested canonical block header.

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -692,7 +692,6 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 		storageHash = types.EmptyRootHash
 	}
 	keccakCodeHash := state.GetKeccakCodeHash(address)
-	poseidonCodeHash := state.GetPoseidonCodeHash(address)
 	storageProof := make([]StorageResult, len(storageKeys))
 
 	// if we have a storageTrie, (which means the account exists), we can update the storagehash
@@ -701,7 +700,6 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 	} else {
 		// no storageTrie means the account does not exist, so the codeHash is the hash of an empty bytearray.
 		keccakCodeHash = codehash.EmptyKeccakCodeHash
-		poseidonCodeHash = codehash.EmptyPoseidonCodeHash
 	}
 
 	// create the proof for the storageKeys
@@ -724,15 +722,14 @@ func (s *PublicBlockChainAPI) GetProof(ctx context.Context, address common.Addre
 	}
 
 	return &AccountResult{
-		Address:          address,
-		AccountProof:     toHexSlice(accountProof),
-		Balance:          (*hexutil.Big)(state.GetBalance(address)),
-		KeccakCodeHash:   keccakCodeHash,
-		PoseidonCodeHash: poseidonCodeHash,
-		CodeSize:         hexutil.Uint64(state.GetCodeSize(address)),
-		Nonce:            hexutil.Uint64(state.GetNonce(address)),
-		StorageHash:      storageHash,
-		StorageProof:     storageProof,
+		Address:        address,
+		AccountProof:   toHexSlice(accountProof),
+		Balance:        (*hexutil.Big)(state.GetBalance(address)),
+		KeccakCodeHash: keccakCodeHash,
+		CodeSize:       hexutil.Uint64(state.GetCodeSize(address)),
+		Nonce:          hexutil.Uint64(state.GetNonce(address)),
+		StorageHash:    storageHash,
+		StorageProof:   storageProof,
 	}, state.Error()
 }
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 32        // Patch version component of the current release
+	VersionPatch = 33        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Remove `PoseidonCodeHash` since it's only supported before `Euclid`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the blockchain API responses by removing the Poseidon code hash from account data.
- **Chores**
	- Updated the application patch version from 32 to 33 to reflect the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->