### PR TITLE
fix(rollup verifier): nil pointer due to missing `CommittedBatchMeta`

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 48        // Patch version component of the current release
+	VersionPatch = 49        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -42,11 +42,15 @@ const (
 
 	// defaultLogInterval is the frequency at which we print the latest processed block.
 	defaultLogInterval = 5 * time.Minute
+
+	// rewindL1Height is the number of blocks to rewind the L1 sync height when a missing batch event is detected.
+	rewindL1Height = 10
 )
 
 var (
 	finalizedBlockGauge      = metrics.NewRegisteredGauge("chain/head/finalized", nil)
 	ErrShouldResetSyncHeight = errors.New("ErrShouldResetSyncHeight")
+	ErrMissingBatchEvent     = errors.New("ErrMissingBatchEvent")
 )
 
 // RollupSyncService collects ScrollChain batch commit/revert/finalize events and stores metadata into db.
@@ -223,6 +227,16 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 
 				return nil
 			}
+			if errors.Is(err, ErrMissingBatchEvent) {
+				// If there's a missing batch event, rewind the L1 sync height by some blocks to re-fetch from L1 RPC and
+				// replay creating corresponding CommittedBatchMeta in local DB.
+				// This happens recursively until the missing event has been recovered as we will call fetchRollupEvents again
+				// with the `L1Height = prevL1Height - rewindL1Height`.
+				s.callDataBlobSource.SetL1Height(prevL1Height - rewindL1Height)
+
+				return fmt.Errorf("missing batch event, rewinding L1 sync height by %d blocks: %w", rewindL1Height, err)
+			}
+
 			// Reset the L1 height to the previous value to retry fetching the same data.
 			s.callDataBlobSource.SetL1Height(prevL1Height)
 			return fmt.Errorf("failed to parse and update rollup event logs: %w", err)
