### PR TITLE
fix: apply hard forks during tracing

### DIFF
--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -148,18 +148,8 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		chainConfig.DAOForkBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
-	// Apply Curie hard fork
-	if chainConfig.CurieBlock != nil && chainConfig.CurieBlock.Cmp(new(big.Int).SetUint64(pre.Env.Number)) == 0 {
-		misc.ApplyCurieHardFork(statedb)
-	}
-	// Apply Feynman hard fork
-	if chainConfig.IsFeynmanTransitionBlock(pre.Env.Timestamp, pre.Env.ParentTimestamp) {
-		misc.ApplyFeynmanHardFork(statedb)
-	}
-	// Apply GalileoV2 hard fork
-	if chainConfig.IsGalileoV2TransitionBlock(pre.Env.Timestamp, pre.Env.ParentTimestamp) {
-		misc.ApplyGalileoV2HardFork(statedb)
-	}
+	// Apply Scroll hard fork state transitions on state
+	misc.ApplyForkStateTransitions(chainConfig, statedb, pre.Env.Number, pre.Env.Timestamp, pre.Env.ParentTimestamp)
 	// Apply EIP-2935
 	if pre.Env.BlockHashes != nil && chainConfig.IsFeynman(pre.Env.Timestamp) {
 		var (

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -150,7 +150,7 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 	}
 	// Apply Scroll hard fork state transitions on state
 	misc.ApplyForkStateTransitions(chainConfig, statedb, pre.Env.Number, pre.Env.Timestamp, pre.Env.ParentTimestamp)
-	// Apply EIP-2935
+	// Apply EIP-2935: Insert parent hash in history contract.
 	if pre.Env.BlockHashes != nil && chainConfig.IsFeynman(pre.Env.Timestamp) {
 		var (
 			prevNumber = pre.Env.Number - 1

--- a/consensus/misc/curie.go
+++ b/consensus/misc/curie.go
@@ -7,9 +7,9 @@ import (
 	"github.com/scroll-tech/go-ethereum/rollup/rcfg"
 )
 
-// ApplyCurieHardFork modifies the state database according to the Curie hard-fork rules,
+// applyCurieHardFork modifies the state database according to the Curie hard-fork rules,
 // updating the bytecode and storage of the L1GasPriceOracle contract.
-func ApplyCurieHardFork(statedb *state.StateDB) {
+func applyCurieHardFork(statedb *state.StateDB) {
 	log.Info("Applying Curie hard fork")
 
 	// update contract byte code

--- a/consensus/misc/feynman.go
+++ b/consensus/misc/feynman.go
@@ -7,9 +7,9 @@ import (
 	"github.com/scroll-tech/go-ethereum/rollup/rcfg"
 )
 
-// ApplyFeynmanHardFork modifies the state database according to the Feynman hard-fork rules,
+// applyFeynmanHardFork modifies the state database according to the Feynman hard-fork rules,
 // updating the bytecode and storage of the L1GasPriceOracle contract.
-func ApplyFeynmanHardFork(statedb *state.StateDB) {
+func applyFeynmanHardFork(statedb *state.StateDB) {
 	log.Info("Applying Feynman hard fork")
 
 	// update contract byte code

--- a/consensus/misc/forks.go
+++ b/consensus/misc/forks.go
@@ -49,14 +49,14 @@ func VerifyForkHashes(config *params.ChainConfig, header *types.Header, uncle bo
 func ApplyForkStateTransitions(config *params.ChainConfig, statedb *state.StateDB, blockNumber, blockTimestamp, parentTimestamp uint64) {
 	// Apply Curie hard fork
 	if config.CurieBlock != nil && config.CurieBlock.Cmp(new(big.Int).SetUint64(blockNumber)) == 0 {
-		ApplyCurieHardFork(statedb)
+		applyCurieHardFork(statedb)
 	}
 	// Apply Feynman hard fork
 	if config.IsFeynmanTransitionBlock(blockTimestamp, parentTimestamp) {
-		ApplyFeynmanHardFork(statedb)
+		applyFeynmanHardFork(statedb)
 	}
 	// Apply GalileoV2 hard fork
 	if config.IsGalileoV2TransitionBlock(blockTimestamp, parentTimestamp) {
-		ApplyGalileoV2HardFork(statedb)
+		applyGalileoV2HardFork(statedb)
 	}
 }

--- a/consensus/misc/forks.go
+++ b/consensus/misc/forks.go
@@ -18,8 +18,10 @@ package misc
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
 	"github.com/scroll-tech/go-ethereum/params"
 )
@@ -40,4 +42,21 @@ func VerifyForkHashes(config *params.ChainConfig, header *types.Header, uncle bo
 	}
 	// All ok, return
 	return nil
+}
+
+// ApplyForkStateTransitions applies the special hard fork state transitions for
+// Curie, Feynman, or GalileoV2, if the given block is the upgrade block.
+func ApplyForkStateTransitions(config *params.ChainConfig, statedb *state.StateDB, blockNumber, blockTimestamp, parentTimestamp uint64) {
+	// Apply Curie hard fork
+	if config.CurieBlock != nil && config.CurieBlock.Cmp(new(big.Int).SetUint64(blockNumber)) == 0 {
+		ApplyCurieHardFork(statedb)
+	}
+	// Apply Feynman hard fork
+	if config.IsFeynmanTransitionBlock(blockTimestamp, parentTimestamp) {
+		ApplyFeynmanHardFork(statedb)
+	}
+	// Apply GalileoV2 hard fork
+	if config.IsGalileoV2TransitionBlock(blockTimestamp, parentTimestamp) {
+		ApplyGalileoV2HardFork(statedb)
+	}
 }

--- a/consensus/misc/galileoV2.go
+++ b/consensus/misc/galileoV2.go
@@ -7,9 +7,9 @@ import (
 	"github.com/scroll-tech/go-ethereum/rollup/rcfg"
 )
 
-// ApplyGalileoV2HardFork modifies the state database according to the GalileoV2 hard-fork rules,
+// applyGalileoV2HardFork modifies the state database according to the GalileoV2 hard-fork rules,
 // updating the bytecode and storage of the L1GasPriceOracle contract.
-func ApplyGalileoV2HardFork(statedb *state.StateDB) {
+func applyGalileoV2HardFork(statedb *state.StateDB) {
 	log.Info("Applying GalileoV2 hard fork")
 
 	// update contract byte code

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -246,15 +246,8 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 		if config.DAOForkSupport && config.DAOForkBlock != nil && config.DAOForkBlock.Cmp(b.header.Number) == 0 {
 			misc.ApplyDAOHardFork(statedb)
 		}
-		if config.CurieBlock != nil && config.CurieBlock.Cmp(b.header.Number) == 0 {
-			misc.ApplyCurieHardFork(statedb)
-		}
-		if config.IsFeynmanTransitionBlock(b.Time(), parent.Time()) {
-			misc.ApplyFeynmanHardFork(statedb)
-		}
-		if config.IsGalileoV2TransitionBlock(b.Time(), parent.Time()) {
-			misc.ApplyGalileoV2HardFork(statedb)
-		}
+		// Apply Scroll hard fork state transitions on state
+		misc.ApplyForkStateTransitions(config, statedb, b.header.Number.Uint64(), b.header.Time, parent.Time())
 		// Execute any user modifications to the block
 		if gen != nil {
 			gen(i, b)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -247,7 +247,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			misc.ApplyDAOHardFork(statedb)
 		}
 		// Apply Scroll hard fork state transitions on state
-		misc.ApplyForkStateTransitions(config, statedb, b.header.Number.Uint64(), b.header.Time, parent.Time())
+		misc.ApplyForkStateTransitions(config, statedb, b.header.Number.Uint64(), b.Time(), parent.Time())
 		// Execute any user modifications to the block
 		if gen != nil {
 			gen(i, b)

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -88,23 +88,13 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	if p.config.DAOForkSupport && p.config.DAOForkBlock != nil && p.config.DAOForkBlock.Cmp(block.Number()) == 0 {
 		misc.ApplyDAOHardFork(statedb)
 	}
-	// Apply Curie hard fork
-	if p.config.CurieBlock != nil && p.config.CurieBlock.Cmp(block.Number()) == 0 {
-		misc.ApplyCurieHardFork(statedb)
-	}
-	// Apply Feynman hard fork
+	// Apply Scroll hard fork state transitions on state
 	parent := p.bc.GetHeaderByHash(block.ParentHash())
-	if p.config.IsFeynmanTransitionBlock(block.Time(), parent.Time) {
-		misc.ApplyFeynmanHardFork(statedb)
-	}
-	// Apply GalileoV2 hard fork
-	if p.config.IsGalileoV2TransitionBlock(block.Time(), parent.Time) {
-		misc.ApplyGalileoV2HardFork(statedb)
-	}
+	misc.ApplyForkStateTransitions(p.config, statedb, blockNumber.Uint64(), blockTime, parent.Time)
+	// Apply EIP-2935
 	blockContext := NewEVMBlockContext(header, p.bc, p.config, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 	processorBlockTransactionGauge.Update(int64(block.Transactions().Len()))
-	// Apply EIP-2935
 	if p.config.IsFeynman(block.Time()) {
 		ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
 	}

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -91,7 +91,7 @@ func (p *StateProcessor) Process(block *types.Block, statedb *state.StateDB, cfg
 	// Apply Scroll hard fork state transitions on state
 	parent := p.bc.GetHeaderByHash(block.ParentHash())
 	misc.ApplyForkStateTransitions(p.config, statedb, blockNumber.Uint64(), blockTime, parent.Time)
-	// Apply EIP-2935
+	// Apply EIP-2935: Insert parent hash in history contract.
 	blockContext := NewEVMBlockContext(header, p.bc, p.config, nil)
 	vmenv := vm.NewEVM(blockContext, vm.TxContext{}, statedb, p.config, cfg)
 	processorBlockTransactionGauge.Update(int64(block.Transactions().Len()))

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/scroll-tech/go-ethereum/common"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	"github.com/scroll-tech/go-ethereum/core"
 	"github.com/scroll-tech/go-ethereum/core/state"
 	"github.com/scroll-tech/go-ethereum/core/types"
@@ -176,6 +177,8 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 	if err != nil {
 		return nil, vm.BlockContext{}, nil, err
 	}
+	// Apply Scroll hard fork state transitions on state
+	misc.ApplyForkStateTransitions(eth.blockchain.Config(), statedb, block.NumberU64(), block.Time(), parent.Time())
 	// If feynman hardfork, insert parent block hash in the state as per EIP-2935.
 	if eth.blockchain.Config().IsFeynman(block.Time()) {
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, eth.blockchain.Config(), nil)

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -179,7 +179,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 	}
 	// Apply Scroll hard fork state transitions on state
 	misc.ApplyForkStateTransitions(eth.blockchain.Config(), statedb, block.NumberU64(), block.Time(), parent.Time())
-	// If feynman hardfork, insert parent block hash in the state as per EIP-2935.
+	// Apply EIP-2935: Insert parent hash in history contract.
 	if eth.blockchain.Config().IsFeynman(block.Time()) {
 		context := core.NewEVMBlockContext(block.Header(), eth.blockchain, eth.blockchain.Config(), nil)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, statedb, eth.blockchain.Config(), vm.Config{})

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -32,6 +32,7 @@ import (
 	"github.com/scroll-tech/go-ethereum/common"
 	"github.com/scroll-tech/go-ethereum/common/hexutil"
 	"github.com/scroll-tech/go-ethereum/consensus"
+	"github.com/scroll-tech/go-ethereum/consensus/misc"
 	"github.com/scroll-tech/go-ethereum/core"
 	"github.com/scroll-tech/go-ethereum/core/rawdb"
 	"github.com/scroll-tech/go-ethereum/core/state"
@@ -202,10 +203,11 @@ type txTraceResult struct {
 // blockTraceTask represents a single block trace task when an entire chain is
 // being traced.
 type blockTraceTask struct {
-	statedb *state.StateDB   // Intermediate state prepped for tracing
-	block   *types.Block     // Block to trace the transactions from
-	rootref common.Hash      // Trie root reference held for this task
-	results []*txTraceResult // Trace results procudes by the task
+	statedb     *state.StateDB   // Intermediate state prepped for tracing
+	block       *types.Block     // Block to trace the transactions from
+	parentBlock *types.Block     // Block to trace the transactions from
+	rootref     common.Hash      // Trie root reference held for this task
+	results     []*txTraceResult // Trace results procudes by the task
 }
 
 // blockTraceResult represets the results of tracing a single block when an entire
@@ -277,11 +279,16 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			for task := range tasks {
 				signer := types.MakeSigner(api.backend.ChainConfig(), task.block.Number(), task.block.Time())
 				blockCtx := core.NewEVMBlockContext(task.block.Header(), api.chainContext(localctx), api.backend.ChainConfig(), nil)
+
+				// Apply Scroll hard fork state transitions on state
+				misc.ApplyForkStateTransitions(api.backend.ChainConfig(), task.statedb, task.block.NumberU64(), task.block.Time(), task.parentBlock.Time())
+
 				// EIP-2935: Insert parent hash in history contract.
 				if api.backend.ChainConfig().IsFeynman(task.block.Time()) {
 					evm := vm.NewEVM(blockCtx, vm.TxContext{}, task.statedb, api.backend.ChainConfig(), vm.Config{})
 					core.ProcessParentBlockHash(task.block.ParentHash(), evm, task.statedb)
 				}
+
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
 					msg, _ := tx.AsMessage(signer, task.block.BaseFee())
@@ -410,7 +417,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 			// Send the block over to the concurrent tracers (if not in the fast-forward phase)
 			txs := next.Transactions()
 			select {
-			case tasks <- &blockTraceTask{statedb: statedb.Copy(), block: next, rootref: block.Root(), results: make([]*txTraceResult, len(txs))}:
+			case tasks <- &blockTraceTask{statedb: statedb.Copy(), block: next, parentBlock: block, rootref: block.Root(), results: make([]*txTraceResult, len(txs))}:
 			case <-notifier.Closed():
 				return
 			}
@@ -544,6 +551,10 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 		vmctx              = core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), api.backend.ChainConfig(), nil)
 		deleteEmptyObjects = chainConfig.IsEIP158(block.Number())
 	)
+
+	// Apply Scroll hard fork state transitions on state
+	misc.ApplyForkStateTransitions(api.backend.ChainConfig(), statedb, block.NumberU64(), block.Time(), parent.Time())
+
 	// EIP-2935: Insert parent hash in history contract.
 	if api.backend.ChainConfig().IsFeynman(block.Time()) {
 		vmenv := vm.NewEVM(vmctx, vm.TxContext{}, statedb, chainConfig, vm.Config{})
@@ -624,11 +635,16 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		threads = len(txs)
 	}
 	blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), api.backend.ChainConfig(), nil)
+
+	// Apply Scroll hard fork state transitions on state
+	misc.ApplyForkStateTransitions(api.backend.ChainConfig(), statedb, block.NumberU64(), block.Time(), parent.Time())
+
 	// EIP-2935: Insert parent hash in history contract.
 	if api.backend.ChainConfig().IsFeynman(block.Time()) {
 		evm := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
 		core.ProcessParentBlockHash(block.ParentHash(), evm, statedb)
 	}
+
 	blockHash := block.Hash()
 	blockNumber := block.NumberU64()
 	for th := 0; th < threads; th++ {
@@ -763,6 +779,9 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 			canon = false
 		}
 	}
+
+	// Apply Scroll hard fork state transitions on state
+	misc.ApplyForkStateTransitions(api.backend.ChainConfig(), statedb, block.NumberU64(), block.Time(), parent.Time())
 
 	// EIP-2935: Insert parent hash in history contract.
 	if api.backend.ChainConfig().IsFeynman(block.Time()) {

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -205,7 +205,7 @@ type txTraceResult struct {
 type blockTraceTask struct {
 	statedb     *state.StateDB   // Intermediate state prepped for tracing
 	block       *types.Block     // Block to trace the transactions from
-	parentBlock *types.Block     // Block to trace the transactions from
+	parentBlock *types.Block     // Parent block of the block to trace
 	rootref     common.Hash      // Trie root reference held for this task
 	results     []*txTraceResult // Trace results procudes by the task
 }
@@ -283,7 +283,7 @@ func (api *API) traceChain(ctx context.Context, start, end *types.Block, config 
 				// Apply Scroll hard fork state transitions on state
 				misc.ApplyForkStateTransitions(api.backend.ChainConfig(), task.statedb, task.block.NumberU64(), task.block.Time(), task.parentBlock.Time())
 
-				// EIP-2935: Insert parent hash in history contract.
+				// Apply EIP-2935: Insert parent hash in history contract.
 				if api.backend.ChainConfig().IsFeynman(task.block.Time()) {
 					evm := vm.NewEVM(blockCtx, vm.TxContext{}, task.statedb, api.backend.ChainConfig(), vm.Config{})
 					core.ProcessParentBlockHash(task.block.ParentHash(), evm, task.statedb)
@@ -555,7 +555,7 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 	// Apply Scroll hard fork state transitions on state
 	misc.ApplyForkStateTransitions(api.backend.ChainConfig(), statedb, block.NumberU64(), block.Time(), parent.Time())
 
-	// EIP-2935: Insert parent hash in history contract.
+	// Apply EIP-2935: Insert parent hash in history contract.
 	if api.backend.ChainConfig().IsFeynman(block.Time()) {
 		vmenv := vm.NewEVM(vmctx, vm.TxContext{}, statedb, chainConfig, vm.Config{})
 		core.ProcessParentBlockHash(block.ParentHash(), vmenv, statedb)
@@ -639,7 +639,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 	// Apply Scroll hard fork state transitions on state
 	misc.ApplyForkStateTransitions(api.backend.ChainConfig(), statedb, block.NumberU64(), block.Time(), parent.Time())
 
-	// EIP-2935: Insert parent hash in history contract.
+	// Apply EIP-2935: Insert parent hash in history contract.
 	if api.backend.ChainConfig().IsFeynman(block.Time()) {
 		evm := vm.NewEVM(blockCtx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
 		core.ProcessParentBlockHash(block.ParentHash(), evm, statedb)
@@ -783,7 +783,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 	// Apply Scroll hard fork state transitions on state
 	misc.ApplyForkStateTransitions(api.backend.ChainConfig(), statedb, block.NumberU64(), block.Time(), parent.Time())
 
-	// EIP-2935: Insert parent hash in history contract.
+	// Apply EIP-2935: Insert parent hash in history contract.
 	if api.backend.ChainConfig().IsFeynman(block.Time()) {
 		evm := vm.NewEVM(vmctx, vm.TxContext{}, statedb, api.backend.ChainConfig(), vm.Config{})
 		core.ProcessParentBlockHash(block.ParentHash(), evm, statedb)

--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -633,7 +633,7 @@ func (w *worker) handleForks(parent *types.Block) (bool, error) {
 	// Apply Scroll hard fork state transitions on state
 	misc.ApplyForkStateTransitions(w.chainConfig, w.current.state, w.current.header.Number.Uint64(), w.current.header.Time, parent.Time())
 
-	// Apply EIP-2935
+	// Apply EIP-2935: Insert parent hash in history contract.
 	if w.chainConfig.IsFeynman(w.current.header.Time) {
 		context := core.NewEVMBlockContext(w.current.header, w.chain, w.chainConfig, nil)
 		vmenv := vm.NewEVM(context, vm.TxContext{}, w.current.state, w.chainConfig, vm.Config{})

--- a/miner/scroll_worker.go
+++ b/miner/scroll_worker.go
@@ -630,21 +630,8 @@ func (w *worker) tryCommitNewWork(now time.Time, parentHash common.Hash, reorgin
 
 // handleForks
 func (w *worker) handleForks(parent *types.Block) (bool, error) {
-	// Apply Curie predeployed contract update
-	if w.chainConfig.CurieBlock != nil && w.chainConfig.CurieBlock.Cmp(w.current.header.Number) == 0 {
-		misc.ApplyCurieHardFork(w.current.state)
-		return true, nil
-	}
-
-	// Apply Feynman hard fork
-	if w.chainConfig.IsFeynmanTransitionBlock(w.current.header.Time, parent.Time()) {
-		misc.ApplyFeynmanHardFork(w.current.state)
-	}
-
-	// Apply GalileoV2 hard fork
-	if w.chainConfig.IsGalileoV2TransitionBlock(w.current.header.Time, parent.Time()) {
-		misc.ApplyGalileoV2HardFork(w.current.state)
-	}
+	// Apply Scroll hard fork state transitions on state
+	misc.ApplyForkStateTransitions(w.chainConfig, w.current.state, w.current.header.Number.Uint64(), w.current.header.Time, parent.Time())
 
 	// Apply EIP-2935
 	if w.chainConfig.IsFeynman(w.current.header.Time) {

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 18        // Patch version component of the current release
+	VersionPatch = 19        // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Consider the special hard fork state transitions (typically upgrading the L1GasPriceOracle predeploy) during tracing operations like `debug_traceTransaction`. See also [this thread](https://scrollco.slack.com/archives/C084B3JSWM8/p1764854297642779).


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Version bumped to patch 19.

* **Refactor**
  * Centralized hard-fork state transitions into a single unified application step across execution, block production, state processing, mining, and tracing.
  * Tracing and state-preparation flows now propagate parent-block context to ensure fork transitions are applied consistently before transaction/tracing execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->