### PR TITLE
fix: provide parent header during EuclidV2 transition verification

### DIFF
--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -226,7 +226,7 @@ func (c *Clique) VerifyHeader(chain consensus.ChainHeaderReader, header *types.H
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers. The
 // method returns a quit channel to abort the operations and a results channel to
 // retrieve the async verifications (the order is that of the input slice).
-func (c *Clique) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (c *Clique) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool, parent *types.Header) (chan<- struct{}, <-chan error) {
 	abort := make(chan struct{})
 	results := make(chan error, len(headers))
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -71,7 +71,7 @@ type Engine interface {
 	// concurrently. The method returns a quit channel to abort the operations and
 	// a results channel to retrieve the async verifications (the order is that of
 	// the input slice).
-	VerifyHeaders(chain ChainHeaderReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error)
+	VerifyHeaders(chain ChainHeaderReader, headers []*types.Header, seals []bool, parent *types.Header) (chan<- struct{}, <-chan error)
 
 	// VerifyUncles verifies that the given block's uncles conform to the consensus
 	// rules of a given engine.

--- a/consensus/ethash/consensus.go
+++ b/consensus/ethash/consensus.go
@@ -119,7 +119,7 @@ func (ethash *Ethash) VerifyHeader(chain consensus.ChainHeaderReader, header *ty
 // VerifyHeaders is similar to VerifyHeader, but verifies a batch of headers
 // concurrently. The method returns a quit channel to abort the operations and
 // a results channel to retrieve the async verifications.
-func (ethash *Ethash) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool) (chan<- struct{}, <-chan error) {
+func (ethash *Ethash) VerifyHeaders(chain consensus.ChainHeaderReader, headers []*types.Header, seals []bool, parent *types.Header) (chan<- struct{}, <-chan error) {
 	// If we're running a full engine faking, accept any input as valid
 	if ethash.config.PowMode == ModeFullFake || len(headers) == 0 {
 		abort, results := make(chan struct{}), make(chan error, len(headers))

--- a/consensus/system_contract/system_contract.go
+++ b/consensus/system_contract/system_contract.go
@@ -3,10 +3,13 @@ package system_contract
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"sync"
 	"time"
 
+	"github.com/scroll-tech/go-ethereum"
 	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/log"
 	"github.com/scroll-tech/go-ethereum/params"
 	"github.com/scroll-tech/go-ethereum/rollup/sync_service"
@@ -139,4 +142,54 @@ func (s *SystemContract) localSignerAddress() common.Address {
 	defer s.lock.RUnlock()
 
 	return s.signer
+}
+
+// FakeEthClient implements a minimal version of sync_service.EthClient for testing purposes.
+type FakeEthClient struct {
+	mu sync.Mutex
+	// Value is the fixed Value to return from StorageAt.
+	// We'll assume StorageAt returns a 32-byte Value representing an Ethereum address.
+	Value common.Address
+}
+
+// BlockNumber returns 0.
+func (f *FakeEthClient) BlockNumber(ctx context.Context) (uint64, error) {
+	return 0, nil
+}
+
+// ChainID returns a zero-value chain ID.
+func (f *FakeEthClient) ChainID(ctx context.Context) (*big.Int, error) {
+	return big.NewInt(0), nil
+}
+
+// FilterLogs returns an empty slice of logs.
+func (f *FakeEthClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	return []types.Log{}, nil
+}
+
+// HeaderByNumber returns nil.
+func (f *FakeEthClient) HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error) {
+	return nil, nil
+}
+
+// SubscribeFilterLogs returns a nil subscription.
+func (f *FakeEthClient) SubscribeFilterLogs(ctx context.Context, query ethereum.FilterQuery, ch chan<- types.Log) (ethereum.Subscription, error) {
+	return nil, nil
+}
+
+// TransactionByHash returns (nil, false, nil).
+func (f *FakeEthClient) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	return nil, false, nil
+}
+
+// BlockByHash returns nil.
+func (f *FakeEthClient) BlockByHash(ctx context.Context, hash common.Hash) (*types.Block, error) {
+	return nil, nil
+}
+
+// StorageAt returns the byte representation of f.value.
+func (f *FakeEthClient) StorageAt(ctx context.Context, account common.Address, key common.Hash, blockNumber *big.Int) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.Value.Bytes(), nil
 }

--- a/core/block_validator_test.go
+++ b/core/block_validator_test.go
@@ -51,10 +51,10 @@ func TestHeaderVerification(t *testing.T) {
 
 			if valid {
 				engine := ethash.NewFaker()
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true}, nil)
 			} else {
 				engine := ethash.NewFakeFailer(headers[i].Number.Uint64())
-				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true})
+				_, results = engine.VerifyHeaders(chain, []*types.Header{headers[i]}, []bool{true}, nil)
 			}
 			// Wait for the verification result
 			select {
@@ -107,11 +107,11 @@ func testHeaderConcurrentVerification(t *testing.T, threads int) {
 
 		if valid {
 			chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, ethash.NewFaker(), vm.Config{}, nil, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
+			_, results = chain.engine.VerifyHeaders(chain, headers, seals, nil)
 			chain.Stop()
 		} else {
 			chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, ethash.NewFakeFailer(uint64(len(headers)-1)), vm.Config{}, nil, nil)
-			_, results = chain.engine.VerifyHeaders(chain, headers, seals)
+			_, results = chain.engine.VerifyHeaders(chain, headers, seals, nil)
 			chain.Stop()
 		}
 		// Wait for all the verification results
@@ -176,7 +176,7 @@ func testHeaderConcurrentAbortion(t *testing.T, threads int) {
 	chain, _ := NewBlockChain(testdb, nil, params.TestChainConfig, ethash.NewFakeDelayer(time.Millisecond), vm.Config{}, nil, nil)
 	defer chain.Stop()
 
-	abort, results := chain.engine.VerifyHeaders(chain, headers, seals)
+	abort, results := chain.engine.VerifyHeaders(chain, headers, seals, nil)
 	close(abort)
 
 	// Deplete the results channel

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1546,7 +1546,7 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals bool) (int, er
 		headers[i] = block.Header()
 		seals[i] = verifySeals
 	}
-	abort, results := bc.engine.VerifyHeaders(bc, headers, seals)
+	abort, results := bc.engine.VerifyHeaders(bc, headers, seals, nil)
 	defer close(abort)
 
 	// Peek the error for the first block to decide the directing import logic

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -339,7 +339,7 @@ func (hc *HeaderChain) ValidateHeaderChain(chain []*types.Header, checkFreq int)
 		seals[len(seals)-1] = true
 	}
 
