### PR TITLE
feat: schedule Galileo and GalileoV2 on Scroll mainnet

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -388,8 +388,8 @@ var (
 		EuclidTime:          newUint64(1744815600),
 		EuclidV2Time:        newUint64(1745305200),
 		FeynmanTime:         newUint64(1755576000),
-		GalileoTime:         nil,
-		GalileoV2Time:       nil,
+		GalileoTime:         newUint64(1765868400),
+		GalileoV2Time:       newUint64(1766041200),
 		Clique: &CliqueConfig{
 			Period: 3,
 			Epoch:  30000,

--- a/params/version.go
+++ b/params/version.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	VersionMajor = 5         // Major version component of the current release
-	VersionMinor = 9         // Minor version component of the current release
-	VersionPatch = 19        // Patch version component of the current release
+	VersionMinor = 10        // Minor version component of the current release
+	VersionPatch = 0         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Schedule the two Galileo hard forks on Scroll mainnet.
- Galileo: `1765868400` ([Tue Dec 16 2025 07:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20251216T070000&p1=224&p2=179&p3=1440&p4=37&p5=236))
- GalileoV2: `1766041200` ([Thu Dec 18 2025 07:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20251218T070000&p1=224&p2=179&p3=1440&p4=37&p5=236))

Rationale:
- Governance vote officially ends on 10 Dec, Security Council will sign the upgrade transaction by 11 Dec, so the 3-day timelock should expire no later than 15 Dec.
- 7am UTC leaves us enough time during the day to debug any issues (but it is inconvenient for many node operators).
- 2 days between upgrades leaves some time for an emergency release if anything goes wrong.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature

## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 5.10.0
  * Updated Galileo fork configuration parameters for mainnet

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->