### PR TITLE
feat: schedule Galileo on Scroll Sepolia

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -333,6 +333,7 @@ var (
 		EuclidTime:          newUint64(1741680000),
 		EuclidV2Time:        newUint64(1741852800),
 		FeynmanTime:         newUint64(1753167600),
+		GalileoTime:         newUint64(1763625600),
 		Clique: &CliqueConfig{
 			Period: 3,
 			Epoch:  30000,

--- a/params/config.go
+++ b/params/config.go
@@ -333,7 +333,7 @@ var (
 		EuclidTime:          newUint64(1741680000),
 		EuclidV2Time:        newUint64(1741852800),
 		FeynmanTime:         newUint64(1753167600),
-		GalileoTime:         newUint64(1763625600),
+		GalileoTime:         newUint64(1764054000),
 		Clique: &CliqueConfig{
 			Period: 3,
 			Epoch:  30000,

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 10        // Patch version component of the current release
+	VersionPatch = 11        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 12        // Patch version component of the current release
+	VersionPatch = 13        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 11        // Patch version component of the current release
+	VersionPatch = 12        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Schedule the [Galileo upgrade](https://forum.scroll.io/t/proposal-galileo-upgrade/1315) on Scroll Sepolia at Unix timestamp `1764054000` (see [here](https://www.timeanddate.com/worldclock/converter.html?iso=20251125T070000&p1=224&p2=179&p3=1440&p4=37&p5=236) for time zone conversions).

Release notes draft: https://gist.github.com/Thegaram/df724b248c56c65b779440a8faa1dc55


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Product patch version bumped (12 → 13), updating the reported product version strings and archives.
  * Scroll Sepolia chain configuration augmented with a new fork-time field to influence Sepolia network behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->