### PR TITLE
feat(L1Reader): change to NextUnfinalizedL1MessageQueueIndex and add GetFinalizedStateRootByBatchIndex

### DIFF
--- a/rollup/l1/reader.go
+++ b/rollup/l1/reader.go
@@ -72,7 +72,7 @@ func NewReader(ctx context.Context, config Config, l1Client Client) (*Reader, er
 	return &reader, nil
 }
 
-func (r *Reader) FinalizedL1MessageQueueIndex(blockNumber uint64) (uint64, error) {
+func (r *Reader) NextUnfinalizedL1MessageQueueIndex(blockNumber uint64) (uint64, error) {
 	data, err := r.l1MessageQueueABI.Pack(nextUnfinalizedQueueIndex)
 	if err != nil {
 		return 0, fmt.Errorf("failed to pack %s: %w", nextUnfinalizedQueueIndex, err)
@@ -92,11 +92,7 @@ func (r *Reader) FinalizedL1MessageQueueIndex(blockNumber uint64) (uint64, error
 	}
 
 	next := parsedResult.Uint64()
-	if next == 0 {
-		return 0, nil
-	}
-
-	return next - 1, nil
+	return next, nil
 }
 
 func (r *Reader) LatestFinalizedBatchIndex(blockNumber uint64) (uint64, error) {

--- a/rollup/l1/reader.go
+++ b/rollup/l1/reader.go
@@ -23,6 +23,7 @@ const (
 	finalizeBatchEventName    = "FinalizeBatch"
 	nextUnfinalizedQueueIndex = "nextUnfinalizedQueueIndex"
 	lastFinalizedBatchIndex   = "lastFinalizedBatchIndex"
+	finalizedStateRoots       = "finalizedStateRoots"
 
 	defaultRollupEventsFetchBlockRange = 100
 )
@@ -115,6 +116,28 @@ func (r *Reader) LatestFinalizedBatchIndex(blockNumber uint64) (uint64, error) {
 	}
 
 	return parsedResult.Uint64(), nil
+}
+
+func (r *Reader) GetFinalizedStateRootByBatchIndex(blockNumber uint64, batchIndex uint64) (common.Hash, error) {
+	data, err := r.scrollChainABI.Pack(finalizedStateRoots, big.NewInt(int64(batchIndex)))
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to pack %s: %w", finalizedStateRoots, err)
+	}
+
+	result, err := r.client.CallContract(r.ctx, ethereum.CallMsg{
+		To:   &r.config.ScrollChainAddress,
+		Data: data,
+	}, new(big.Int).SetUint64(blockNumber))
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to call %s: %w", finalizedStateRoots, err)
+	}
+
+	var parsedResult common.Hash
+	if err = r.scrollChainABI.UnpackIntoInterface(&parsedResult, finalizedStateRoots, result); err != nil {
+		return common.Hash{}, fmt.Errorf("failed to unpack result: %w", err)
+	}
+
+	return parsedResult, nil
 }
 
 // GetLatestFinalizedBlockNumber fetches the block number of the latest finalized block from the L1 chain.


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

change FinalizedL1MessageQueueIndex to NextUnfinalizedL1MessageQueueIndex


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to fetch finalized state roots by batch index.
- **Improvements**
  - Updated terminology for message queue index retrieval to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->