### PR TITLE
feat: support verify block signature signed by RN

### DIFF
--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -393,9 +393,9 @@ func SealHash(header *types.Header) (hash common.Hash) {
 // ecrecover extracts the Ethereum account address from a signed header.
 func ecrecover(header *types.Header) (common.Address, error) {
 	signature := header.BlockSignature[0:]
-	// Normalize recovery ID for compatibility with Scroll's reth node.
-	// Scroll's reth uses alloy signer which produces signatures with recovery ID (V) of 27/28,
-	// but Ethereum's standard crypto.Ecrecover expects V to be 0/1.
+	// Normalize recovery ID for compatibility with Scroll's rollup node.
+	// Scroll's rollup node uses alloy signer which produces signatures with recovery ID (V) of 27/28,
+	// but go-ethereum's standard crypto.Ecrecover expects V to be 0/1.
 	// Convert 27/28 format to 0/1 format by subtracting 27.
 	if signature[64] >= 27 && signature[64] <= 28 {
 		signature[64] -= 27

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -2,7 +2,6 @@ package system_contract
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -394,12 +393,12 @@ func SealHash(header *types.Header) (hash common.Hash) {
 // ecrecover extracts the Ethereum account address from a signed header.
 func ecrecover(header *types.Header) (common.Address, error) {
 	signature := header.BlockSignature[0:]
-
-	// For compatibility with scroll's reth node, the signature is stored in the extra data field
-	// If the signature is not found in the block signature field, we try to extract it from the extra data field
-	log.Info("Morty: ecrecover", "hash", header.Hash(), "signature", hex.EncodeToString(signature), "extra", hex.EncodeToString(header.Extra))
-	if len(signature) == 0 && len(header.Extra) == crypto.SignatureLength {
-		signature = header.Extra[0:]
+	// Normalize recovery ID for compatibility with Scroll's reth node.
+	// Scroll's reth uses alloy signer which produces signatures with recovery ID (V) of 27/28,
+	// but Ethereum's standard crypto.Ecrecover expects V to be 0/1.
+	// Convert 27/28 format to 0/1 format by subtracting 27.
+	if signature[64] >= 27 && signature[64] <= 28 {
+		signature[64] -= 27
 	}
 
 	// Recover the public key and the Ethereum address

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -394,6 +394,12 @@ func SealHash(header *types.Header) (hash common.Hash) {
 func ecrecover(header *types.Header) (common.Address, error) {
 	signature := header.BlockSignature[0:]
 
+	// For compatibility with scroll's reth node, the signature is stored in the extra data field
+	// If the signature is not found in the block signature field, we try to extract it from the extra data field
+	if len(signature) == 0 && len(header.Extra) == crypto.SignatureLength {
+		signature = header.Extra[0:]
+	}
+
 	// Recover the public key and the Ethereum address
 	pubkey, err := crypto.Ecrecover(SealHash(header).Bytes(), signature)
 	if err != nil {

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -2,6 +2,7 @@ package system_contract
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -211,6 +212,7 @@ func (s *SystemContract) verifyCascadingFields(chain consensus.ChainHeaderReader
 	defer s.lock.RUnlock()
 
 	if signer != s.signerAddressL1 {
+		log.Info("Morty: ecrecover Unauthorized signer", "Got", signer, "Expected:", s.signerAddressL1)
 		log.Error("Unauthorized signer", "Got", signer, "Expected:", s.signerAddressL1)
 		return ErrUnauthorizedSigner
 	}
@@ -401,14 +403,17 @@ func ecrecover(header *types.Header) (common.Address, error) {
 		signature[64] -= 27
 	}
 
+	log.Info("Morty: ecrecover", "hash", header.Hash(), "signature", hex.EncodeToString(signature))
+
 	// Recover the public key and the Ethereum address
 	pubkey, err := crypto.Ecrecover(SealHash(header).Bytes(), signature)
 	if err != nil {
+		log.Info("Morty: failed to ecrecover", "hash", header.Hash(), "signature", hex.EncodeToString(signature), "error", err)
 		return common.Address{}, err
 	}
 	var signer common.Address
 	copy(signer[:], crypto.Keccak256(pubkey[1:])[12:])
-
+	log.Info("Morty: ecrecover", "hash", header.Hash(), "signer", signer.Hex())
 	return signer, nil
 }
 

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -2,7 +2,6 @@ package system_contract
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -137,7 +136,6 @@ func (s *SystemContract) verifyHeader(chain consensus.ChainHeaderReader, header 
 	}
 	// Check that the BlockSignature contains signature if block is not requested
 	if header.Number.Cmp(big.NewInt(0)) != 0 && len(header.BlockSignature) != extraSeal {
-		log.Info("Morty: missing signature", "hash", header.Hash(), "signature", hex.EncodeToString(header.BlockSignature), "extra", hex.EncodeToString(header.Extra), "number", header.Number)
 		return errMissingSignature
 	}
 	// Ensure that the mix digest is zero
@@ -213,7 +211,6 @@ func (s *SystemContract) verifyCascadingFields(chain consensus.ChainHeaderReader
 	defer s.lock.RUnlock()
 
 	if signer != s.signerAddressL1 {
-		log.Info("Morty: ecrecover Unauthorized signer", "Got", signer, "Expected:", s.signerAddressL1)
 		log.Error("Unauthorized signer", "Got", signer, "Expected:", s.signerAddressL1)
 		return ErrUnauthorizedSigner
 	}
@@ -404,17 +401,14 @@ func ecrecover(header *types.Header) (common.Address, error) {
 		signature[64] -= 27
 	}
 
-	log.Info("Morty: ecrecover", "hash", header.Hash(), "signature", hex.EncodeToString(signature))
-
 	// Recover the public key and the Ethereum address
 	pubkey, err := crypto.Ecrecover(SealHash(header).Bytes(), signature)
 	if err != nil {
-		log.Info("Morty: failed to ecrecover", "hash", header.Hash(), "signature", hex.EncodeToString(signature), "error", err)
 		return common.Address{}, err
 	}
 	var signer common.Address
 	copy(signer[:], crypto.Keccak256(pubkey[1:])[12:])
-	log.Info("Morty: ecrecover", "hash", header.Hash(), "signer", signer.Hex())
+
 	return signer, nil
 }
 

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -2,6 +2,7 @@ package system_contract
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -396,6 +397,7 @@ func ecrecover(header *types.Header) (common.Address, error) {
 
 	// For compatibility with scroll's reth node, the signature is stored in the extra data field
 	// If the signature is not found in the block signature field, we try to extract it from the extra data field
+	log.Info("Morty: ecrecover", "hash", header.Hash(), "signature", hex.EncodeToString(signature), "extra", hex.EncodeToString(header.Extra))
 	if len(signature) == 0 && len(header.Extra) == crypto.SignatureLength {
 		signature = header.Extra[0:]
 	}

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -137,6 +137,7 @@ func (s *SystemContract) verifyHeader(chain consensus.ChainHeaderReader, header 
 	}
 	// Check that the BlockSignature contains signature if block is not requested
 	if header.Number.Cmp(big.NewInt(0)) != 0 && len(header.BlockSignature) != extraSeal {
+		log.Info("Morty: missing signature", "hash", header.Hash(), "signature", hex.EncodeToString(header.BlockSignature), "extra", hex.EncodeToString(header.Extra), "number", header.Number)
 		return errMissingSignature
 	}
 	// Ensure that the mix digest is zero

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -172,8 +172,8 @@ func checkSignature(sig []byte) error {
 	if len(sig) != 65 {
 		return ErrInvalidSignatureLen
 	}
-	// if sig[64] >= 4 {
-	// 	return ErrInvalidRecoveryID
-	// }
+	if sig[64] >= 4 {
+		return ErrInvalidRecoveryID
+	}
 	return nil
 }

--- a/crypto/secp256k1/secp256.go
+++ b/crypto/secp256k1/secp256.go
@@ -172,8 +172,8 @@ func checkSignature(sig []byte) error {
 	if len(sig) != 65 {
 		return ErrInvalidSignatureLen
 	}
-	if sig[64] >= 4 {
-		return ErrInvalidRecoveryID
-	}
+	// if sig[64] >= 4 {
+	// 	return ErrInvalidRecoveryID
+	// }
 	return nil
 }


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR makes l2geth compatible with Scroll’s reth node. Currently, the sequencer signs blocks using alloy_signer::Signer, which has been modified to align with Ethereum by mapping the recovery ID from 0|1 to 27|28. However, l2geth relies on a vanilla secp256k1 signer that expects the raw 0|1 values. As a result, l2geth fails to verify signatures produced by the sequencer.

So here we override the recovery ID to make them compatible.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize signature recovery IDs (accept 27/28 and convert to 0/1) to improve signature verification compatibility and reduce signature-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->