### PR TITLE
feat(l1 sync service): add flag for sync interval

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -170,6 +170,7 @@ var (
 		utils.L1EndpointFlag,
 		utils.L1ConfirmationsFlag,
 		utils.L1DeploymentBlockFlag,
+		utils.L1SyncIntervalFlag,
 		utils.L1DisableMessageQueueV2Flag,
 		utils.CircuitCapacityCheckEnabledFlag,
 		utils.CircuitCapacityCheckWorkersFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -233,6 +233,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.L1EndpointFlag,
 			utils.L1ConfirmationsFlag,
 			utils.L1DeploymentBlockFlag,
+			utils.L1SyncIntervalFlag,
 			utils.L1DisableMessageQueueV2Flag,
 			utils.RollupVerifyEnabledFlag,
 			utils.DASyncEnabledFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -853,6 +853,10 @@ var (
 		Name:  "l1.sync.startblock",
 		Usage: "L1 block height to start syncing from. Should be set to the L1 message queue deployment block number.",
 	}
+	L1SyncIntervalFlag = cli.DurationFlag{
+		Name:  "l1.sync.interval",
+		Usage: "Poll interval for L1 message syncing (e.g., 2s, 10s, 1m)",
+	}
 	L1DisableMessageQueueV2Flag = &cli.BoolFlag{
 		Name:  "l1.disablemqv2",
 		Usage: "Disable L1 message queue v2",
@@ -1469,6 +1473,9 @@ func setL1(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(L1DeploymentBlockFlag.Name) {
 		cfg.L1DeploymentBlock = ctx.GlobalUint64(L1DeploymentBlockFlag.Name)
+	}
+	if ctx.GlobalIsSet(L1SyncIntervalFlag.Name) {
+		cfg.L1SyncInterval = ctx.GlobalDuration(L1SyncIntervalFlag.Name)
 	}
 	if ctx.GlobalIsSet(L1DisableMessageQueueV2Flag.Name) {
 		cfg.L1DisableMessageQueueV2 = ctx.GlobalBool(L1DisableMessageQueueV2Flag.Name)

--- a/node/config.go
+++ b/node/config.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/crypto"
@@ -197,6 +198,8 @@ type Config struct {
 	L1Confirmations rpc.BlockNumber `toml:",omitempty"`
 	// L1 bridge deployment block number
 	L1DeploymentBlock uint64 `toml:",omitempty"`
+	// Poll interval for L1 message syncing
+	L1SyncInterval time.Duration `toml:",omitempty"`
 	// Explicitly disable L1 message queue V2 and only query from L1 message queue V1 (before EuclidV2)
 	L1DisableMessageQueueV2 bool `toml:",omitempty"`
 	// Is daSyncingEnabled

--- a/rollup/sync_service/sync_service.go
+++ b/rollup/sync_service/sync_service.go
@@ -100,12 +100,17 @@ func NewSyncService(ctx context.Context, genesisConfig *params.ChainConfig, node
 
 	ctx, cancel := context.WithCancel(ctx)
 
+	pollInterval := nodeConfig.L1SyncInterval
+	if pollInterval == 0 {
+		pollInterval = DefaultPollInterval
+	}
+
 	service := SyncService{
 		ctx:                  ctx,
 		cancel:               cancel,
 		client:               client,
 		db:                   db,
-		pollInterval:         DefaultPollInterval,
+		pollInterval:         pollInterval,
 		latestProcessedBlock: latestProcessedBlock,
 	}
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR
This PR adds a flag to make the L1 sync interval configurable. This is necessary for testing with shorter L1 block and finality times: https://github.com/scroll-tech/rollup-node/pull/343


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a CLI option to configure the L1 sync polling interval, allowing users to adjust how frequently the node polls for L1 messages. If not set, a default interval is used.

- Documentation
  - Updated CLI help to list the new L1 sync interval option under the ROLLUP category, making it easier to discover and configure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->