### PR TITLE
feat: explicitly reject blob txs in txpool

### DIFF
--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -773,6 +773,10 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	if !pool.eip1559 && tx.Type() == types.DynamicFeeTxType {
 		return ErrTxTypeNotSupported
 	}
+	// Reject blob transactions.
+	if tx.Type() == types.BlobTxType {
+		return ErrTxTypeNotSupported
+	}
 	// Reject set code transactions until EIP-7702 activates.
 	if !pool.eip7702 && tx.Type() == types.SetCodeTxType {
 		return ErrTxTypeNotSupported

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 10        // Minor version component of the current release
-	VersionPatch = 3         // Patch version component of the current release
+	VersionPatch = 4         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Scroll does not allow blob transactions. Currently the node txpool rejects these via the `IsValidBlockSizeForMining` check. This PR makes the check explicit -- no real change in node behavior, but easier to reason about the code.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] feat: A new feature


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blob transactions are now explicitly rejected during validation, returning an error indicating the transaction type is not supported.

* **Chores**
  * Version patch number incremented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->