### PR TITLE
[Don't Merge] feat: add param to skip system config signer check

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -182,6 +182,7 @@ var (
 		utils.GossipSequencerHTTPFlag,
 		utils.GossipBroadcastToAllEnabledFlag,
 		utils.GossipBroadcastToAllCapFlag,
+		utils.SkipSignerCheckFlag,
 		utils.DASyncEnabledFlag,
 		utils.DAMissingHeaderFieldsBaseURLFlag,
 		utils.DABlockNativeAPIEndpointFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -255,6 +255,7 @@ var AppHelpFlagGroups = []flags.FlagGroup{
 			utils.GossipSequencerHTTPFlag,
 			utils.GossipBroadcastToAllEnabledFlag,
 			utils.GossipBroadcastToAllCapFlag,
+			utils.SkipSignerCheckFlag,
 		},
 	},
 	{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1854,7 +1854,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	}
 	if ctx.GlobalIsSet(SkipSignerCheckFlag.Name) {
 		cfg.SkipSignerCheck = ctx.GlobalBool(SkipSignerCheckFlag.Name)
-		log.Info("Skip signer check for the SystemContract engine", "skipped", cfg.SkipSignerCheck)
+		log.Warn("Skip signer check for the SystemContract engine", "skipped", cfg.SkipSignerCheck)
 	}
 	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
 	if ctx.IsSet(GossipSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -919,6 +919,11 @@ var (
 		Value: 30,
 	}
 
+	SkipSignerCheckFlag = cli.BoolFlag{
+		Name:  "skipsignercheck",
+		Usage: "Skip signer check for the SystemContract engine",
+	}
+
 	// DA syncing settings
 	DASyncEnabledFlag = cli.BoolFlag{
 		Name:  "da.sync",
@@ -1846,6 +1851,10 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		cfg.GossipBroadcastToAllEnabled = ctx.GlobalBool(GossipBroadcastToAllEnabledFlag.Name)
 		cfg.GossipBroadcastToAllCap = ctx.GlobalInt(GossipBroadcastToAllCapFlag.Name)
 		log.Info("Gossip broadcast to all enabled", "enabled", cfg.GossipBroadcastToAllEnabled, "cap", cfg.GossipBroadcastToAllCap)
+	}
+	if ctx.GlobalIsSet(SkipSignerCheckFlag.Name) {
+		cfg.SkipSignerCheck = ctx.GlobalBool(SkipSignerCheckFlag.Name)
+		log.Info("Skip signer check for the SystemContract engine", "skipped", cfg.SkipSignerCheck)
 	}
 	// Only configure sequencer http flag if we're running in verifier mode i.e. --mine is disabled.
 	if ctx.IsSet(GossipSequencerHTTPFlag.Name) && !ctx.IsSet(MiningEnabledFlag.Name) {

--- a/consensus/system_contract/consensus.go
+++ b/consensus/system_contract/consensus.go
@@ -135,7 +135,7 @@ func (s *SystemContract) verifyHeader(chain consensus.ChainHeaderReader, header 
 		return errInvalidNonce
 	}
 	// Check that the BlockSignature contains signature if block is not requested
-	if header.Number.Cmp(big.NewInt(0)) != 0 && len(header.BlockSignature) != extraSeal {
+	if !s.skipSignerCheck && header.Number.Cmp(big.NewInt(0)) != 0 && len(header.BlockSignature) != extraSeal {
 		return errMissingSignature
 	}
 	// Ensure that the mix digest is zero
@@ -200,6 +200,10 @@ func (s *SystemContract) verifyCascadingFields(chain consensus.ChainHeaderReader
 	} else if err := misc.VerifyEip1559Header(chain.Config(), parent, header); err != nil {
 		// Verify the header's EIP-1559 attributes.
 		return err
+	}
+
+	if s.skipSignerCheck {
+		return nil
 	}
 
 	signer, err := ecrecover(header)

--- a/consensus/system_contract/system_contract.go
+++ b/consensus/system_contract/system_contract.go
@@ -50,6 +50,8 @@ func New(ctx context.Context, config *params.SystemContractConfig, client sync_s
 
 		ctx:    ctx,
 		cancel: cancel,
+
+		skipSignerCheck: skipSignerCheck,
 	}
 
 	if err := s.fetchAddressFromL1(); err != nil {

--- a/consensus/system_contract/system_contract.go
+++ b/consensus/system_contract/system_contract.go
@@ -33,11 +33,13 @@ type SystemContract struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	skipSignerCheck bool
 }
 
 // New creates a SystemContract consensus engine with the initial
 // authorized signer fetched from L1 (if available).
-func New(ctx context.Context, config *params.SystemContractConfig, client sync_service.EthClient) *SystemContract {
+func New(ctx context.Context, config *params.SystemContractConfig, client sync_service.EthClient, skipSignerCheck bool) *SystemContract {
 	log.Info("Initializing system_contract consensus engine", "config", config)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/consensus/system_contract/system_contract_test.go
+++ b/consensus/system_contract/system_contract_test.go
@@ -36,7 +36,7 @@ func TestSystemContract_FetchSigner(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	sys := New(ctx, config, fakeClient)
+	sys := New(ctx, config, fakeClient, false)
 	defer sys.Close()
 
 	require.NoError(t, sys.fetchAddressFromL1())
@@ -62,7 +62,7 @@ func TestSystemContract_AuthorizeCheck(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	sys := New(ctx, config, fakeClient)
+	sys := New(ctx, config, fakeClient, false)
 	defer sys.Close()
 
 	require.NoError(t, sys.fetchAddressFromL1())
@@ -117,7 +117,7 @@ func TestSystemContract_SignsAfterUpdate(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	sys := New(ctx, config, fakeClient)
+	sys := New(ctx, config, fakeClient, false)
 	defer sys.Close()
 
 	require.NoError(t, sys.fetchAddressFromL1())

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -120,7 +120,7 @@ type Ethereum struct {
 
 // New creates a new Ethereum object (including the
 // initialisation of the common Ethereum object)
-func New(stack *node.Node, config *ethconfig.Config, l1Client l1.Client) (*Ethereum, error) {
+func New(stack *node.Node, config *ethconfig.Config, l1Client l1.Client, ) (*Ethereum, error) {
 	// Ensure configuration values are compatible and sane
 	if config.SyncMode == downloader.LightSync {
 		return nil, errors.New("can't run eth.Ethereum in light sync mode, use les.LightEthereum")
@@ -166,7 +166,7 @@ func New(stack *node.Node, config *ethconfig.Config, l1Client l1.Client) (*Ether
 		chainDb:           chainDb,
 		eventMux:          stack.EventMux(),
 		accountManager:    stack.AccountManager(),
-		engine:            ethconfig.CreateConsensusEngine(stack, chainConfig, &ethashConfig, config.Miner.Notify, config.Miner.Noverify, chainDb, l1Client),
+		engine:            ethconfig.CreateConsensusEngine(stack, chainConfig, &ethashConfig, config.Miner.Notify, config.Miner.Noverify, chainDb, l1Client, config.SkipSignerCheck),
 		closeBloomHandler: make(chan struct{}),
 		networkID:         config.NetworkId,
 		gasPrice:          config.Miner.GasPrice,

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -236,14 +236,17 @@ type Config struct {
 	GossipSequencerHTTP         string
 	GossipBroadcastToAllEnabled bool
 	GossipBroadcastToAllCap     int
+
+	// Skip signer check for the SystemContract engine
+	SkipSignerCheck bool
 }
 
 // CreateConsensusEngine creates a consensus engine for the given chain configuration.
-func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, config *ethash.Config, notify []string, noverify bool, db ethdb.Database, l1Client sync_service.EthClient) consensus.Engine {
+func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, config *ethash.Config, notify []string, noverify bool, db ethdb.Database, l1Client sync_service.EthClient, skipSignerCheck bool) consensus.Engine {
 	// Case 1: Both SystemContract and Clique are defined: create an upgradable engine.
 	if chainConfig.SystemContract != nil && chainConfig.Clique != nil {
 		cliqueEngine := clique.New(chainConfig.Clique, db)
-		sysEngine := system_contract.New(context.Background(), chainConfig.SystemContract, l1Client)
+		sysEngine := system_contract.New(context.Background(), chainConfig.SystemContract, l1Client, skipSignerCheck)
 		sysEngine.Start()
 		return wrapper.NewUpgradableEngine(chainConfig.IsEuclidV2, cliqueEngine, sysEngine)
 	}
@@ -255,7 +258,7 @@ func CreateConsensusEngine(stack *node.Node, chainConfig *params.ChainConfig, co
 
 	// Case 3: Only the SystemContract engine is defined.
 	if chainConfig.SystemContract != nil {
-		sysEngine := system_contract.New(context.Background(), chainConfig.SystemContract, l1Client)
+		sysEngine := system_contract.New(context.Background(), chainConfig.SystemContract, l1Client, skipSignerCheck)
 		sysEngine.Start()
 		return sysEngine
 	}

--- a/les/client.go
+++ b/les/client.go
@@ -110,7 +110,7 @@ func New(stack *node.Node, config *ethconfig.Config, l1Client sync_service.EthCl
 		eventMux:       stack.EventMux(),
 		reqDist:        newRequestDistributor(peers, &mclock.System{}),
 		accountManager: stack.AccountManager(),
-		engine:         ethconfig.CreateConsensusEngine(stack, chainConfig, &config.Ethash, nil, false, chainDb, l1Client),
+		engine:         ethconfig.CreateConsensusEngine(stack, chainConfig, &config.Ethash, nil, false, chainDb, l1Client, config.SkipSignerCheck),
 		bloomRequests:  make(chan chan *bloombits.Retrieval),
 		bloomIndexer:   core.NewBloomIndexer(chainDb, params.BloomBitsBlocksClient, params.HelperTrieConfirmations),
 		p2pServer:      stack.Server(),

--- a/miner/scroll_worker_test.go
+++ b/miner/scroll_worker_test.go
@@ -1411,7 +1411,7 @@ func TestEuclidV2TransitionVerification(t *testing.T) {
 	// init worker
 	db := rawdb.NewMemoryDatabase()
 	cliqueEngine := clique.New(chainConfig.Clique, db)
-	sysEngine := system_contract.New(context.Background(), chainConfig.SystemContract, &system_contract.FakeEthClient{Value: testBankAddress})
+	sysEngine := system_contract.New(context.Background(), chainConfig.SystemContract, &system_contract.FakeEthClient{Value: testBankAddress}, false)
 	engine := wrapper.NewUpgradableEngine(chainConfig.IsEuclidV2, cliqueEngine, sysEngine)
 	w, b := newTestWorkerWithEmptyBlock(t, chainConfig, engine, db, 0)
 	defer w.close()

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 10        // Minor version component of the current release
-	VersionPatch = 3         // Patch version component of the current release
+	VersionPatch = 4         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

This PR adds param to skip system config signer check. 
To use:  add  `--skipsignercheck`

This PR is tailored for l2reth testing architecture, we probably don't want to merge it.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [ ] build: Changes that affect the build system or external dependencies (example scopes: yarn, eslint, typescript)
- [ ] ci: Changes to our CI configuration files and scripts (example scopes: vercel, github, cypress)
- [ ] docs: Documentation-only changes
- [x] feat: A new feature
- [ ] fix: A bug fix
- [ ] perf: A code change that improves performance
- [ ] refactor: A code change that doesn't fix a bug, or add a feature, or improves performance
- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] test: Adding missing tests or correcting existing tests


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [x] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [ ] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [x] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI flag to skip signer verification for the SystemContract engine; help/usage now shows the flag under the Rollup section.

* **Chores**
  * Version patch bumped from 3 to 4.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->