### PR TITLE
feat: parameterize sync service fetch block range

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -171,6 +171,7 @@ var (
 		utils.L1ConfirmationsFlag,
 		utils.L1DeploymentBlockFlag,
 		utils.L1SyncIntervalFlag,
+		utils.L1FetchBlockRangeFlag,
 		utils.L1DisableMessageQueueV2Flag,
 		utils.CircuitCapacityCheckEnabledFlag,
 		utils.CircuitCapacityCheckWorkersFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -857,7 +857,7 @@ var (
 		Name:  "l1.sync.interval",
 		Usage: "Poll interval for L1 message syncing (e.g., 2s, 10s, 1m)",
 	}
-	L1FetchBlockRangeFlag = cli.Uint64Flag{
+	L1FetchBlockRangeFlag = cli.Int64Flag{
 		Name:  "l1.sync.fetchblockrange",
 		Usage: "Block range for L1 message fetching in a single eth_getLogs query",
 	}

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -857,6 +857,10 @@ var (
 		Name:  "l1.sync.interval",
 		Usage: "Poll interval for L1 message syncing (e.g., 2s, 10s, 1m)",
 	}
+	L1FetchBlockRangeFlag = cli.Uint64Flag{
+		Name:  "l1.sync.fetchblockrange",
+		Usage: "Block range for L1 message fetching in a single eth_getLogs query",
+	}
 	L1DisableMessageQueueV2Flag = &cli.BoolFlag{
 		Name:  "l1.disablemqv2",
 		Usage: "Disable L1 message queue v2",
@@ -1476,6 +1480,9 @@ func setL1(ctx *cli.Context, cfg *node.Config) {
 	}
 	if ctx.GlobalIsSet(L1SyncIntervalFlag.Name) {
 		cfg.L1SyncInterval = ctx.GlobalDuration(L1SyncIntervalFlag.Name)
+	}
+	if ctx.GlobalIsSet(L1FetchBlockRangeFlag.Name) {
+		cfg.L1FetchBlockRange = ctx.GlobalUint64(L1FetchBlockRangeFlag.Name)
 	}
 	if ctx.GlobalIsSet(L1DisableMessageQueueV2Flag.Name) {
 		cfg.L1DisableMessageQueueV2 = ctx.GlobalBool(L1DisableMessageQueueV2Flag.Name)

--- a/node/config.go
+++ b/node/config.go
@@ -200,6 +200,8 @@ type Config struct {
 	L1DeploymentBlock uint64 `toml:",omitempty"`
 	// Poll interval for L1 message syncing
 	L1SyncInterval time.Duration `toml:",omitempty"`
+	// Block range for L1 message fetching in a single eth_getLogs query
+	L1FetchBlockRange uint64 `toml:",omitempty"`
 	// Explicitly disable L1 message queue V2 and only query from L1 message queue V1 (before EuclidV2)
 	L1DisableMessageQueueV2 bool `toml:",omitempty"`
 	// Is daSyncingEnabled

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 5         // Patch version component of the current release
+	VersionPatch = 6         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR parameterize sync service fetch block range, which required by DogeOS team to address the issue that the default 100 block range is too large in their case.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI and configuration option to control the block range used when fetching L1 messages, allowing adjustable batch sizes during sync.
  * Sync process now uses the configured range and falls back to sensible defaults when unset.

* **Chores**
  * Bumped the patch version to reflect this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->