### PR TITLE
fix: serve blockhash from state

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -485,18 +485,12 @@ func opBlockhashPostFeynman(pc *uint64, interpreter *EVMInterpreter, scope *Scop
 		lower = upper - 256
 	}
 	if num64 >= lower && num64 < upper {
-		res := interpreter.evm.Context.GetHash(num64)
-		if witness := interpreter.evm.StateDB.Witness(); witness != nil {
-			witness.AddBlockHash(num64)
-		}
-		num.SetBytes(res[:])
-
-		// for provability, revm loads block hash from the history storage system contract,
-		// so we need to ensure that the corresponding slot is present in the execution witness.
+		// load block hash from the history storage system contract.
 		ringIndex := num64 % params.HistoryServeWindow
 		var key common.Hash
 		binary.BigEndian.PutUint64(key[24:], ringIndex)
-		interpreter.evm.StateDB.GetState(params.HistoryStorageAddress, key)
+		res := interpreter.evm.StateDB.GetState(params.HistoryStorageAddress, key)
+		num.SetBytes(res[:])
 	} else {
 		num.Clear()
 	}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 70        // Patch version component of the current release
+	VersionPatch = 71        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Ensure behavior of `blockhash` opcode in blocks shortly after the Feynman transition is consistent with [scroll-revm](https://github.com/scroll-tech/scroll-revm/blob/6a1e33df5b9e5ad6585a8469faaba9e6ea5e3f3d/src/instructions.rs#L120-L139).


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [ ] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of block hash retrieval for recent blocks with enhanced handling around protocol fork boundaries.

* **Chores**
  * Updated the application patch version to 0.71.

* **Tests**
  * Added new tests to verify block hash behavior before and after the protocol fork.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->