### PR TITLE
Fix/delegated code failed witness missing

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -190,6 +190,13 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 	}
 	// Fail if we're trying to transfer more than the available balance
 	if value.Sign() != 0 && !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
+		// EIP-7702: Ensure delegated code is loaded into witness even when balance check fails.
+		// revm always loads the code regardless of balance check result.
+		if code := evm.StateDB.GetCode(addr); len(code) > 0 {
+			if target, ok := types.ParseDelegation(code); ok {
+				evm.StateDB.GetCode(target)
+			}
+		}
 		return nil, gas, ErrInsufficientBalance
 	}
 	snapshot := evm.StateDB.Snapshot()

--- a/eth/api.go
+++ b/eth/api.go
@@ -382,19 +382,6 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 		}
 	}
 
-	// Ensure that EIP-7702 delegated code is included in the witness.
-	// When a transaction calls an EIP-7702 EOA (that has delegated to a contract)
-	// and fails in precheck (e.g., insufficient balance), geth doesn't load the
-	// bytecode from the delegated address. However, revm always loads it.
-	for _, tx := range block.Transactions() {
-		// Check if the To address has delegated code
-		if to := tx.To(); to != nil {
-			if target, ok := types.ParseDelegation(statedb.GetCode(*to)); ok {
-				statedb.GetCode(target)
-			}
-		}
-	}
-
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process block %d: %w", block.Number(), err)

--- a/eth/api.go
+++ b/eth/api.go
@@ -382,6 +382,19 @@ func generateWitness(blockchain *core.BlockChain, block *types.Block) (*stateles
 		}
 	}
 
+	// Ensure that EIP-7702 delegated code is included in the witness.
+	// When a transaction calls an EIP-7702 EOA (that has delegated to a contract)
+	// and fails in precheck (e.g., insufficient balance), geth doesn't load the
+	// bytecode from the delegated address. However, revm always loads it.
+	for _, tx := range block.Transactions() {
+		// Check if the To address has delegated code
+		if to := tx.To(); to != nil {
+			if target, ok := types.ParseDelegation(statedb.GetCode(*to)); ok {
+				statedb.GetCode(target)
+			}
+		}
+	}
+
 	receipts, _, usedGas, err := blockchain.Processor().Process(block, statedb, *blockchain.GetVMConfig())
 	if err != nil {
 		return nil, fmt.Errorf("failed to process block %d: %w", block.Number(), err)

--- a/params/version.go
+++ b/params/version.go
@@ -39,7 +39,6 @@ var VersionWithMeta = func() string {
 	if VersionMeta != "" {
 		v += "-" + VersionMeta
 	}
-
 	return v
 }()
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 10        // Minor version component of the current release
-	VersionPatch = 2         // Patch version component of the current release
+	VersionPatch = 3         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 

--- a/params/version.go
+++ b/params/version.go
@@ -39,6 +39,7 @@ var VersionWithMeta = func() string {
 	if VersionMeta != "" {
 		v += "-" + VersionMeta
 	}
+
 	return v
 }()
 

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 10        // Minor version component of the current release
-	VersionPatch = 1         // Patch version component of the current release
+	VersionPatch = 2         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Essentially, the setting of witness is different from upstream

*  Upstream ProcessBlock -> statedb.StartPrefetcher("chain", witness, ...), it can `GetCode` to put the pre-check failure to witness
* But srcroll's old logic is call `statedb.WithWitness` ->  blockchain.Processor().Process to load witness, if the pre-check failed, will return and don't add the failed delegated code to witness.

## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [ ] feat: A new feature
- [x] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped patch version.

* **Bug Fixes**
  * When a transfer would exceed the sender’s balance, the runtime now materializes delegated contract code before returning an insufficient-balance error (per EIP-7702), ensuring delegated code is available even on balance-failure paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->