### PR TITLE
feat(feynman): ensure that transition block timestamp is exact

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -362,11 +362,6 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	// Collect storage locations that prover needs but sequencer might not touch necessarily
 	statedb.GetState(rcfg.L2MessageQueueAddress, rcfg.WithdrawTrieRootSlot)
 
-	// Note: scroll-revm detects the Feynman transition block using this storage slot,
-	// since it does not have access to the parent block timestamp. We need to make
-	// sure that this is always present in the execution witness.
-	statedb.GetState(rcfg.L1GasPriceOracleAddress, rcfg.IsFeynmanSlot)
-
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process block %d: %w", block.Number(), err)

--- a/eth/api.go
+++ b/eth/api.go
@@ -362,6 +362,12 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	// Collect storage locations that prover needs but sequencer might not touch necessarily
 	statedb.GetState(rcfg.L2MessageQueueAddress, rcfg.WithdrawTrieRootSlot)
 
+	// Note: scroll-revm detects the Feynman transition block using the block
+	// timestamp, but since there might be multiple blocks with the same timestamp,
+	// it also needs this value to avoid applying the state update multiple times.
+	// So we need to make sure that this is always present in the execution witness.
+	statedb.GetState(rcfg.L1GasPriceOracleAddress, rcfg.IsFeynmanSlot)
+
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process block %d: %w", block.Number(), err)

--- a/eth/api.go
+++ b/eth/api.go
@@ -362,7 +362,7 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	// Collect storage locations that prover needs but sequencer might not touch necessarily
 	statedb.GetState(rcfg.L2MessageQueueAddress, rcfg.WithdrawTrieRootSlot)
 
-	// Note: scroll-revm detects the Feynman transition block using the block
+	// Note: scroll-reth detects the Feynman transition block using the block
 	// timestamp, but since there might be multiple blocks with the same timestamp,
 	// it also needs this value to avoid applying the state update multiple times.
 	// So we need to make sure that this is always present in the execution witness.

--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -510,9 +510,17 @@ func (w *worker) newWork(now time.Time, parent *types.Block, reorging bool, reor
 		header.Coinbase = common.Address{}
 		header.Nonce = types.BlockNonce{}
 	} else {
+		var timeOverride *uint64
+		if w.chainConfig.IsFeynmanTransitionBlock(header.Time, parent.Time()) {
+			// current candidate timestamp suggests that this block is the Feynman transition block,
+			// we forcibly set timestamp to the exact upgrade timestamp.
+			timeOverride = new(uint64)
+			*timeOverride = *w.chainConfig.FeynmanTime // IsFeynmanTransitionBlock guarantees that this is not nil
+		}
+
 		prepareStart := time.Now()
 		// Note: this call will set header.Time, among other fields.
-		if err := w.engine.Prepare(w.chain, header, nil); err != nil {
+		if err := w.engine.Prepare(w.chain, header, timeOverride); err != nil {
 			return fmt.Errorf("failed to prepare header for mining: %w", err)
 		}
 		prepareTimer.UpdateSince(prepareStart)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 58        // Patch version component of the current release
+	VersionPatch = 59        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Feynman requires us to apply a _pre execution change_ at the top of the transition block, upgrading a predeploy contract.

Since we use timestamp-based forks, in Reth it's not possible to detect if the current block is the transition block, because the state transition function does not have access to the parent timestamp (see sub-optimal workaround in https://github.com/scroll-tech/reth/pull/254/commits/7a31b73c21b3d4c4b29ecdd75732909615fa59d7).

As a workaround, we propose a way to ensure that the transition block uses the exact Feynman timestamp.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the Feynman transition block by ensuring the block timestamp is set precisely during mining and clarifying the detection method to avoid state update duplication.
- **Chores**
  - Updated the patch version number to 59.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->