### PR TITLE
refactor: make tx forwarding to sequencer non-blocking if tx pool is enabled

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -280,14 +280,20 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 	if b.eth.sequencerRPCService != nil {
 		// If the transaction pool is disabled, then we need to make sure that we send the transaction to the sequencer RPC synchronously.
 		if b.disableTxPool {
-			return b.sendToSequencer(ctx, signedTx)
+			err = b.sendToSequencer(ctx, signedTx)
+			if err != nil {
+				log.Warn("failed to forward tx to sequencer", "tx", signedTx.Hash(), "err", err)
+			}
+			return err
 		}
 
 		// If the transaction pool is enabled, we send the transaction to the sequencer RPC asynchronously as this is
 		// additional to the public mempool.
 		go func() {
 			err := b.sendToSequencer(ctx, signedTx)
-			log.Warn("failed to forward tx to sequencer", "tx", signedTx.Hash(), "err", err)
+			if err != nil {
+				log.Warn("failed to forward tx to sequencer", "tx", signedTx.Hash(), "err", err)
+			}
 		}()
 	}
 

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -277,16 +278,29 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 
 	// Forward to remote sequencer RPC
 	if b.eth.sequencerRPCService != nil {
-		signedTxData, err := signedTx.MarshalBinary()
-		if err != nil {
-			return err
+		// If the transaction pool is disabled, then we need to make sure that we send the transaction to the sequencer RPC synchronously.
+		if b.disableTxPool {
+			return b.sendToSequencer(ctx, signedTx)
 		}
-		if err = b.eth.sequencerRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(signedTxData)); err != nil {
+
+		// If the transaction pool is enabled, we send the transaction to the sequencer RPC asynchronously as this is
+		// additional to the public mempool.
+		go func() {
+			err := b.sendToSequencer(ctx, signedTx)
 			log.Warn("failed to forward tx to sequencer", "tx", signedTx.Hash(), "err", err)
-			if b.disableTxPool {
-				return err
-			}
-		}
+		}()
+	}
+
+	return nil
+}
+
+func (b *EthAPIBackend) sendToSequencer(ctx context.Context, signedTx *types.Transaction) error {
+	signedTxData, err := signedTx.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("failed to marshal signed tx: %w", err)
+	}
+	if err = b.eth.sequencerRPCService.CallContext(ctx, nil, "eth_sendRawTransaction", hexutil.Encode(signedTxData)); err != nil {
+		return fmt.Errorf("eth_sendRawTransaction to sequencer RPC failed: %w", err)
 	}
 
 	return nil

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 75        // Patch version component of the current release
+	VersionPatch = 76        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 8         // Minor version component of the current release
-	VersionPatch = 74        // Patch version component of the current release
+	VersionPatch = 75        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/rollup/da_syncer/blob_client/beacon_node_client.go
+++ b/rollup/da_syncer/blob_client/beacon_node_client.go
@@ -114,7 +114,11 @@ func (c *BeaconNodeClient) GetBlobByVersionedHashAndBlockTime(ctx context.Contex
 	if err != nil {
 		return nil, fmt.Errorf("failed to join path, err: %w", err)
 	}
-	resp, err := c.client.Get(blobSidecarPath)
+	req, err := http.NewRequestWithContext(ctx, "GET", blobSidecarPath, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request, err: %w", err)
+	}
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot do request, err: %w", err)
 	}


### PR DESCRIPTION
This PR makes tx forwarding non-blocking if the tx pool is enabled. If the tx pool is disabled (private mempool mode) then the forwarding is done synchronously to notify the user. In the additional case this is not necessary as it is optional and in the failure case the transaction will simply be broadcast like usual via gossip (public mempool).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced transaction sending to handle synchronous and asynchronous modes based on transaction pool status, improving reliability.
  * Improved HTTP request handling with context support for better request management.
* **Chores**
  * Updated the patch version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->