-	abort, results := hc.engine.VerifyHeaders(hc, chain, seals)
+	abort, results := hc.engine.VerifyHeaders(hc, chain, seals, nil)
 	defer close(abort)
 
 	// Iterate over the headers and ensure they all check out

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 46        // Patch version component of the current release
+	VersionPatch = 47        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This is a follow-up PR to https://github.com/scroll-tech/go-ethereum/pull/1186.

While that PR correctly handled a race condition, it did not address the real root cause, which is that `engine.VerifyHeaders` can be triggered from two different code paths:
1. Inside `BlockChain.insertChain`, which would do header verification and insertion in parallel (pipelined).
2. Inside `BlockChain.InsertHeaderChain`, which does blocking verification, and then inserts the header chain.

The upgradable engine fails in (2), because calling `SystemConfig.VerifyHeaders` assumes that the ancestor of this chain had already been inserted.

To address this edge case, we pass an optional `parent` hint to `VerifyHeaders`, which should work in both cases.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved header verification by allowing additional context to be provided during batch verification.
  - Added support for seamless consensus engine transitions during block verification.
  - Introduced enhanced testing for consensus engine upgrades and hard fork transitions.

- **Bug Fixes**
  - Enhanced reliability when verifying headers across consensus transitions.

- **Chores**
  - Updated internal method signatures to support the new verification parameter.
  - Increased patch version to 47.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->