### PR TITLE
feat(witness): include access-list in witness

### DIFF
--- a/eth/api.go
+++ b/eth/api.go
@@ -367,6 +367,20 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 	// sure that this is always present in the execution witness.
 	statedb.GetState(rcfg.L1GasPriceOracleAddress, rcfg.IsFeynmanSlot)
 
+	// Ensure that all access list entries are included in the witness,
+	// as these are always loaded by revm.
+	for _, tx := range block.Transactions() {
+		for _, accessTuple := range tx.AccessList() {
+			// Load account
+			statedb.GetBalance(accessTuple.Address)
+
+			// Load storage entries
+			for _, key := range accessTuple.StorageKeys {
+				statedb.GetState(accessTuple.Address, key)
+			}
+		}
+	}
+
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process block %d: %w", block.Number(), err)

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 14        // Patch version component of the current release
+	VersionPatch = 15        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

During stateless execution, revm [eagerly loads](https://github.com/scroll-tech/revm/blob/10e11b985ed28bd383e624539868bcc3f613d77c/crates/handler/src/pre_execution.rs#L57) access list entries, even if they are not used during execution. To ensure compatibility with witnesses produced by l2geth, we explicitly add access list items in `debug_executionWitness`.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [x] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Preloads access-list entries into execution witness so access-list-derived reads are present before block processing.

* **Chores**
  * Patch version increment (minor build/version metadata update).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->