### PR TITLE
feat: reject txs with max l1 data fee

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -844,7 +844,7 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		}
 		// Reject transactions that require the max data fee amount.
 		// This can only happen if the L1 gas oracle is updated incorrectly.
-		if l1DataFee.Cmp(fees.MaxL1DataFee) >= 0 {
+		if l1DataFee.Cmp(fees.MaxL1DataFee()) >= 0 {
 			return errors.New("invalid transaction: invalid L1 data fee")
 		}
 		// Transactor should have enough funds to cover the costs

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -842,6 +842,11 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to calculate L1 data fee, err: %w", err)
 		}
+		// Reject transactions that require the max data fee amount.
+		// This can only happen if the L1 gas oracle is updated incorrectly.
+		if l1DataFee.Cmp(fees.MaxL1DataFee) >= 0 {
+			return errors.New("invalid transaction: invalid L1 data fee")
+		}
 		// Transactor should have enough funds to cover the costs
 		// cost == L1 data fee + V + GP * GL
 		if b := pool.currentState.GetBalance(from); b.Cmp(new(big.Int).Add(tx.Cost(), l1DataFee)) < 0 {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 54        // Patch version component of the current release
+	VersionPatch = 55        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -20,6 +20,9 @@ var (
 	// to be non-zero.
 	// - tx length prefix: 4 bytes
 	txExtraDataBytes = uint64(4)
+
+	// L1 data fee cap.
+	MaxL1DataFee = new(big.Int).SetUint64(math.MaxUint64)
 )
 
 // Message represents the interface of a message.
@@ -248,8 +251,8 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB, config *params.Cha
 
 	// ensure l1DataFee fits into uint64 for circuit compatibility
 	// (note: in practice this value should never be this big)
-	if !l1DataFee.IsUint64() {
-		l1DataFee.SetUint64(math.MaxUint64)
+	if l1DataFee.Cmp(MaxL1DataFee) > 0 {
+		l1DataFee.Set(MaxL1DataFee)
 	}
 
 	return l1DataFee, nil

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -256,7 +256,7 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB, config *params.Cha
 	// ensure l1DataFee fits into uint64 for circuit compatibility
 	// (note: in practice this value should never be this big)
 	if l1DataFee.Cmp(l1DataFeeCap) > 0 {
-		l1DataFee.Set(l1DataFeeCap)
+		l1DataFee = new(big.Int).Set(l1DataFeeCap)
 	}
 
 	return l1DataFee, nil

--- a/rollup/fees/rollup_fee.go
+++ b/rollup/fees/rollup_fee.go
@@ -22,8 +22,12 @@ var (
 	txExtraDataBytes = uint64(4)
 
 	// L1 data fee cap.
-	MaxL1DataFee = new(big.Int).SetUint64(math.MaxUint64)
+	l1DataFeeCap = new(big.Int).SetUint64(math.MaxUint64)
 )
+
+func MaxL1DataFee() *big.Int {
+	return new(big.Int).Set(l1DataFeeCap)
+}
 
 // Message represents the interface of a message.
 // It should be a subset of the methods found on
@@ -251,8 +255,8 @@ func CalculateL1DataFee(tx *types.Transaction, state StateDB, config *params.Cha
 
 	// ensure l1DataFee fits into uint64 for circuit compatibility
 	// (note: in practice this value should never be this big)
-	if l1DataFee.Cmp(MaxL1DataFee) > 0 {
-		l1DataFee.Set(MaxL1DataFee)
+	if l1DataFee.Cmp(l1DataFeeCap) > 0 {
+		l1DataFee.Set(l1DataFeeCap)
 	}
 
 	return l1DataFee, nil


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Reject transactions that run into the L1 data fee cap.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Transactions with L1 data fees exceeding the maximum allowed limit are now rejected during validation.

- **Chores**
  - Updated version patch number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->