### PR TITLE
feat: schedule Feynman upgrade on Scroll Sepolia

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -332,7 +332,7 @@ var (
 		DarwinV2Time:        newUint64(1724832000),
 		EuclidTime:          newUint64(1741680000),
 		EuclidV2Time:        newUint64(1741852800),
-		FeynmanTime:         nil,
+		FeynmanTime:         newUint64(1753167600),
 		Clique: &CliqueConfig{
 			Period: 3,
 			Epoch:  30000,

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 69        // Patch version component of the current release
+	VersionPatch = 70        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Schedule Feynman on Scroll Sepolia at Unix timestamp [1753167600](https://www.timeanddate.com/worldclock/converter.html?iso=20250722T070000&p1=224&p2=1440&p3=136&p4=50&p5=33&p6=236).


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Set a specific activation time for the Feynman fork on the Scroll Sepolia test network.

* **Chores**
  * Updated the patch version number to 70.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->