### PR TITLE
ci: add cloak build workflow

### DIFF
--- a/.github/workflows/cloak.yml
+++ b/.github/workflows/cloak.yml
@@ -1,0 +1,29 @@
+name: Cloak Docker
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract commit digest
+        id: vars
+        run: echo "sha8=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+
+      - name: Build and Push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: scrolltech/cloak-l2geth:${{ steps.vars.outputs.sha8 }}

--- a/.github/workflows/cloak.yml
+++ b/.github/workflows/cloak.yml
@@ -6,12 +6,16 @@ on:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    permissions: {}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -21,7 +25,7 @@ jobs:
         run: echo "sha8=${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
 
       - name: Build and Push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           platforms: linux/amd64


### PR DESCRIPTION
Since this workflow can be triggered manually (`workflow_dispatch`), it needs to be added to the default branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Introduced a new workflow to build and publish Docker images on demand, improving release reliability and consistency.
  - Supports manual triggers to create images from the current commit, enhancing traceability of builds.
  - Streamlines the deployment pipeline by automating authentication, build, and push steps.
  - No user-facing changes; this update improves operational efficiency and release management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->