### PR TITLE
fix(worker): respect deadline in commit condition

### DIFF
--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -415,7 +415,9 @@ func (w *worker) mainLoop() {
 			// be automatically eliminated.
 			if w.current != nil {
 				shouldCommit, _ := w.processTxnSlice(ev.Txs)
-				if shouldCommit || (w.current.deadlineReached && len(w.current.txs) > 0) {
+				// Note: shouldCommit implies that the block is not empty.
+				// Note: We must still wait for the deadline to avoid creating a block with a future timestamp.
+				if shouldCommit && w.current.deadlineReached {
 					_, err = w.commit()
 				}
 			}

--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -414,10 +414,10 @@ func (w *worker) mainLoop() {
 			// already included in the current mining block. These transactions will
 			// be automatically eliminated.
 			if w.current != nil {
-				shouldCommit, _ := w.processTxnSlice(ev.Txs)
-				// Note: shouldCommit implies that the block is not empty.
-				// Note: We must still wait for the deadline to avoid creating a block with a future timestamp.
-				if shouldCommit && w.current.deadlineReached {
+				// Note: We ignore shouldCommit and commit based on len(w.current.txs) instead.
+				w.processTxnSlice(ev.Txs)
+				// Note: We must wait for the deadline to avoid creating a block with a future timestamp.
+				if w.current.deadlineReached && len(w.current.txs) > 0 {
 					_, err = w.commit()
 				}
 			}

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 5         // Patch version component of the current release
+	VersionPatch = 6         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

It was reported that under high load, the signer node runs into `ErrFutureBlock` consensus failures. The root cause seems to be that once `processTxnSlice` returns `true`, we commit regardless of the deadline (block timestamp). The timestamp without relaxed mode is set to `parent.Time + Period` which might be in the future.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block production timing: publishing now waits for the block deadline and presence of transactions, reducing future-dated blocks and ensuring more predictable timestamps and stability.

* **Chores**
  * Bumped patch version to .6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->