### PR TITLE
fix(feynman): fee ranges

### DIFF
--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -122,6 +122,11 @@ func calcBaseFeeFeynman(config *params.ChainConfig, parent *types.Header, overhe
 	baseFee := new(big.Int).Set(baseFeeEIP1559)
 	baseFee.Add(baseFee, overhead)
 
+	// Apply maximum base fee bound to the final result (including overhead)
+	if baseFee.Cmp(big.NewInt(MaximumL2BaseFee)) > 0 {
+		baseFee = big.NewInt(MaximumL2BaseFee)
+	}
+
 	return baseFee
 }
 
@@ -159,9 +164,6 @@ func calcBaseFeeEIP1559(config *params.ChainConfig, parent *types.Header) *big.I
 			return num.Add(parentBaseFeeEIP1559, common.Big1)
 		}
 		baseFee := num.Add(parentBaseFeeEIP1559, num)
-		if baseFee.Cmp(big.NewInt(MaximumL2BaseFee)) > 0 {
-			baseFee = big.NewInt(MaximumL2BaseFee)
-		}
 		return baseFee
 	} else {
 		// Otherwise if the parent block used less gas than its target, the baseFee should decrease.
@@ -179,10 +181,21 @@ func calcBaseFeeEIP1559(config *params.ChainConfig, parent *types.Header) *big.I
 	}
 }
 
-func extractBaseFeeEIP1559(config *params.ChainConfig, baseFee *big.Int) *big.Int {
+func extractBaseFeeEIP1559(_ *params.ChainConfig, baseFee *big.Int) *big.Int {
 	_, overhead := ReadL2BaseFeeCoefficients()
 	// In Feynman base fee calculation, we reuse the contract's baseFeeOverhead slot as the proving base fee.
-	return new(big.Int).Sub(baseFee, overhead)
+	result := new(big.Int).Sub(baseFee, overhead)
+
+	// Add underflow protection: return max(0, baseFee - overhead)
+	//
+	// Potential underflow scenarios:
+	// 1. During transition to Feynman: parent base fee might be < overhead
+	// 2. Contract overhead updates: when overhead is updated via contract,
+	//    it might become larger than current base fee
+	if result.Sign() < 0 {
+		return big.NewInt(0)
+	}
+	return result
 }
 
 // MinBaseFee calculates the minimum L2 base fee based on the current coefficients.

--- a/consensus/misc/eip1559.go
+++ b/consensus/misc/eip1559.go
@@ -183,15 +183,15 @@ func calcBaseFeeEIP1559(config *params.ChainConfig, parent *types.Header) *big.I
 
 func extractBaseFeeEIP1559(_ *params.ChainConfig, baseFee *big.Int) *big.Int {
 	_, overhead := ReadL2BaseFeeCoefficients()
+
 	// In Feynman base fee calculation, we reuse the contract's baseFeeOverhead slot as the proving base fee.
 	result := new(big.Int).Sub(baseFee, overhead)
 
 	// Add underflow protection: return max(0, baseFee - overhead)
 	//
 	// Potential underflow scenarios:
-	// 1. During transition to Feynman: parent base fee might be < overhead
-	// 2. Contract overhead updates: when overhead is updated via contract,
-	//    it might become larger than current base fee
+	// - Contract overhead updates: when overhead is updated via contract,
+	//   it might become larger than current base fee
 	if result.Sign() < 0 {
 		return big.NewInt(0)
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 70        // Patch version component of the current release
+	VersionPatch = 71        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 71        // Patch version component of the current release
+	VersionPatch = 72        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Fix 1: Change to `baseFee - overhead` to `max(0, baseFee - overhead)`.
Fix 2: Bound max base fee after adding `overhead`, if the base fee is bounded excluding the overhead part [here](https://github.com/scroll-tech/go-ethereum/blob/c604c901598fd401f1816ac5eff83b5f97bf8b7d/consensus/misc/eip1559.go#L163), it will fail the check [here](https://github.com/scroll-tech/go-ethereum/blob/c604c901598fd401f1816ac5eff83b5f97bf8b7d/consensus/misc/eip1559.go#L98).

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [x] fix: A bug fix

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] Yes

## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved base fee calculation to prevent negative values and ensure correct enforcement of maximum base fee caps.
* **Chores**
  * Updated the application patch version to 72.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->