@@ -297,12 +311,18 @@ func (s *RollupSyncService) updateRollupEvents(daEntries da.Entries) error {
 				var err error
 				if index > 0 {
 					if parentCommittedBatchMeta, err = rawdb.ReadCommittedBatchMeta(s.db, index-1); err != nil {
-						return fmt.Errorf("failed to read parent committed batch meta, batch index: %v, err: %w", index-1, err)
+						return fmt.Errorf("failed to read parent committed batch meta, batch index: %v, err: %w", index-1, errors.Join(ErrMissingBatchEvent, err))
+					}
+					if parentCommittedBatchMeta == nil {
+						return fmt.Errorf("parent committed batch meta = nil, batch index: %v, err: %w", index-1, ErrMissingBatchEvent)
 					}
 				}
 				committedBatchMeta, err := rawdb.ReadCommittedBatchMeta(s.db, index)
 				if err != nil {
-					return fmt.Errorf("failed to read committed batch meta, batch index: %v, err: %w", index, err)
+					return fmt.Errorf("failed to read committed batch meta, batch index: %v, err: %w", index, errors.Join(ErrMissingBatchEvent, err))
+				}
+				if committedBatchMeta == nil {
+					return fmt.Errorf("committed batch meta = nil, batch index: %v, err: %w\"", index, ErrMissingBatchEvent)
 				}
 
 				chunks, err := s.getLocalChunksForBatch(committedBatchMeta.ChunkBlockRanges)
@@ -447,7 +467,10 @@ func (s *RollupSyncService) getCommittedBatchMeta(commitedBatch da.EntryWithBloc
 	if commitedBatch.Version() == encoding.CodecV7 {
 		parentCommittedBatchMeta, err := rawdb.ReadCommittedBatchMeta(s.db, commitedBatch.BatchIndex()-1)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read parent committed batch meta, batch index: %v, err: %w", commitedBatch.BatchIndex()-1, err)
+			return nil, fmt.Errorf("failed to read parent committed batch meta, batch index: %v, err: %w", commitedBatch.BatchIndex()-1, errors.Join(ErrMissingBatchEvent, err))
+		}
+		if parentCommittedBatchMeta == nil {
+			return nil, fmt.Errorf("parent committed batch meta = nil, batch index: %v, err: %w\"", commitedBatch.BatchIndex()-1, ErrMissingBatchEvent)
 		}
 
 		// If parent batch has a lower version this means this is the first batch of CodecV7.

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -322,7 +322,7 @@ func (s *RollupSyncService) updateRollupEvents(daEntries da.Entries) error {
 					return fmt.Errorf("failed to read committed batch meta, batch index: %v, err: %w", index, errors.Join(ErrMissingBatchEvent, err))
 				}
 				if committedBatchMeta == nil {
-					return fmt.Errorf("committed batch meta = nil, batch index: %v, err: %w\"", index, ErrMissingBatchEvent)
+					return fmt.Errorf("committed batch meta = nil, batch index: %v, err: %w", index, ErrMissingBatchEvent)
 				}
 
 				chunks, err := s.getLocalChunksForBatch(committedBatchMeta.ChunkBlockRanges)
@@ -470,7 +470,7 @@ func (s *RollupSyncService) getCommittedBatchMeta(commitedBatch da.EntryWithBloc
 			return nil, fmt.Errorf("failed to read parent committed batch meta, batch index: %v, err: %w", commitedBatch.BatchIndex()-1, errors.Join(ErrMissingBatchEvent, err))
 		}
 		if parentCommittedBatchMeta == nil {
-			return nil, fmt.Errorf("parent committed batch meta = nil, batch index: %v, err: %w\"", commitedBatch.BatchIndex()-1, ErrMissingBatchEvent)
+			return nil, fmt.Errorf("parent committed batch meta = nil, batch index: %v, err: %w", commitedBatch.BatchIndex()-1, ErrMissingBatchEvent)
 		}
 
 		// If parent batch has a lower version this means this is the first batch of CodecV7.

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -44,7 +44,7 @@ const (
 	defaultLogInterval = 5 * time.Minute
 
 	// rewindL1Height is the number of blocks to rewind the L1 sync height when a missing batch event is detected.
-	rewindL1Height = 10
+	rewindL1Height = 100
 )
 
 var (
@@ -234,7 +234,7 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 				// with the `L1Height = prevL1Height - rewindL1Height`.
 				s.callDataBlobSource.SetL1Height(prevL1Height - rewindL1Height)
 
-				return fmt.Errorf("missing batch event, rewinding L1 sync height by %d blocks: %w", rewindL1Height, err)
+				return fmt.Errorf("missing batch event, rewinding L1 sync height by %d blocks to %d: %w", rewindL1Height, prevL1Height-rewindL1Height, err)
 			}
 
 			// Reset the L1 height to the previous value to retry fetching the same data.

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -228,13 +228,19 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 				return nil
 			}
 			if errors.Is(err, ErrMissingBatchEvent) {
+				// make sure no underflow
+				var rewindTo uint64
+				if prevL1Height > rewindL1Height {
+					rewindTo = prevL1Height - rewindL1Height
+				}
+
 				// If there's a missing batch event, rewind the L1 sync height by some blocks to re-fetch from L1 RPC and
 				// replay creating corresponding CommittedBatchMeta in local DB.
 				// This happens recursively until the missing event has been recovered as we will call fetchRollupEvents again
 				// with the `L1Height = prevL1Height - rewindL1Height`.
-				s.callDataBlobSource.SetL1Height(prevL1Height - rewindL1Height)
+				s.callDataBlobSource.SetL1Height(rewindTo)
 
-				return fmt.Errorf("missing batch event, rewinding L1 sync height by %d blocks to %d: %w", rewindL1Height, prevL1Height-rewindL1Height, err)
+				return fmt.Errorf("missing batch event, rewinding L1 sync height by %d blocks to %d: %w", rewindL1Height, rewindTo, err)
 			}
 
 			// Reset the L1 height to the previous value to retry fetching the same data.


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
fix nil pointer due to `CommittedBatchMeta` not being found in the DB and add rewind of L1 sync height to recover from missing `CommittedBatchMeta`. This is most likely caused by a faulty L1 RPC (missing or out-of-order events). With this mechanism rollup verifier should be able to handle and recover from such a case. 

This should also fix: https://github.com/scroll-tech/go-ethereum/issues/1142



## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rollup synchronization to better recover from missing batch events by rewinding the sync height further.

- **Chores**
  - Updated internal version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->