### PR TITLE
feat(rollup-verifier): make withdraw root check optional

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 43        // Patch version component of the current release
+	VersionPatch = 44        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Make withdraw trie root verification optional, so that rollup-verifier works on full nodes with pruned historical states.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the patch version number to 44.

- **Bug Fixes**
	- Improved handling of missing withdraw root data during batch validation, allowing the process to continue even if local withdraw root information is unavailable.
	- Withdraw root validation is now optional and non-blocking, enhancing compatibility with nodes lacking historical state data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->