### PR TITLE
fix(blob clients): nil pointer with unexpected blob client response

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 51        // Patch version component of the current release
+	VersionPatch = 52        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/da_syncer/blob_client/blob_scan_client.go
+++ b/rollup/da_syncer/blob_client/blob_scan_client.go
@@ -64,6 +64,12 @@ func (c *BlobScanClient) GetBlobByVersionedHashAndBlockTime(ctx context.Context,
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode result into struct, err: %w", err)
 	}
+
+	// check that blob data is not empty
+	if len(result.Data) < 2 {
+		return nil, fmt.Errorf("blob data is too short to be valid, expected at least 2 characters, got: %s, versioned hash: %s", result.Data, versionedHash.String())
+	}
+
 	blobBytes, err := hex.DecodeString(result.Data[2:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode data to bytes, err: %w", err)

--- a/rollup/da_syncer/blob_client/block_native_client.go
+++ b/rollup/da_syncer/blob_client/block_native_client.go
@@ -59,6 +59,12 @@ func (c *BlockNativeClient) GetBlobByVersionedHashAndBlockTime(ctx context.Conte
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode result into struct, err: %w", err)
 	}
+
+	// check that blob data is not empty
+	if len(result.Blob.Data) < 2 {
+		return nil, fmt.Errorf("blob data is too short to be valid, expected at least 2 characters, got: %s, versioned hash: %s", result.Blob.Data, versionedHash.String())
+	}
+
 	blobBytes, err := hex.DecodeString(result.Blob.Data[2:])
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode data to bytes, err: %w", err)


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
This PR fixes an issue where the blob client API delivers an unexpected response that is not checked for length before accessed. 

```
WARN [06-05|06:46:37.665] BlobClients: failed to get blob by versioned hash from BlobClient err="beacon node request failed, status: 404 Not Found, body: {\"code\":404,\"message\":\"NOT_FOUND: no blobs stored for block 0xb2946d447a0dc81b6bcfe3119df4e05087126770b886092a2792992890f880b0\",\"stacktraces\":[]}" blob client pos in BlobClients=1
panic: runtime error: slice bounds out of range [2:0]
goroutine 88 [running]:
github.com/scroll-tech/go-ethereum/rollup/da_syncer/blob_client.(*BlobScanClient).GetBlobByVersionedHashAndBlockTime(0xc02bb31bc0, {0x1cea5a0, 0xc01a40a320}, {0x1, 0xb9, 0x1f, 0xc, 0xf6, 0x95, 0xa0, ...}, ...)
	github.com/scroll-tech/go-ethereum/rollup/da_syncer/blob_client/blob_scan_client.go:67 +0xde5
github.com/scroll-tech/go-ethereum/rollup/da_syncer/blob_client.(*BlobClients).GetBlobByVersionedHashAndBlockTime(0xc027f489a0, {0x1cea5a0, 0xc01a40a320}, {0x1, 0xb9, 0x1f, 0xc, 0xf6, 0x95, 0xa0, ...}, ...)
	github.com/scroll-tech/go-ethereum/rollup/da_syncer/blob_client/blob_client.go:41 +0x182
github.com/scroll-tech/go-ethereum/rollup/da_syncer/da.NewCommitBatchDAV1({0x1cea5a0, 0xc01a40a320}, {0x1cf6f78, 0xc000028558}, {0x1ce01e0?, 0xc027f489a0}, {0x1cf7df0, 0x29d3500}, 0xc02c2925b0, {0xc0303600a4, ...}, ...)
	github.com/scroll-tech/go-ethereum/rollup/da_syncer/da/commitV1.go:45 +0x1e9
```


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation for blob data responses to prevent errors when handling invalid or empty data.
- **Chores**
	- Updated the patch version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->