### PR TITLE
feat(worker): disable l1 message skipping

### DIFF
--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -796,7 +796,10 @@ func (w *worker) processTxns(txs types.OrderedTransactionSet) (bool, error) {
 			}
 
 			if tx.IsL1MessageTx() {
-				txs.Shift()
+				log.Error("Encountered error while processing L1MessageTx", "err", err, "blockNumber", w.current.header.Number, "queueIndex", tx.AsL1MessageTx().QueueIndex)
+				// Instead of skipping a message or stopping block building,
+				// we continue and build a block with no (more) L1 messages.
+				return false, nil
 			} else {
 				txs.Pop()
 			}
@@ -1061,13 +1064,8 @@ func (w *worker) onTxFailing(txIndex int, tx *types.Transaction, err error) {
 			return
 		}
 
-		queueIndex := tx.AsL1MessageTx().QueueIndex
-		log.Warn("Skipping L1 message", "queueIndex", queueIndex, "tx", tx.Hash().String(), "block",
-			w.current.header.Number, "reason", err)
-		rawdb.WriteSkippedTransaction(w.eth.ChainDb(), tx, nil, err.Error(),
-			w.current.header.Number.Uint64(), nil)
-		w.current.nextL1MsgIndex = queueIndex + 1
-		l1SkippedCounter.Inc(1)
+		// previously we would skip this transaction here,
+		// but now skipping is disabled.
 	} else if errors.Is(err, core.ErrInsufficientFunds) {
 		log.Trace("Skipping tx with insufficient funds", "tx", tx.Hash().String())
 		w.eth.TxPool().RemoveTx(tx.Hash(), true)


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

CCC is disabled, so it won't lead to skipping.

There are other error conditions that might lead to skipping L1 messages. To the best of our knowledge, these are all impossible. But if we do encounter such an error, we should avoid corrupting the chain by skipping an L1 message.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for L1 message transactions to prevent automatic skipping of failing transactions. Now, processing stops and an error is logged if a failure occurs, ensuring better reliability and transparency during block building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->