### PR TITLE
fix: address race condition during EuclidV2 header chain verification

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 45        // Patch version component of the current release
+	VersionPatch = 46        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

A race condition during the verification of EuclidV2 transition headers occasionally lead to issues like this:

```
Verifying EuclidV2 transition header chain
Start EuclidV2 transition verification in Clique section startBlockNumber=14,906,951 endBlockNumber=14,907,014
Start EuclidV2 transition verification in SystemContract section startBlockNumber=14,907,015 endBlockNumber=14,907,910
Error verifying headers                  err="unknown ancestor"
Aborted EuclidV2 transition verification in SystemContract section
Invalid header encountered               number=14,907,015 hash=d0ba21..a048c6 parent=75c8df..83fe94 err="unknown ancestor"
```


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of header verification, reducing the chance of "unknown ancestor" errors during synchronization.
- **Chores**
	- Updated the patch version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->