### PR TITLE
fix: remove wrong transition check in rollup-verifier

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 73        // Patch version component of the current release
+	VersionPatch = 74        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -482,14 +482,8 @@ func (s *RollupSyncService) getCommittedBatchMeta(commitedBatch da.EntryWithBloc
 			return nil, fmt.Errorf("parent committed batch meta = nil, batch index: %v, err: %w", commitedBatch.BatchIndex()-1, ErrMissingBatchEvent)
 		}
 
-		// If parent batch has a lower version this means this is the first batch of CodecV7.
-		// In this case we need to compute the prevL1MessageQueueHash from the empty hash.
-		var prevL1MessageQueueHash common.Hash
-		if encoding.CodecVersion(parentCommittedBatchMeta.Version) < commitedBatch.Version() {
-			prevL1MessageQueueHash = common.Hash{}
-		} else {
-			prevL1MessageQueueHash = parentCommittedBatchMeta.PostL1MessageQueueHash
-		}
+		// For the first batch of CodecV7, this will be the empty hash.
+		prevL1MessageQueueHash := parentCommittedBatchMeta.PostL1MessageQueueHash
 
 		chunks, err := s.getLocalChunksForBatch(chunkRanges)
 		if err != nil {

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -602,6 +602,11 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 			log.Warn("Resetting sync height to L1 block 7892668 to fix L1 message queue hash calculation issue after EuclidV2 on Scroll Sepolia")
 			return 0, nil, errShouldResetSyncHeight{height: 7892668}
 		}
+		// This is hotfix for the L1 message hash mismatch issue which lead to wrong committedBatchMeta.PostL1MessageQueueHash hashes.
+		// This happened after upgrading to Feyman where rollup-verifier erroneously reset the prevMessageQueueHash to the empty hash.
+		// If the error message due to mismatching PostL1MessageQueueHash contains the same hash as the hardcoded one,
+		// this means the node ran into this issue.
+		// We need to reset the sync height to before committing the first Feynman batch.
 		if strings.Contains(err.Error(), "expected 0x19c790f49efb448b523d94e5672d9ed108656886be12c038cf39062700000000, got 0x0000000000000000000000000000000000000000000000000000000000000000") {
 			log.Warn("Resetting sync height to L1 block 8816625 to fix L1 message queue hash calculation issue after Feynman on Scroll Sepolia")
 			return 0, nil, errShouldResetSyncHeight{height: 8816625}

--- a/rollup/rollup_sync_service/rollup_sync_service.go
+++ b/rollup/rollup_sync_service/rollup_sync_service.go
@@ -48,10 +48,17 @@ const (
 )
 
 var (
-	finalizedBlockGauge      = metrics.NewRegisteredGauge("chain/head/finalized", nil)
-	ErrShouldResetSyncHeight = errors.New("ErrShouldResetSyncHeight")
-	ErrMissingBatchEvent     = errors.New("ErrMissingBatchEvent")
+	finalizedBlockGauge  = metrics.NewRegisteredGauge("chain/head/finalized", nil)
+	ErrMissingBatchEvent = errors.New("ErrMissingBatchEvent")
 )
+
+type errShouldResetSyncHeight struct {
+	height uint64
+}
+
+func (e errShouldResetSyncHeight) Error() string {
+	return fmt.Sprintf("ErrShouldResetSyncHeight: height=%d", e.height)
+}
 
 // RollupSyncService collects ScrollChain batch commit/revert/finalize events and stores metadata into db.
 type RollupSyncService struct {
@@ -224,10 +231,10 @@ func (s *RollupSyncService) fetchRollupEvents() error {
 		}
 
 		if err = s.updateRollupEvents(daEntries); err != nil {
-			if errors.Is(err, ErrShouldResetSyncHeight) {
-				log.Warn("Resetting sync height to L1 block 7892668 to fix L1 message queue hash calculation")
-				s.callDataBlobSource.SetL1Height(7892668)
-
+			var resetSyncErr errShouldResetSyncHeight
+			if errors.As(err, &resetSyncErr) {
+				log.Warn("Resetting rollup sync height", "height", resetSyncErr.height)
+				s.callDataBlobSource.SetL1Height(resetSyncErr.height)
 				return nil
 			}
 			if errors.Is(err, ErrMissingBatchEvent) {
@@ -592,7 +599,12 @@ func validateBatch(batchIndex uint64, event *l1.FinalizeBatchEvent, parentFinali
 		// We need to reset the sync height to 1 block before the L1 block in which the last batch in CodecV6 was committed.
 		// The node will overwrite the wrongly computed message queue hashes.
 		if strings.Contains(err.Error(), "0xaa16faf2a1685fe1d7e0f2810b1a0e98c2841aef96596d10456a6d0f00000000") {
-			return 0, nil, ErrShouldResetSyncHeight
+			log.Warn("Resetting sync height to L1 block 7892668 to fix L1 message queue hash calculation issue after EuclidV2 on Scroll Sepolia")
+			return 0, nil, errShouldResetSyncHeight{height: 7892668}
+		}
+		if strings.Contains(err.Error(), "expected 0x19c790f49efb448b523d94e5672d9ed108656886be12c038cf39062700000000, got 0x0000000000000000000000000000000000000000000000000000000000000000") {
+			log.Warn("Resetting sync height to L1 block 8816625 to fix L1 message queue hash calculation issue after Feynman on Scroll Sepolia")
+			return 0, nil, errShouldResetSyncHeight{height: 8816625}
 		}
 		return 0, nil, fmt.Errorf("failed to create DA batch, batch index: %v, codec version: %v, err: %w", batchIndex, codecVersion, err)
 	}


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This transition check was supposed to initialize `prevL1MessageQueueHash` in EuclidV2, but it also got applied in Feynman, erroneously resetting the msg queue hash to zero, halting the rollup verification process.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [X] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during rollup synchronization by dynamically resetting sync height based on specific error conditions.
  * Added support for an additional error condition that triggers a sync reset to a new block height.

* **Chores**
  * Updated patch version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->