### PR TITLE
fix: configure default timeout for blob clients

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 49        // Patch version component of the current release
+	VersionPatch = 50        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/da_syncer/blob_client/beacon_node_client.go
+++ b/rollup/da_syncer/blob_client/beacon_node_client.go
@@ -9,12 +9,18 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
 )
 
+const (
+	BeaconNodeDefaultTimeout = 15 * time.Second
+)
+
 type BeaconNodeClient struct {
+	client         *http.Client
 	apiEndpoint    string
 	genesisTime    uint64
 	secondsPerSlot uint64
@@ -27,12 +33,14 @@ var (
 )
 
 func NewBeaconNodeClient(apiEndpoint string) (*BeaconNodeClient, error) {
+	client := &http.Client{Timeout: BlobScanDefaultTimeout}
+
 	// get genesis time
 	genesisPath, err := url.JoinPath(apiEndpoint, beaconNodeGenesisEndpoint)
 	if err != nil {
 		return nil, fmt.Errorf("failed to join path, err: %w", err)
 	}
-	resp, err := http.Get(genesisPath)
+	resp, err := client.Get(genesisPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot do request, err: %w", err)
 	}
@@ -62,7 +70,7 @@ func NewBeaconNodeClient(apiEndpoint string) (*BeaconNodeClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to join path, err: %w", err)
 	}
-	resp, err = http.Get(specPath)
+	resp, err = client.Get(specPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot do request, err: %w", err)
 	}
@@ -91,6 +99,7 @@ func NewBeaconNodeClient(apiEndpoint string) (*BeaconNodeClient, error) {
 	}
 
 	return &BeaconNodeClient{
+		client:         client,
 		apiEndpoint:    apiEndpoint,
 		genesisTime:    genesisTime,
 		secondsPerSlot: secondsPerSlot,
@@ -105,7 +114,7 @@ func (c *BeaconNodeClient) GetBlobByVersionedHashAndBlockTime(ctx context.Contex
 	if err != nil {
 		return nil, fmt.Errorf("failed to join path, err: %w", err)
 	}
-	resp, err := http.Get(blobSidecarPath)
+	resp, err := c.client.Get(blobSidecarPath)
 	if err != nil {
 		return nil, fmt.Errorf("cannot do request, err: %w", err)
 	}

--- a/rollup/da_syncer/blob_client/beacon_node_client.go
+++ b/rollup/da_syncer/blob_client/beacon_node_client.go
@@ -33,7 +33,7 @@ var (
 )
 
 func NewBeaconNodeClient(apiEndpoint string) (*BeaconNodeClient, error) {
-	client := &http.Client{Timeout: BlobScanDefaultTimeout}
+	client := &http.Client{Timeout: BeaconNodeDefaultTimeout}
 
 	// get genesis time
 	genesisPath, err := url.JoinPath(apiEndpoint, beaconNodeGenesisEndpoint)

--- a/rollup/da_syncer/blob_client/blob_scan_client.go
+++ b/rollup/da_syncer/blob_client/blob_scan_client.go
@@ -8,10 +8,15 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/common/hexutil"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
+)
+
+const (
+	BlobScanDefaultTimeout = 15 * time.Second
 )
 
 type BlobScanClient struct {
@@ -21,7 +26,7 @@ type BlobScanClient struct {
 
 func NewBlobScanClient(apiEndpoint string) *BlobScanClient {
 	return &BlobScanClient{
-		client:      http.DefaultClient,
+		client:      &http.Client{Timeout: BlobScanDefaultTimeout},
 		apiEndpoint: apiEndpoint,
 	}
 }

--- a/rollup/da_syncer/blob_client/block_native_client.go
+++ b/rollup/da_syncer/blob_client/block_native_client.go
@@ -8,18 +8,25 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/common/hexutil"
 	"github.com/scroll-tech/go-ethereum/crypto/kzg4844"
 )
 
+const (
+	BlockNativeDefaultTimeout = 15 * time.Second
+)
+
 type BlockNativeClient struct {
+	client      *http.Client
 	apiEndpoint string
 }
 
 func NewBlockNativeClient(apiEndpoint string) *BlockNativeClient {
 	return &BlockNativeClient{
+		client:      &http.Client{Timeout: BlockNativeDefaultTimeout},
 		apiEndpoint: apiEndpoint,
 	}
 }
@@ -34,7 +41,7 @@ func (c *BlockNativeClient) GetBlobByVersionedHashAndBlockTime(ctx context.Conte
 	if err != nil {
 		return nil, fmt.Errorf("cannot create request, err: %w", err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot do request, err: %w", err)
 	}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Avoid issues where the client hangs indefinitely, blocking follower node sync.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced consistent 15-second timeouts for all network requests made by various clients, improving reliability and responsiveness during network issues.

- **Chores**
  - Updated patch version number from 49 to 50.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->