### PR TITLE
fix(evm): load delegation code during balance check in CallCode

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -289,6 +289,13 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 	// if caller doesn't have enough balance, it would be an error to allow
 	// over-charging itself. So the check here is necessary.
 	if !evm.Context.CanTransfer(evm.StateDB, caller.Address(), value) {
+		// EIP-7702: Ensure delegated code is loaded into witness even when balance check fails.
+		// revm always loads the code regardless of balance check result.
+		if code := evm.StateDB.GetCode(addr); len(code) > 0 {
+			if target, ok := types.ParseDelegation(code); ok {
+				evm.StateDB.GetCode(target)
+			}
+		}
 		return nil, gas, ErrInsufficientBalance
 	}
 	var snapshot = evm.StateDB.Snapshot()

--- a/params/version.go
+++ b/params/version.go
@@ -24,7 +24,7 @@ import (
 const (
 	VersionMajor = 5         // Major version component of the current release
 	VersionMinor = 10        // Minor version component of the current release
-	VersionPatch = 4         // Patch version component of the current release
+	VersionPatch = 5         // Patch version component of the current release
 	VersionMeta  = "mainnet" // Version metadata to append to the version string
 )
 


### PR DESCRIPTION
## 1. Purpose or design rationale of this PR

Make sure delegated code is loaded, even if `CallCode` fails with balance insufficient error (same as in https://github.com/scroll-tech/go-ethereum/pull/1270). This ensures that revm can process the produced execution witness.


## 2. PR title

Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) (as we are doing squash merge for each PR), so it must start with one of the following [types](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type):

- [X] fix: A bug fix


## 3. Deployment tag versioning

Has the version in `params/version.go` been updated?

- [ ] This PR doesn't involve a new deployment, git tag, docker image tag, and it doesn't affect traces
- [X] Yes


## 4. Breaking change label

Does this PR have the `breaking-change` label?

- [X] This PR is not a breaking change
- [ ] Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in delegated code handling during balance validation scenarios.

* **Chores**
  * Updated patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->