### PR TITLE
fix: add missing Galileo precompile activation

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -47,6 +47,8 @@ type (
 func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	var precompiles map[common.Address]PrecompiledContract
 	switch {
+	case evm.chainRules.IsGalileo:
+		precompiles = PrecompiledContractsGalileo
 	case evm.chainRules.IsFeynman:
 		precompiles = PrecompiledContractsFeynman
 	case evm.chainRules.IsEuclidV2:

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 8         // Patch version component of the current release
+	VersionPatch = 9         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Add missing precompile activation.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Galileo network upgrade with dynamic precompile contract selection based on network rules. System intelligently maps to appropriate contract implementations while maintaining backward compatibility with previous network versions.

* **Chores**
  * Patch version updated from 8 to 9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->